### PR TITLE
Add select number of pairs

### DIFF
--- a/mei-tra-backend/src/services/card.service.ts
+++ b/mei-tra-backend/src/services/card.service.ts
@@ -221,7 +221,21 @@ export class CardService {
 
   compareCards(cardA: string, cardB: string): number {
     const suitsOrder = ['♠', '♦', '♣', '♥'];
-    const valuesOrder = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A'];
+    const valuesOrder = [
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '10',
+      'J',
+      'Q',
+      'K',
+      'A',
+    ];
 
     const suitA = cardA.slice(-1);
     const suitB = cardB.slice(-1);
@@ -230,11 +244,11 @@ export class CardService {
     const valueB = cardB.startsWith('10') ? '10' : cardB[0];
 
     // Compare suits
-    const suitComparison = suitsOrder.indexOf(suitA) - suitsOrder.indexOf(suitB);
+    const suitComparison =
+      suitsOrder.indexOf(suitA) - suitsOrder.indexOf(suitB);
     if (suitComparison !== 0) return suitComparison;
 
     // Compare values
     return valuesOrder.indexOf(valueA) - valuesOrder.indexOf(valueB);
   }
-
 }


### PR DESCRIPTION
前の吹きに対して宣言が通る数字のみを選択肢に表示する。
基本は6-10であるがフィルターで数字を絞っていく方式。
10（スラミ）が宣言され、11以上を吹きたい場合にも対応。（最大13）
　10→11→12→13
frontendにて条件処理記述しているので、backendで記載したほうが綺麗とかあれば教授願う。

ローカルにて動作確認済み。