### PR TITLE
DeclaringTeam error check debug

### DIFF
--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -598,7 +598,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       (p) => p.playerId === state.blowState.currentHighestDeclaration?.playerId,
     )?.team as Team;
 
-    if (!declaringTeam) {
+    if (declaringTeam == null) {
       console.error(
         'No declaring team found for player:',
         state.blowState.currentHighestDeclaration.playerId,


### PR DESCRIPTION
team0がdeclaringの時もエラー判断されて止まってしまうのを回避。



if (declaringTeam == null) {
      console.error(
        'No declaring team found for player:',
        state.blowState.currentHighestDeclaration.playerId,
      );
      return;
    }