### PR TITLE
add host moderation controls

### DIFF
--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -246,6 +246,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const roomGameState = await this.roomService.getRoomGameState(roomId);
     this.server.to(roomId).emit('player-converted-to-com', {
       playerId,
+      playerName: targetPlayer?.name ?? playerId,
       message,
     });
     this.server
@@ -303,6 +304,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
             monitor.idleEmitted = true;
             this.server.to(roomId).emit('player-idle', {
               playerId,
+              playerName: currentPlayer.name,
               roomId,
             });
           }
@@ -827,6 +829,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       }
 
       const player = players.find((p) => p.id === client.id);
+      const authenticatedUser = (client.data as { user?: AuthenticatedUser })
+        .user;
 
       if (player) {
         const activeMonitor = this.turnAckMonitors.get(roomId);
@@ -834,11 +838,35 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
           this.clearTurnAckMonitor(roomId);
         }
 
+        const disconnectDisplayName =
+          authenticatedUser?.profile?.displayName || player.name;
+
         // プレイヤーのチーム情報を保持
         state.teamAssignments[player.playerId] = player.team;
 
         // ソケットIDをクリア（切断状態を示す）
         player.id = '';
+
+        const room = await this.roomService.getRoom(roomId);
+        if (room?.hostId === player.playerId) {
+          const nextHost = room.players.find(
+            (candidate) =>
+              candidate.playerId !== player.playerId && !candidate.isCOM,
+          );
+          if (nextHost) {
+            await this.roomService.updateRoom(roomId, {
+              hostId: nextHost.playerId,
+            });
+            const updatedRoom = await this.roomService.getRoom(roomId);
+            if (updatedRoom) {
+              this.server.to(roomId).emit('room-updated', updatedRoom);
+              this.server
+                .to(roomId)
+                .emit('update-players', updatedRoom.players);
+            }
+            this.server.emit('rooms-list', await this.roomService.listRooms());
+          }
+        }
 
         // Notify other players in the same room about the disconnection
         this.server.to(roomId).emit('player-left', {
@@ -847,6 +875,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         });
         this.server.to(roomId).emit('player-disconnected', {
           playerId: player.playerId,
+          playerName: disconnectDisplayName,
           roomId,
         });
 
@@ -866,6 +895,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
                   if (converted) {
                     this.server.to(roomId).emit('player-converted-to-com', {
                       playerId: player.playerId,
+                      playerName: disconnectDisplayName,
                       message:
                         'Player disconnected for too long - converted to COM',
                     });

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -687,6 +687,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
                 negriCard: state.playState?.negriCard,
                 fields: state.playState?.fields,
                 roomId: roomId,
+                hostId: room.hostId,
                 pointsToWin: state.pointsToWin,
               });
               this.server.to(roomId).emit('update-players', state.players);
@@ -1179,6 +1180,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
               player.playerId === normalizedUser.playerId ? player.hand : [],
           })),
           you: normalizedUser.playerId,
+          hostId: room.hostId,
         };
 
         this.server.to(client.id).emit('game-resumed', {

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -878,6 +878,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
           playerName: disconnectDisplayName,
           roomId,
         });
+        this.server.to(roomId).emit('update-players', state.players);
 
         // プレイ中の場合は長めのタイムアウトを設定
         // プレイヤーとトークンを保持しつつ、長時間放置されたらCOMに変換

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -244,14 +244,19 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
 
     const roomGameState = await this.roomService.getRoomGameState(roomId);
+    const updatedRoom = await this.roomService.getRoom(roomId);
     this.server.to(roomId).emit('player-converted-to-com', {
       playerId,
       playerName: targetPlayer?.name ?? playerId,
       message,
     });
+    if (updatedRoom) {
+      this.server.to(roomId).emit('room-updated', updatedRoom);
+    }
     this.server
       .to(roomId)
       .emit('update-players', roomGameState.getState().players);
+    this.server.emit('rooms-list', await this.roomService.listRooms());
     this.triggerComAutoPlayIfNeeded(roomId);
     return true;
   }
@@ -458,6 +463,10 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     console.warn(
       `[Reconnection] Sending back-to-lobby for socket=${client.id} room=${roomId ?? 'none'} reason=${reason}`,
     );
+    if (roomId) {
+      await client.leave(roomId);
+    }
+    this.playerRooms.delete(client.id);
     client.emit('back-to-lobby');
     client.emit('error-message', reason);
     client.emit('rooms-list', await this.roomService.listRooms());
@@ -895,15 +904,23 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
                       player.playerId,
                     );
                   if (converted) {
+                    const updatedRoom = await this.roomService.getRoom(roomId);
                     this.server.to(roomId).emit('player-converted-to-com', {
                       playerId: player.playerId,
                       playerName: disconnectDisplayName,
                       message:
                         'Player disconnected for too long - converted to COM',
                     });
+                    if (updatedRoom) {
+                      this.server.to(roomId).emit('room-updated', updatedRoom);
+                    }
                     this.server
                       .to(roomId)
                       .emit('update-players', roomGameState.getState().players);
+                    this.server.emit(
+                      'rooms-list',
+                      await this.roomService.listRooms(),
+                    );
                   }
                 }
               } catch (error) {

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -46,6 +46,17 @@ import { IComAutoPlayUseCase } from './use-cases/interfaces/com-autoplay-use-cas
 import { IActivityTrackerService } from './services/interfaces/activity-tracker-service.interface';
 
 const DISCONNECT_TO_COM_TIMEOUT_MS = 2 * 60 * 1000;
+const TURN_ACK_PING_INTERVAL_MS = 15 * 1000;
+const TURN_IDLE_WARNING_MS = 45 * 1000;
+const TURN_IDLE_TO_COM_TIMEOUT_MS = 2 * 60 * 1000;
+
+interface TurnAckMonitor {
+  playerId: string;
+  lastAckAt: number;
+  pingInterval: NodeJS.Timeout;
+  statusInterval: NodeJS.Timeout;
+  idleEmitted: boolean;
+}
 
 @WebSocketGateway({
   cors: {
@@ -61,6 +72,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer() server: Server;
   private readonly logger = new Logger(GameGateway.name);
   private playerRooms: Map<string, string> = new Map(); // socketId -> roomId
+  private turnAckMonitors: Map<string, TurnAckMonitor> = new Map();
 
   constructor(
     @Inject('IGameStateService')
@@ -151,6 +163,12 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
           case 'room':
             if (event.roomId) {
               this.server.to(event.roomId).emit(event.event, event.payload);
+              if (
+                event.event === 'update-turn' &&
+                typeof event.payload === 'string'
+              ) {
+                void this.startTurnAckMonitor(event.roomId, event.payload);
+              }
             }
             break;
           case 'socket':
@@ -170,6 +188,170 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         emit();
       }
     });
+  }
+
+  private clearTurnAckMonitor(roomId: string): void {
+    const monitor = this.turnAckMonitors.get(roomId);
+    if (!monitor) {
+      return;
+    }
+
+    clearInterval(monitor.pingInterval);
+    clearInterval(monitor.statusInterval);
+    this.turnAckMonitors.delete(roomId);
+  }
+
+  private async isTurnStillOwnedByPlayer(
+    roomId: string,
+    playerId: string,
+  ): Promise<boolean> {
+    const roomGameState = await this.roomService.getRoomGameState(roomId);
+    const state = roomGameState.getState();
+    const currentPlayer = state.players[state.currentPlayerIndex];
+
+    return (
+      (state.gamePhase === 'play' || state.gamePhase === 'blow') &&
+      currentPlayer?.playerId === playerId
+    );
+  }
+
+  private async forceReplacePlayerWithCOM(
+    roomId: string,
+    playerId: string,
+    message: string,
+  ): Promise<boolean> {
+    const room = await this.roomService.getRoom(roomId);
+    const targetPlayer = room?.players.find(
+      (player) => player.playerId === playerId,
+    );
+    const targetSocket = targetPlayer?.id
+      ? this.server.sockets.sockets.get(targetPlayer.id)
+      : undefined;
+
+    if (targetSocket) {
+      await targetSocket.leave(roomId);
+      this.playerRooms.delete(targetSocket.id);
+      targetSocket.emit('error-message', message);
+      targetSocket.emit('back-to-lobby');
+    }
+
+    const converted = await this.roomService.convertPlayerToCOM(
+      roomId,
+      playerId,
+    );
+    if (!converted) {
+      return false;
+    }
+
+    const roomGameState = await this.roomService.getRoomGameState(roomId);
+    this.server.to(roomId).emit('player-converted-to-com', {
+      playerId,
+      message,
+    });
+    this.server
+      .to(roomId)
+      .emit('update-players', roomGameState.getState().players);
+    this.triggerComAutoPlayIfNeeded(roomId);
+    return true;
+  }
+
+  private async startTurnAckMonitor(
+    roomId: string,
+    playerId: string,
+  ): Promise<void> {
+    this.clearTurnAckMonitor(roomId);
+
+    const room = await this.roomService.getRoom(roomId);
+    if (room?.status !== RoomStatus.PLAYING) {
+      return;
+    }
+
+    const roomGameState = await this.roomService.getRoomGameState(roomId);
+    const state = roomGameState.getState();
+    const currentPlayer = state.players.find(
+      (candidate) => candidate.playerId === playerId,
+    );
+
+    if (
+      !currentPlayer ||
+      currentPlayer.isCOM ||
+      !currentPlayer.id ||
+      (state.gamePhase !== 'play' && state.gamePhase !== 'blow')
+    ) {
+      return;
+    }
+
+    const emitPing = () => {
+      this.server.to(currentPlayer.id).emit('turn-ping', { roomId, playerId });
+    };
+
+    const monitor: TurnAckMonitor = {
+      playerId,
+      lastAckAt: Date.now(),
+      pingInterval: setInterval(emitPing, TURN_ACK_PING_INTERVAL_MS),
+      statusInterval: setInterval(() => {
+        void (async () => {
+          if (!(await this.isTurnStillOwnedByPlayer(roomId, playerId))) {
+            this.clearTurnAckMonitor(roomId);
+            return;
+          }
+
+          const now = Date.now();
+          const silenceMs = now - monitor.lastAckAt;
+
+          if (!monitor.idleEmitted && silenceMs >= TURN_IDLE_WARNING_MS) {
+            monitor.idleEmitted = true;
+            this.server.to(roomId).emit('player-idle', {
+              playerId,
+              roomId,
+            });
+          }
+
+          if (silenceMs >= TURN_IDLE_TO_COM_TIMEOUT_MS) {
+            this.clearTurnAckMonitor(roomId);
+            try {
+              await this.forceReplacePlayerWithCOM(
+                roomId,
+                playerId,
+                'Player became unresponsive during their turn - converted to COM',
+              );
+            } catch (error) {
+              console.error(
+                '[TurnAck] Error converting idle player to COM:',
+                error,
+              );
+            }
+          }
+        })();
+      }, 5000),
+      idleEmitted: false,
+    };
+
+    this.turnAckMonitors.set(roomId, monitor);
+    emitPing();
+  }
+
+  private markTurnAck(roomId: string, playerId: string): void {
+    const monitor = this.turnAckMonitors.get(roomId);
+    if (!monitor || monitor.playerId !== playerId) {
+      return;
+    }
+
+    monitor.lastAckAt = Date.now();
+    if (monitor.idleEmitted) {
+      monitor.idleEmitted = false;
+      this.server.to(roomId).emit('player-idle-cleared', {
+        playerId,
+        roomId,
+      });
+    }
+  }
+
+  private isPlayerIdle(roomId: string, playerId: string): boolean {
+    const monitor = this.turnAckMonitors.get(roomId);
+    return Boolean(
+      monitor && monitor.playerId === playerId && monitor.idleEmitted,
+    );
   }
 
   private async triggerRevealBrokenHand(request?: RevealBrokenRequest) {
@@ -242,6 +424,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   private async closeFinishedRoom(roomId: string): Promise<void> {
     try {
+      this.clearTurnAckMonitor(roomId);
+
       const socketIds = Array.from(
         this.server.sockets.adapter.rooms.get(roomId) ?? [],
       );
@@ -569,6 +753,18 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
             true,
           );
         }
+        try {
+          const currentRoomGameState =
+            await this.roomService.getRoomGameState(roomId);
+          const currentTurnPlayerId = currentRoomGameState.currentTurn;
+          if (currentTurnPlayerId) {
+            void this.startTurnAckMonitor(roomId, currentTurnPlayerId);
+          }
+        } catch (error) {
+          this.logger.warn(
+            `Failed to restart turn monitor after reconnection for room ${roomId}: ${String(error)}`,
+          );
+        }
         return;
       }
     }
@@ -633,6 +829,11 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       const player = players.find((p) => p.id === client.id);
 
       if (player) {
+        const activeMonitor = this.turnAckMonitors.get(roomId);
+        if (activeMonitor?.playerId === player.playerId) {
+          this.clearTurnAckMonitor(roomId);
+        }
+
         // プレイヤーのチーム情報を保持
         state.teamAssignments[player.playerId] = player.team;
 
@@ -649,7 +850,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
           roomId,
         });
 
-        // プレイ中の場合は長めのタイムアウト(5分)を設定
+        // プレイ中の場合は長めのタイムアウトを設定
         // プレイヤーとトークンを保持しつつ、長時間放置されたらCOMに変換
         if (state.gamePhase === 'play' || state.gamePhase === 'blow') {
           const timeout: NodeJS.Timeout = setTimeout(() => {
@@ -1168,38 +1369,42 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         (player) => player.playerId === data.targetPlayerId,
       );
 
-      if (
-        room.status !== RoomStatus.PLAYING ||
-        !targetStatePlayer ||
-        targetStatePlayer.id
-      ) {
+      const canReplaceDisconnected = Boolean(
+        room.status === RoomStatus.PLAYING &&
+          targetStatePlayer &&
+          !targetStatePlayer.id,
+      );
+      const canReplaceIdle = Boolean(
+        room.status === RoomStatus.PLAYING &&
+          targetStatePlayer &&
+          this.isPlayerIdle(data.roomId, data.targetPlayerId),
+      );
+
+      if (!canReplaceDisconnected && !canReplaceIdle) {
         client.emit(
           'error-message',
-          'Only disconnected in-game players can be replaced with COM',
+          'Only disconnected or idle in-game players can be replaced with COM',
         );
         return {
           success: false,
-          error: 'Only disconnected in-game players can be replaced with COM',
+          error:
+            'Only disconnected or idle in-game players can be replaced with COM',
         };
       }
 
-      const converted = await this.roomService.convertPlayerToCOM(
+      this.clearTurnAckMonitor(data.roomId);
+
+      const converted = await this.forceReplacePlayerWithCOM(
         data.roomId,
         data.targetPlayerId,
+        canReplaceIdle
+          ? 'Host replaced an unresponsive player with COM'
+          : 'Host replaced a disconnected player with COM',
       );
       if (!converted) {
         client.emit('error-message', 'Failed to replace player with COM');
         return { success: false, error: 'Failed to replace player with COM' };
       }
-
-      this.server.to(data.roomId).emit('player-converted-to-com', {
-        playerId: data.targetPlayerId,
-        message: 'Host replaced a disconnected player with COM',
-      });
-      this.server
-        .to(data.roomId)
-        .emit('update-players', roomGameState.getState().players);
-      this.triggerComAutoPlayIfNeeded(data.roomId);
 
       return { success: true };
     } catch (error) {
@@ -1207,6 +1412,39 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       client.emit('error-message', 'Internal server error');
       return { success: false, error: 'Internal server error' };
     }
+  }
+
+  @SubscribeMessage('turn-ack')
+  async handleTurnAck(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() data: { roomId?: string },
+  ): Promise<void> {
+    const roomId = data.roomId || this.playerRooms.get(client.id);
+    if (!roomId) {
+      return;
+    }
+
+    const monitor = this.turnAckMonitors.get(roomId);
+    if (!monitor) {
+      return;
+    }
+
+    const roomGameState = await this.roomService.getRoomGameState(roomId);
+    const state = roomGameState.getState();
+    const currentPlayer = state.players.find(
+      (player) => player.playerId === monitor.playerId,
+    );
+    const userId = (client.data as { user?: AuthenticatedUser }).user?.id;
+    const matchesCurrentTurnPlayer =
+      currentPlayer &&
+      (currentPlayer.id === client.id ||
+        (Boolean(userId) && currentPlayer.userId === userId));
+
+    if (!matchesCurrentTurnPlayer) {
+      return;
+    }
+
+    this.markTurnAck(roomId, monitor.playerId);
   }
 
   @SubscribeMessage('change-player-team')
@@ -1354,6 +1592,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       .emit('game-started', data.roomId, players, pointsToWin);
     this.server.to(data.roomId).emit('update-phase', updatePhase);
     this.server.to(data.roomId).emit('update-turn', currentTurnPlayerId);
+    void this.startTurnAckMonitor(data.roomId, currentTurnPlayerId);
 
     this.triggerComAutoPlayIfNeeded(data.roomId);
 

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -45,6 +45,8 @@ import { IComAutoPlayService } from './services/interfaces/com-autoplay-service.
 import { IComAutoPlayUseCase } from './use-cases/interfaces/com-autoplay-use-case.interface';
 import { IActivityTrackerService } from './services/interfaces/activity-tracker-service.interface';
 
+const DISCONNECT_TO_COM_TIMEOUT_MS = 2 * 60 * 1000;
+
 @WebSocketGateway({
   cors: {
     origin: '*',
@@ -642,45 +644,43 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
           playerId: player.playerId,
           roomId,
         });
+        this.server.to(roomId).emit('player-disconnected', {
+          playerId: player.playerId,
+          roomId,
+        });
 
         // プレイ中の場合は長めのタイムアウト(5分)を設定
         // プレイヤーとトークンを保持しつつ、長時間放置されたらCOMに変換
         if (state.gamePhase === 'play' || state.gamePhase === 'blow') {
-          const timeout: NodeJS.Timeout = setTimeout(
-            () => {
-              void (async () => {
-                try {
-                  const room = await this.roomService.getRoom(roomId);
-                  if (room?.status === RoomStatus.PLAYING) {
-                    const converted: boolean =
-                      await this.roomService.convertPlayerToCOM(
-                        roomId,
-                        player.playerId,
-                      );
-                    if (converted) {
-                      this.server.to(roomId).emit('player-converted-to-com', {
-                        playerId: player.playerId,
-                        message:
-                          'Player disconnected for too long - converted to COM',
-                      });
-                      this.server
-                        .to(roomId)
-                        .emit(
-                          'update-players',
-                          roomGameState.getState().players,
-                        );
-                    }
+          const timeout: NodeJS.Timeout = setTimeout(() => {
+            void (async () => {
+              try {
+                const room = await this.roomService.getRoom(roomId);
+                if (room?.status === RoomStatus.PLAYING) {
+                  const converted: boolean =
+                    await this.roomService.convertPlayerToCOM(
+                      roomId,
+                      player.playerId,
+                    );
+                  if (converted) {
+                    this.server.to(roomId).emit('player-converted-to-com', {
+                      playerId: player.playerId,
+                      message:
+                        'Player disconnected for too long - converted to COM',
+                    });
+                    this.server
+                      .to(roomId)
+                      .emit('update-players', roomGameState.getState().players);
                   }
-                } catch (error) {
-                  console.error(
-                    '[Disconnect] Error converting player to COM:',
-                    error,
-                  );
                 }
-              })();
-            },
-            5 * 60 * 1000,
-          ); // 5 minutes
+              } catch (error) {
+                console.error(
+                  '[Disconnect] Error converting player to COM:',
+                  error,
+                );
+              }
+            })();
+          }, DISCONNECT_TO_COM_TIMEOUT_MS);
 
           roomGameState.setDisconnectTimeout(player.playerId, timeout);
         } else {
@@ -1059,6 +1059,152 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       return { success: true };
     } catch (error) {
       console.error('Error in handleLeaveRoom:', error);
+      return { success: false, error: 'Internal server error' };
+    }
+  }
+
+  @SubscribeMessage('moderate-player')
+  async handleModeratePlayer(
+    @ConnectedSocket() client: Socket,
+    @MessageBody()
+    data: {
+      roomId: string;
+      requesterPlayerId: string;
+      targetPlayerId: string;
+      action: 'remove' | 'replace-with-com';
+    },
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      const room = await this.roomService.getRoom(data.roomId);
+      if (!room) {
+        client.emit('error-message', 'Room not found');
+        return { success: false, error: 'Room not found' };
+      }
+
+      if (room.hostId !== data.requesterPlayerId) {
+        client.emit('error-message', 'Only the host can moderate players');
+        return { success: false, error: 'Only the host can moderate players' };
+      }
+
+      if (data.requesterPlayerId === data.targetPlayerId) {
+        client.emit('error-message', 'Host cannot moderate themselves');
+        return { success: false, error: 'Host cannot moderate themselves' };
+      }
+
+      const targetPlayer = room.players.find(
+        (player) => player.playerId === data.targetPlayerId,
+      );
+      if (!targetPlayer || targetPlayer.isCOM) {
+        client.emit('error-message', 'Target player not found');
+        return { success: false, error: 'Target player not found' };
+      }
+
+      if (data.action === 'remove') {
+        if (room.status !== RoomStatus.WAITING) {
+          client.emit(
+            'error-message',
+            'Players can only be removed in the waiting room',
+          );
+          return {
+            success: false,
+            error: 'Players can only be removed in the waiting room',
+          };
+        }
+
+        const targetSocket = targetPlayer.id
+          ? this.server.sockets.sockets.get(targetPlayer.id)
+          : undefined;
+        if (targetSocket) {
+          await targetSocket.leave(data.roomId);
+          this.playerRooms.delete(targetPlayer.id);
+          targetSocket.emit(
+            'error-message',
+            'You were removed from the room by the host',
+          );
+          targetSocket.emit('back-to-lobby');
+        }
+
+        const result = await this.leaveRoomUseCase.execute({
+          playerId: data.targetPlayerId,
+          roomId: data.roomId,
+        });
+
+        if (!result.success || !result.data) {
+          const errorMessage = result.errorMessage || 'Failed to remove player';
+          client.emit('error-message', errorMessage);
+          return { success: false, error: errorMessage };
+        }
+
+        const { playerId, roomDeleted, roomsList, updatedPlayers } =
+          result.data;
+
+        if (roomDeleted) {
+          this.server.emit('rooms-list', roomsList);
+          return { success: true };
+        }
+
+        const updatedRoom = await this.roomService.getRoom(data.roomId);
+        if (updatedRoom) {
+          this.server.to(data.roomId).emit('room-updated', updatedRoom);
+        }
+
+        this.server.to(data.roomId).emit('player-left', {
+          playerId,
+          roomId: data.roomId,
+        });
+        this.server.emit('rooms-list', roomsList);
+        if (updatedPlayers) {
+          this.server.to(data.roomId).emit('update-players', updatedPlayers);
+        }
+
+        return { success: true };
+      }
+
+      const roomGameState = await this.roomService.getRoomGameState(
+        data.roomId,
+      );
+      const state = roomGameState.getState();
+      const targetStatePlayer = state.players.find(
+        (player) => player.playerId === data.targetPlayerId,
+      );
+
+      if (
+        room.status !== RoomStatus.PLAYING ||
+        !targetStatePlayer ||
+        targetStatePlayer.id
+      ) {
+        client.emit(
+          'error-message',
+          'Only disconnected in-game players can be replaced with COM',
+        );
+        return {
+          success: false,
+          error: 'Only disconnected in-game players can be replaced with COM',
+        };
+      }
+
+      const converted = await this.roomService.convertPlayerToCOM(
+        data.roomId,
+        data.targetPlayerId,
+      );
+      if (!converted) {
+        client.emit('error-message', 'Failed to replace player with COM');
+        return { success: false, error: 'Failed to replace player with COM' };
+      }
+
+      this.server.to(data.roomId).emit('player-converted-to-com', {
+        playerId: data.targetPlayerId,
+        message: 'Host replaced a disconnected player with COM',
+      });
+      this.server
+        .to(data.roomId)
+        .emit('update-players', roomGameState.getState().players);
+      this.triggerComAutoPlayIfNeeded(data.roomId);
+
+      return { success: true };
+    } catch (error) {
+      console.error('Error in handleModeratePlayer:', error);
+      client.emit('error-message', 'Internal server error');
       return { success: false, error: 'Internal server error' };
     }
   }

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -877,6 +877,57 @@ describe('Reconnection Token Management', () => {
         ]);
       });
 
+      it('should normalize duplicate host flags based on room.hostId', async () => {
+        const roomId = 'room-123';
+        const room: Room = {
+          ...baseRoom,
+          hostId: 'player-2',
+          players: [
+            {
+              id: 'socket-1',
+              playerId: 'player-1',
+              name: 'Player1',
+              team: 0,
+              hand: [],
+              isPasser: false,
+              hasBroken: false,
+              hasRequiredBroken: false,
+              isReady: false,
+              isHost: true,
+              joinedAt: new Date(),
+            },
+            {
+              id: 'socket-2',
+              playerId: 'player-2',
+              name: 'Player2',
+              team: 1,
+              hand: [],
+              isPasser: false,
+              hasBroken: false,
+              hasRequiredBroken: false,
+              isReady: false,
+              isHost: true,
+              joinedAt: new Date(),
+            },
+          ] as RoomPlayer[],
+        };
+
+        roomRepository.findById.mockResolvedValue(room);
+
+        const normalizedRoom = await roomService.getRoom(roomId);
+
+        expect(
+          normalizedRoom?.players.find(
+            (player) => player.playerId === 'player-1',
+          )?.isHost,
+        ).toBe(false);
+        expect(
+          normalizedRoom?.players.find(
+            (player) => player.playerId === 'player-2',
+          )?.isHost,
+        ).toBe(true);
+      });
+
       it('should restore the correct com seat even when repository order changes', async () => {
         const roomId = 'room-123';
         const playerId = 'player-1';

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -364,9 +364,11 @@ describe('Reconnection Token Management', () => {
       const comPlayerService: jest.Mocked<IComPlayerService> = {
         createComPlayer: jest.fn(),
         selectBestCard: jest.fn(),
-        selectBaseSuit: jest.fn(
-          (_hand: string[], _trump: TrumpType | null) => '♠',
-        ),
+        selectBaseSuit: jest.fn((hand: string[], trump: TrumpType | null) => {
+          void hand;
+          void trump;
+          return '♠';
+        }),
         isComPlayer: jest.fn(),
       };
       gameStateFactory = new GameStateFactory(
@@ -866,13 +868,13 @@ describe('Reconnection Token Management', () => {
         const result = await roomService.joinRoom(roomId, hostUser);
 
         expect(result).toBe(true);
-        expect(roomRepository.addPlayer).toHaveBeenCalledWith(
+        expect(roomRepository.addPlayer.mock.calls).toContainEqual([
           roomId,
           expect.objectContaining({
             playerId: 'player-1',
             isHost: true,
           }),
-        );
+        ]);
       });
 
       it('should restore the correct com seat even when repository order changes', async () => {

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -631,6 +631,7 @@ export class GameStateService implements IGameStateService {
     state.playState = {
       currentField: {
         cards: [],
+        playedBy: [],
         baseCard: '',
         dealerId: state.players[0].playerId,
         isComplete: false,
@@ -670,5 +671,15 @@ export class GameStateService implements IGameStateService {
     }
     // Set new timeout
     this.disconnectedPlayers.set(playerId, timeout);
+  }
+
+  clearDisconnectTimeout(playerId: string): void {
+    const existingTimeout = this.disconnectedPlayers.get(playerId);
+    if (!existingTimeout) {
+      return;
+    }
+
+    clearTimeout(existingTimeout);
+    this.disconnectedPlayers.delete(playerId);
   }
 }

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -329,6 +329,13 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     this.remapBlowStatePlayerIdReferences(state, fromPlayerId, toPlayerId);
   }
 
+  private clearGameStateDisconnectTimeout(
+    gameState: GameStateService,
+    playerId: string,
+  ): void {
+    gameState.clearDisconnectTimeout(playerId);
+  }
+
   async fillVacantSeatsWithCOM(roomId: string): Promise<void> {
     const room = await this.getRoom(roomId);
     if (!room) return;
@@ -662,7 +669,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
           : [];
       team = seatRoomPlayer ? seatRoomPlayer.team : team;
       restoredSeatData = seatData ?? null;
-      gameState.clearDisconnectTimeout(user.playerId);
+      this.clearGameStateDisconnectTimeout(gameState, user.playerId);
       delete roomVacant[assignedIndex];
       if (Object.keys(roomVacant).length === 0) delete this.vacantSeats[roomId];
     } else if (vacantIndexes.length > 0) {
@@ -676,7 +683,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       const originalPlayerId = seatRoomPlayer?.playerId;
       if (originalPlayerId) {
         gameState.removePlayerToken(originalPlayerId);
-        gameState.clearDisconnectTimeout(originalPlayerId);
+        this.clearGameStateDisconnectTimeout(gameState, originalPlayerId);
       }
       restoredSeatData = seatData ?? null;
       delete roomVacant[assignedIndex];

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -30,6 +30,16 @@ export class RoomService implements IRoomService, OnModuleDestroy {
   private readonly CLEANUP_INTERVAL = 30 * 60 * 1000; // 30分
   private cleanupIntervalId: ReturnType<typeof setInterval>;
 
+  private normalizeRoomHostFlags(room: Room): Room {
+    return {
+      ...room,
+      players: room.players.map((player) => ({
+        ...player,
+        isHost: player.playerId === room.hostId,
+      })),
+    };
+  }
+
   constructor(
     @Inject('IRoomRepository')
     private readonly roomRepository: IRoomRepository,
@@ -84,11 +94,12 @@ export class RoomService implements IRoomService, OnModuleDestroy {
 
   async createRoom(room: Room): Promise<Room> {
     const createdRoom = await this.roomRepository.create(room);
-    return createdRoom;
+    return this.normalizeRoomHostFlags(createdRoom);
   }
 
   async getRoom(roomId: string): Promise<Room | null> {
-    return this.roomRepository.findById(roomId);
+    const room = await this.roomRepository.findById(roomId);
+    return room ? this.normalizeRoomHostFlags(room) : null;
   }
 
   async updateRoom(
@@ -109,7 +120,8 @@ export class RoomService implements IRoomService, OnModuleDestroy {
   }
 
   async listRooms(): Promise<Room[]> {
-    return this.roomRepository.findAll();
+    const rooms = await this.roomRepository.findAll();
+    return rooms.map((room) => this.normalizeRoomHostFlags(room));
   }
 
   async createNewRoom(
@@ -762,11 +774,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
         false,
       isReady:
         currentSeatRoomPlayer?.isReady ?? seatRoomSnapshot?.isReady ?? false,
-      isHost:
-        room.hostId === user.playerId ||
-        currentSeatRoomPlayer?.isHost ||
-        seatRoomSnapshot?.isHost ||
-        false,
+      isHost: room.hostId === user.playerId,
       joinedAt: seatRoomSnapshot?.joinedAt
         ? new Date(seatRoomSnapshot.joinedAt)
         : new Date(),

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -121,7 +121,9 @@ export class RoomService implements IRoomService, OnModuleDestroy {
 
   async listRooms(): Promise<Room[]> {
     const rooms = await this.roomRepository.findAll();
-    return rooms.map((room) => this.normalizeRoomHostFlags(room));
+    return rooms
+      .map((room) => this.normalizeRoomHostFlags(room))
+      .filter((room) => room.players.some((player) => !player.isCOM));
   }
 
   async createNewRoom(
@@ -660,6 +662,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
           : [];
       team = seatRoomPlayer ? seatRoomPlayer.team : team;
       restoredSeatData = seatData ?? null;
+      gameState.clearDisconnectTimeout(user.playerId);
       delete roomVacant[assignedIndex];
       if (Object.keys(roomVacant).length === 0) delete this.vacantSeats[roomId];
     } else if (vacantIndexes.length > 0) {
@@ -673,6 +676,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       const originalPlayerId = seatRoomPlayer?.playerId;
       if (originalPlayerId) {
         gameState.removePlayerToken(originalPlayerId);
+        gameState.clearDisconnectTimeout(originalPlayerId);
       }
       restoredSeatData = seatData ?? null;
       delete roomVacant[assignedIndex];
@@ -997,6 +1001,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     this.remapGameStatePlayerIdReferences(state, comPlayerId, playerId);
 
     gameState.registerPlayerToken(playerId, playerId);
+    gameState.clearDisconnectTimeout(playerId);
     if (state.teamAssignments[comPlayerId] != null) {
       delete state.teamAssignments[comPlayerId];
     }

--- a/mei-tra-backend/src/types/game.types.ts
+++ b/mei-tra-backend/src/types/game.types.ts
@@ -55,6 +55,7 @@ export interface BlowState {
 
 export interface Field {
   cards: string[];
+  playedBy: string[];
   baseCard: string;
   baseSuit?: string;
   dealerId: string;

--- a/mei-tra-backend/src/use-cases/complete-field.use-case.ts
+++ b/mei-tra-backend/src/use-cases/complete-field.use-case.ts
@@ -59,6 +59,7 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
       if (state.playState) {
         state.playState.currentField = {
           cards: [],
+          playedBy: [],
           baseCard: '',
           dealerId: winner.playerId,
           isComplete: false,
@@ -269,6 +270,7 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
     const newPlayState = {
       currentField: {
         cards: [],
+        playedBy: [],
         baseCard: '',
         dealerId: nextBlowPlayer.playerId,
         isComplete: false,

--- a/mei-tra-backend/src/use-cases/leave-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/leave-room.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
+import { RoomStatus } from '../types/room.types';
 import { IRoomService } from '../services/interfaces/room-service.interface';
 import {
   ILeaveRoomUseCase,
@@ -68,7 +69,7 @@ export class LeaveRoomUseCase implements ILeaveRoomUseCase {
       // state.players is empty during waiting room (populated only at startGame).
       // Fall back to the room's real (non-COM) players in that case.
       const updatedPlayers =
-        roomExists.status === 'waiting'
+        roomExists.status === RoomStatus.WAITING
           ? roomExists.players
           : state.players.length > 0
             ? state.players

--- a/mei-tra-backend/src/use-cases/play-card.use-case.ts
+++ b/mei-tra-backend/src/use-cases/play-card.use-case.ts
@@ -68,6 +68,7 @@ export class PlayCardUseCase implements IPlayCardUseCase {
 
       const currentField = state.playState.currentField;
       currentField.cards.push(card);
+      currentField.playedBy.push(player.playerId);
       if (currentField.cards.length === 1) {
         currentField.baseCard = card;
       }

--- a/mei-tra-backend/src/use-cases/play-card.use-case.ts
+++ b/mei-tra-backend/src/use-cases/play-card.use-case.ts
@@ -67,8 +67,12 @@ export class PlayCardUseCase implements IPlayCardUseCase {
       player.hand = player.hand.filter((c) => c !== card);
 
       const currentField = state.playState.currentField;
+      const playedBy = Array.isArray(currentField.playedBy)
+        ? currentField.playedBy
+        : [];
+      currentField.playedBy = playedBy;
       currentField.cards.push(card);
-      currentField.playedBy.push(player.playerId);
+      playedBy.push(player.playerId);
       if (currentField.cards.length === 1) {
         currentField.baseCard = card;
       }

--- a/mei-tra-backend/src/use-cases/select-negri.use-case.ts
+++ b/mei-tra-backend/src/use-cases/select-negri.use-case.ts
@@ -45,6 +45,7 @@ export class SelectNegriUseCase implements ISelectNegriUseCase {
       state.playState = {
         currentField: {
           cards: [],
+          playedBy: [],
           baseCard: '',
           dealerId: player.playerId,
           isComplete: false,

--- a/mei-tra-frontend/app/[locale]/page.tsx
+++ b/mei-tra-frontend/app/[locale]/page.tsx
@@ -110,6 +110,7 @@ export default function Home() {
     shuffleTeams,
     removePlayerFromRoom,
     replacePlayerWithCOM,
+    idlePlayerIds = [],
     paused = false,
     pointsToWin = 0,
     isConnected = false,
@@ -213,6 +214,7 @@ export default function Home() {
                   teamScores={teamScores}
                   currentPlayerId={currentPlayerId}
                   currentRoomId={currentRoomId}
+                  idlePlayerIds={idlePlayerIds}
                   pointsToWin={pointsToWin}
                   onLeave={handleLeaveRoom}
                   onReplaceWithCOM={replacePlayerWithCOM}

--- a/mei-tra-frontend/app/[locale]/page.tsx
+++ b/mei-tra-frontend/app/[locale]/page.tsx
@@ -214,6 +214,7 @@ export default function Home() {
                   teamScores={teamScores}
                   currentPlayerId={currentPlayerId}
                   currentRoomId={currentRoomId}
+                  isHost={isHost}
                   idlePlayerIds={idlePlayerIds}
                   pointsToWin={pointsToWin}
                   onLeave={handleLeaveRoom}

--- a/mei-tra-frontend/app/[locale]/page.tsx
+++ b/mei-tra-frontend/app/[locale]/page.tsx
@@ -108,6 +108,8 @@ export default function Home() {
     isHost = false,
     startGame,
     shuffleTeams,
+    removePlayerFromRoom,
+    replacePlayerWithCOM,
     paused = false,
     pointsToWin = 0,
     isConnected = false,
@@ -187,6 +189,7 @@ export default function Home() {
                     onStart={startGame}
                     onLeave={handleLeaveRoom}
                     shuffleTeams={shuffleTeams}
+                    onRemovePlayer={removePlayerFromRoom}
                   />
                 ) : (
                 <GameTable
@@ -212,6 +215,7 @@ export default function Home() {
                   currentRoomId={currentRoomId}
                   pointsToWin={pointsToWin}
                   onLeave={handleLeaveRoom}
+                  onReplaceWithCOM={replacePlayerWithCOM}
                 />
                 )}
                 {gameStarted && (

--- a/mei-tra-frontend/components/GameField/index.tsx
+++ b/mei-tra-frontend/components/GameField/index.tsx
@@ -26,9 +26,6 @@ export const GameField: React.FC<GameFieldProps> = ({
     return null;
   }
 
-  // ディーラーのインデックスを取得
-  const dealerIndex = players.findIndex(p => p.playerId === currentField.dealerId);
-  
   return (
     <div className={styles.fieldContainer}>
       {currentField && (
@@ -37,10 +34,10 @@ export const GameField: React.FC<GameFieldProps> = ({
             {currentField.cards.map((card: string, index: number) => {
               const isRed = card.match(/[♥♦]/);
               const isJoker = card === 'JOKER';
-              const player =
-                dealerIndex === -1
-                  ? null
-                  : players[(dealerIndex + index) % players.length];
+              const playedByPlayerId = currentField.playedBy?.[index];
+              const player = playedByPlayerId
+                ? players.find((candidate) => candidate.playerId === playedByPlayerId) ?? null
+                : null;
               
               return (
                 <div key={index} className={styles.fieldContent}>

--- a/mei-tra-frontend/components/GameTable/index.tsx
+++ b/mei-tra-frontend/components/GameTable/index.tsx
@@ -76,12 +76,6 @@ export const GameTable: React.FC<GameTableProps> = ({
   }
 
   const currentHighestDeclarationPlayer = players.find(p => p.playerId === currentHighestDeclaration?.playerId)?.name;
-  const effectiveIsHost =
-    isHost ||
-    players.some(
-      (player) =>
-        player.playerId === currentPlayerId && Boolean(player.isHost),
-    );
 
   // Consistent table order for all players, self is always bottom
   const orderedPlayers = getSeatOrderWithSelfBottom(
@@ -168,7 +162,7 @@ export const GameTable: React.FC<GameTableProps> = ({
               players={players}
               currentField={currentField}
               currentTrump={currentTrump}
-              isHost={effectiveIsHost}
+              isHost={isHost}
               isIdle={idlePlayerIds.includes(player_.playerId)}
               onReplaceWithCOM={onReplaceWithCOM}
             />

--- a/mei-tra-frontend/components/GameTable/index.tsx
+++ b/mei-tra-frontend/components/GameTable/index.tsx
@@ -30,6 +30,7 @@ interface GameTableProps {
   teamScores: TeamScores;
   currentPlayerId: string | null;
   currentRoomId: string | null;
+  idlePlayerIds?: string[];
   pointsToWin: number;
   // Waiting-room props (shown before game starts)
   isWaiting?: boolean;
@@ -61,6 +62,7 @@ export const GameTable: React.FC<GameTableProps> = ({
   teamScores,
   currentPlayerId,
   pointsToWin,
+  idlePlayerIds = [],
   isWaiting = false,
   isHost = false,
   onStart,
@@ -161,6 +163,7 @@ export const GameTable: React.FC<GameTableProps> = ({
               currentField={currentField}
               currentTrump={currentTrump}
               isHost={isHost}
+              isIdle={idlePlayerIds.includes(player_.playerId)}
               onReplaceWithCOM={onReplaceWithCOM}
             />
           );

--- a/mei-tra-frontend/components/GameTable/index.tsx
+++ b/mei-tra-frontend/components/GameTable/index.tsx
@@ -76,6 +76,12 @@ export const GameTable: React.FC<GameTableProps> = ({
   }
 
   const currentHighestDeclarationPlayer = players.find(p => p.playerId === currentHighestDeclaration?.playerId)?.name;
+  const effectiveIsHost =
+    isHost ||
+    players.some(
+      (player) =>
+        player.playerId === currentPlayerId && Boolean(player.isHost),
+    );
 
   // Consistent table order for all players, self is always bottom
   const orderedPlayers = getSeatOrderWithSelfBottom(
@@ -162,7 +168,7 @@ export const GameTable: React.FC<GameTableProps> = ({
               players={players}
               currentField={currentField}
               currentTrump={currentTrump}
-              isHost={isHost}
+              isHost={effectiveIsHost}
               isIdle={idlePlayerIds.includes(player_.playerId)}
               onReplaceWithCOM={onReplaceWithCOM}
             />

--- a/mei-tra-frontend/components/GameTable/index.tsx
+++ b/mei-tra-frontend/components/GameTable/index.tsx
@@ -36,6 +36,7 @@ interface GameTableProps {
   isHost?: boolean;
   onStart?: () => void;
   onLeave?: () => void;
+  onReplaceWithCOM?: (playerId: string) => void;
 }
 
 
@@ -64,6 +65,7 @@ export const GameTable: React.FC<GameTableProps> = ({
   isHost = false,
   onStart,
   onLeave,
+  onReplaceWithCOM,
 }) => {
   const tRoot = useTranslations();
 
@@ -158,6 +160,8 @@ export const GameTable: React.FC<GameTableProps> = ({
               players={players}
               currentField={currentField}
               currentTrump={currentTrump}
+              isHost={isHost}
+              onReplaceWithCOM={onReplaceWithCOM}
             />
           );
         })}

--- a/mei-tra-frontend/components/PlayerAvatar/index.module.scss
+++ b/mei-tra-frontend/components/PlayerAvatar/index.module.scss
@@ -15,6 +15,19 @@
   aspect-ratio: 1;
 }
 
+.disconnectedBadge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  z-index: 2;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(127, 29, 29, 0.92);
+  color: #fee2e2;
+  font-size: 10px;
+  font-weight: 700;
+}
+
 .comBadge {
   position: absolute;
   inset: 0;
@@ -55,7 +68,20 @@
     max-width: 60px;
   }
 
-  .comBadge {
+  .disconnectedBadge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  z-index: 2;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(127, 29, 29, 0.92);
+  color: #fee2e2;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.comBadge {
     inset: 0;
   }
 
@@ -74,7 +100,20 @@
     max-width: 100px;
   }
 
-  .comBadge {
+  .disconnectedBadge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  z-index: 2;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(127, 29, 29, 0.92);
+  color: #fee2e2;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.comBadge {
     inset: 0;
   }
 
@@ -93,7 +132,20 @@
     max-width: 120px;
   }
 
-  .comBadge {
+  .disconnectedBadge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  z-index: 2;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(127, 29, 29, 0.92);
+  color: #fee2e2;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.comBadge {
     inset: 0;
   }
 

--- a/mei-tra-frontend/components/PlayerAvatar/index.module.scss
+++ b/mei-tra-frontend/components/PlayerAvatar/index.module.scss
@@ -17,15 +17,21 @@
 
 .disconnectedBadge {
   position: absolute;
-  top: 6px;
-  left: 6px;
+  top: 4px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 2;
+  max-width: calc(100% - 8px);
   padding: 2px 6px;
   border-radius: 999px;
   background: rgba(127, 29, 29, 0.92);
   color: #fee2e2;
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 700;
+  line-height: 1.1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .comBadge {
@@ -69,17 +75,10 @@
   }
 
   .disconnectedBadge {
-  position: absolute;
-  top: 6px;
-  left: 6px;
-  z-index: 2;
-  padding: 2px 6px;
-  border-radius: 999px;
-  background: rgba(127, 29, 29, 0.92);
-  color: #fee2e2;
-  font-size: 10px;
-  font-weight: 700;
-}
+    font-size: 8px;
+    max-width: calc(100% - 6px);
+    padding: 2px 5px;
+  }
 
 .comBadge {
     inset: 0;
@@ -101,17 +100,8 @@
   }
 
   .disconnectedBadge {
-  position: absolute;
-  top: 6px;
-  left: 6px;
-  z-index: 2;
-  padding: 2px 6px;
-  border-radius: 999px;
-  background: rgba(127, 29, 29, 0.92);
-  color: #fee2e2;
-  font-size: 10px;
-  font-weight: 700;
-}
+    font-size: 9px;
+  }
 
 .comBadge {
     inset: 0;
@@ -133,17 +123,8 @@
   }
 
   .disconnectedBadge {
-  position: absolute;
-  top: 6px;
-  left: 6px;
-  z-index: 2;
-  padding: 2px 6px;
-  border-radius: 999px;
-  background: rgba(127, 29, 29, 0.92);
-  color: #fee2e2;
-  font-size: 10px;
-  font-weight: 700;
-}
+    font-size: 10px;
+  }
 
 .comBadge {
     inset: 0;

--- a/mei-tra-frontend/components/PlayerAvatar/index.tsx
+++ b/mei-tra-frontend/components/PlayerAvatar/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
-import { useTranslations } from 'next-intl';
 import { Player } from '../../types/game.types';
 import { getPlayerProfile, getDefaultAvatarUrl, PlayerProfile } from '../../lib/utils/profileUtils';
 import { PlayerIdentityChip } from '../PlayerIdentityChip';
@@ -11,7 +10,6 @@ interface PlayerAvatarProps {
   size?: 'small' | 'medium' | 'large';
   showName?: boolean;
   className?: string;
-  statusLabel?: string | null;
 }
 
 export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
@@ -19,9 +17,7 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
   size = 'medium',
   showName = true,
   className = '',
-  statusLabel,
 }) => {
-  const t = useTranslations('playerStatus');
   const [profile, setProfile] = useState<PlayerProfile | null>(null);
   const [imageError, setImageError] = useState(false);
 
@@ -56,8 +52,6 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
   const sizePixels = getSizePixels();
   const isDefaultAvatar = imageError || !profile?.avatarUrl;
   const avatarSrc = getAvatarSrc();
-  const isDisconnected = !player.isCOM && !player.id;
-  const resolvedStatusLabel = statusLabel ?? (isDisconnected ? t('disconnected') : null);
 
   return (
     <div className={`${styles.playerAvatar} ${styles[size]} ${className}`}>
@@ -72,9 +66,6 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
           priority={false}
           unoptimized={isDefaultAvatar}
         />
-        {resolvedStatusLabel && (
-          <div className={styles.disconnectedBadge}>{resolvedStatusLabel}</div>
-        )}
         {player.isCOM && (
           <div className={styles.comBadge}>
             <span className={styles.comIcon}>🤖</span>

--- a/mei-tra-frontend/components/PlayerAvatar/index.tsx
+++ b/mei-tra-frontend/components/PlayerAvatar/index.tsx
@@ -11,6 +11,7 @@ interface PlayerAvatarProps {
   size?: 'small' | 'medium' | 'large';
   showName?: boolean;
   className?: string;
+  statusLabel?: string | null;
 }
 
 export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
@@ -18,6 +19,7 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
   size = 'medium',
   showName = true,
   className = '',
+  statusLabel,
 }) => {
   const t = useTranslations('playerStatus');
   const [profile, setProfile] = useState<PlayerProfile | null>(null);
@@ -55,6 +57,7 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
   const isDefaultAvatar = imageError || !profile?.avatarUrl;
   const avatarSrc = getAvatarSrc();
   const isDisconnected = !player.isCOM && !player.id;
+  const resolvedStatusLabel = statusLabel ?? (isDisconnected ? t('disconnected') : null);
 
   return (
     <div className={`${styles.playerAvatar} ${styles[size]} ${className}`}>
@@ -69,8 +72,8 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
           priority={false}
           unoptimized={isDefaultAvatar}
         />
-        {isDisconnected && (
-          <div className={styles.disconnectedBadge}>{t('disconnected')}</div>
+        {resolvedStatusLabel && (
+          <div className={styles.disconnectedBadge}>{resolvedStatusLabel}</div>
         )}
         {player.isCOM && (
           <div className={styles.comBadge}>

--- a/mei-tra-frontend/components/PlayerAvatar/index.tsx
+++ b/mei-tra-frontend/components/PlayerAvatar/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
+import { useTranslations } from 'next-intl';
 import { Player } from '../../types/game.types';
 import { getPlayerProfile, getDefaultAvatarUrl, PlayerProfile } from '../../lib/utils/profileUtils';
 import { PlayerIdentityChip } from '../PlayerIdentityChip';
@@ -18,12 +19,13 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
   showName = true,
   className = '',
 }) => {
+  const t = useTranslations('playerStatus');
   const [profile, setProfile] = useState<PlayerProfile | null>(null);
   const [imageError, setImageError] = useState(false);
 
   useEffect(() => {
     getPlayerProfile(player).then(setProfile);
-  }, [player.userId, player.name, player.isAuthenticated]);
+  }, [player]);
 
   const handleImageError = () => {
     setImageError(true);
@@ -52,28 +54,23 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
   const sizePixels = getSizePixels();
   const isDefaultAvatar = imageError || !profile?.avatarUrl;
   const avatarSrc = getAvatarSrc();
+  const isDisconnected = !player.isCOM && !player.id;
 
   return (
     <div className={`${styles.playerAvatar} ${styles[size]} ${className}`}>
       <div className={styles.avatarContainer}>
-        {isDefaultAvatar ? (
-          <img
-            src={avatarSrc}
-            alt={`${displayName}'s avatar`}
-            width={sizePixels}
-            height={sizePixels}
-            className={styles.avatarImage}
-          />
-        ) : (
-          <Image
-            src={avatarSrc}
-            alt={`${displayName}'s avatar`}
-            width={sizePixels}
-            height={sizePixels}
-            className={styles.avatarImage}
-            onError={handleImageError}
-            priority={false}
-          />
+        <Image
+          src={avatarSrc}
+          alt={`${displayName}'s avatar`}
+          width={sizePixels}
+          height={sizePixels}
+          className={styles.avatarImage}
+          onError={handleImageError}
+          priority={false}
+          unoptimized={isDefaultAvatar}
+        />
+        {isDisconnected && (
+          <div className={styles.disconnectedBadge}>{t('disconnected')}</div>
         )}
         {player.isCOM && (
           <div className={styles.comBadge}>

--- a/mei-tra-frontend/components/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/PlayerHand/index.module.scss
@@ -199,6 +199,28 @@
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
 }
 
+
+.disconnectedBadge {
+  font-size: 11px;
+  color: #fef3c7;
+  background: rgba(146, 64, 14, 0.75);
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  font-weight: 700;
+}
+
+.replaceWithComButton {
+  min-height: 2rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  background: rgba(127, 29, 29, 0.78);
+  color: #fee2e2;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
 .statusPanel{
   display: flex;
   flex-direction: column;

--- a/mei-tra-frontend/components/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/PlayerHand/index.module.scss
@@ -211,7 +211,8 @@
 
 .replaceWithComButton {
   min-height: 2rem;
-  padding: 0.35rem 0.7rem;
+  width: 100%;
+  padding: 0.45rem 0.7rem;
   border-radius: 999px;
   border: 1px solid rgba(248, 113, 113, 0.4);
   background: rgba(127, 29, 29, 0.78);
@@ -219,6 +220,10 @@
   font-size: 0.78rem;
   font-weight: 700;
   cursor: pointer;
+}
+
+.replaceWithComPanel {
+  min-width: 132px;
 }
 
 .statusPanel{

--- a/mei-tra-frontend/components/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/PlayerHand/index.module.scss
@@ -159,7 +159,7 @@
   border: 1px solid rgba(16, 185, 129, 0.15);
   border-radius: 8px;
   padding: 4px;
-  min-width: 120px;
+  min-width: 132px;
   backdrop-filter: blur(2px);
 }
 

--- a/mei-tra-frontend/components/PlayerHand/index.tsx
+++ b/mei-tra-frontend/components/PlayerHand/index.tsx
@@ -25,6 +25,8 @@ interface PlayerHandProps {
   players: Player[];
   currentField: Field | null;
   currentTrump: TrumpType | null;
+  isHost?: boolean;
+  onReplaceWithCOM?: (playerId: string) => void;
 }
 
 export const PlayerHand: React.FC<PlayerHandProps> = ({
@@ -43,8 +45,11 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
   players,
   currentField,
   currentTrump,
+  isHost = false,
+  onReplaceWithCOM,
 }) => {
   const t = useTranslations('playerHand');
+  const tStatus = useTranslations('playerStatus');
   const [selectedCard, setSelectedCard] = useState<string | null>(null);
   const [selectedNegriCard, setSelectedNegriCard] = useState<string | null>(null);
   const autoRevealAttemptedRef = useRef(false);
@@ -56,6 +61,7 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
   );
   const isCurrentPlayer = currentPlayerId === player.playerId;
   const isWinningPlayer = currentHighestDeclaration?.playerId === player.playerId;
+  const isDisconnected = !player.isCOM && !player.id;
 
   useEffect(() => {
     if (gamePhase !== 'blow' || !isCurrentPlayer || !player.hasRequiredBroken) {
@@ -190,6 +196,22 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
               />
             </div>
             {gamePhase && <div className={styles.cardCount}>{player.hand.length}{t('cards')}</div>}
+            {isDisconnected && (
+              <div className={styles.disconnectedBadge}>{tStatus('disconnected')}</div>
+            )}
+            {isHost &&
+              onReplaceWithCOM &&
+              !isCurrentPlayer &&
+              isDisconnected &&
+              !player.isCOM && (
+                <button
+                  type="button"
+                  className={styles.replaceWithComButton}
+                  onClick={() => onReplaceWithCOM(player.playerId)}
+                >
+                  {tStatus('replaceWithCom')}
+                </button>
+              )}
             {gamePhase === 'blow' && isCurrentPlayer && player.hasBroken && (
               <button
                 className={styles.brokenButton}

--- a/mei-tra-frontend/components/PlayerHand/index.tsx
+++ b/mei-tra-frontend/components/PlayerHand/index.tsx
@@ -200,26 +200,12 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
                 player={player}
                 size="medium"
                 showName={true}
-                statusLabel={statusLabel}
               />
             </div>
             {gamePhase && <div className={styles.cardCount}>{player.hand.length}{t('cards')}</div>}
             {statusLabel && (
               <div className={styles.disconnectedBadge}>{statusLabel}</div>
             )}
-            {isHost &&
-              onReplaceWithCOM &&
-              !isCurrentPlayer &&
-              (isDisconnected || isIdle) &&
-              !player.isCOM && (
-                <button
-                  type="button"
-                  className={styles.replaceWithComButton}
-                  onClick={() => onReplaceWithCOM(player.playerId)}
-                >
-                  {tStatus('replaceWithCom')}
-                </button>
-              )}
             {gamePhase === 'blow' && isCurrentPlayer && player.hasBroken && (
               <button
                 className={styles.brokenButton}
@@ -242,6 +228,22 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
               <div className={styles.statusMessage}>{t('selectNegri')}</div>
             </div>
           )}
+          {isHost &&
+            onReplaceWithCOM &&
+            !isCurrentPlayer &&
+            (isDisconnected || isIdle) &&
+            !player.isCOM && (
+              <div className={`${styles.statusPanel} ${styles.replaceWithComPanel}`}>
+                <div className={styles.statusHeader}>{tStatus('disconnected')}</div>
+                <button
+                  type="button"
+                  className={styles.replaceWithComButton}
+                  onClick={() => onReplaceWithCOM(player.playerId)}
+                >
+                  {tStatus('replaceWithCom')}
+                </button>
+              </div>
+            )}
           {isCurrentPlayer && agariCard && isWinningPlayer && (
             <div className={`${styles.statusPanel} ${styles.agariStatusPanel}`}>
               <div className={styles.statusHeader}>{t('agari')}</div>

--- a/mei-tra-frontend/components/PlayerHand/index.tsx
+++ b/mei-tra-frontend/components/PlayerHand/index.tsx
@@ -26,6 +26,7 @@ interface PlayerHandProps {
   currentField: Field | null;
   currentTrump: TrumpType | null;
   isHost?: boolean;
+  isIdle?: boolean;
   onReplaceWithCOM?: (playerId: string) => void;
 }
 
@@ -46,6 +47,7 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
   currentField,
   currentTrump,
   isHost = false,
+  isIdle = false,
   onReplaceWithCOM,
 }) => {
   const t = useTranslations('playerHand');
@@ -62,6 +64,11 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
   const isCurrentPlayer = currentPlayerId === player.playerId;
   const isWinningPlayer = currentHighestDeclaration?.playerId === player.playerId;
   const isDisconnected = !player.isCOM && !player.id;
+  const statusLabel = isDisconnected
+    ? tStatus('disconnected')
+    : isIdle
+      ? tStatus('idle')
+      : null;
 
   useEffect(() => {
     if (gamePhase !== 'blow' || !isCurrentPlayer || !player.hasRequiredBroken) {
@@ -193,16 +200,17 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
                 player={player}
                 size="medium"
                 showName={true}
+                statusLabel={statusLabel}
               />
             </div>
             {gamePhase && <div className={styles.cardCount}>{player.hand.length}{t('cards')}</div>}
-            {isDisconnected && (
-              <div className={styles.disconnectedBadge}>{tStatus('disconnected')}</div>
+            {statusLabel && (
+              <div className={styles.disconnectedBadge}>{statusLabel}</div>
             )}
             {isHost &&
               onReplaceWithCOM &&
               !isCurrentPlayer &&
-              isDisconnected &&
+              (isDisconnected || isIdle) &&
               !player.isCOM && (
                 <button
                   type="button"

--- a/mei-tra-frontend/components/PlayerHand/index.tsx
+++ b/mei-tra-frontend/components/PlayerHand/index.tsx
@@ -64,11 +64,6 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
   const isCurrentPlayer = currentPlayerId === player.playerId;
   const isWinningPlayer = currentHighestDeclaration?.playerId === player.playerId;
   const isDisconnected = !player.isCOM && !player.id;
-  const statusLabel = isDisconnected
-    ? tStatus('disconnected')
-    : isIdle
-      ? tStatus('idle')
-      : null;
 
   useEffect(() => {
     if (gamePhase !== 'blow' || !isCurrentPlayer || !player.hasRequiredBroken) {
@@ -203,9 +198,6 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
               />
             </div>
             {gamePhase && <div className={styles.cardCount}>{player.hand.length}{t('cards')}</div>}
-            {statusLabel && (
-              <div className={styles.disconnectedBadge}>{statusLabel}</div>
-            )}
             {gamePhase === 'blow' && isCurrentPlayer && player.hasBroken && (
               <button
                 className={styles.brokenButton}

--- a/mei-tra-frontend/components/PlayerIdentityChip/index.module.scss
+++ b/mei-tra-frontend/components/PlayerIdentityChip/index.module.scss
@@ -3,6 +3,7 @@
   align-items: center;
   gap: 0.4rem;
   max-width: 100%;
+  box-sizing: border-box;
   padding: 0.2rem 0.6rem;
   border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 999px;
@@ -36,6 +37,7 @@
 }
 
 .label {
+  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/mei-tra-frontend/components/PreGameTable/index.module.scss
+++ b/mei-tra-frontend/components/PreGameTable/index.module.scss
@@ -22,6 +22,25 @@
   justify-content: center;
 }
 
+.seatContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.seatActionButton {
+  min-height: 2rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  background: rgba(127, 29, 29, 0.78);
+  color: #fee2e2;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
 .top {
   grid-area: top;
   align-self: start;

--- a/mei-tra-frontend/components/PreGameTable/index.tsx
+++ b/mei-tra-frontend/components/PreGameTable/index.tsx
@@ -14,6 +14,7 @@ interface PreGameTableProps {
   onStart: () => void;
   onLeave: () => void;
   shuffleTeams?: () => void;
+  onRemovePlayer?: (playerId: string) => void;
 }
 
 const positions = ['bottom', 'left', 'top', 'right'] as const;
@@ -36,6 +37,7 @@ export const PreGameTable: React.FC<PreGameTableProps> = ({
   onStart,
   onLeave,
   shuffleTeams,
+  onRemovePlayer,
 }) => {
   const tRoot = useTranslations();
 
@@ -56,7 +58,21 @@ export const PreGameTable: React.FC<PreGameTableProps> = ({
           key={player.playerId}
           className={`${styles.playerSeat} ${styles[positions[idx]]}`}
         >
-          <PlayerAvatar player={player} size="medium" showName={true} />
+          <div className={styles.seatContent}>
+            <PlayerAvatar player={player} size="medium" showName={true} />
+            {isHost &&
+              onRemovePlayer &&
+              !player.isCOM &&
+              player.playerId !== currentPlayerId && (
+                <button
+                  type="button"
+                  className={styles.seatActionButton}
+                  onClick={() => onRemovePlayer(player.playerId)}
+                >
+                  {tRoot('room.removePlayer')}
+                </button>
+              )}
+          </div>
         </div>
       ))}
 

--- a/mei-tra-frontend/components/molecules/RoomList/index.tsx
+++ b/mei-tra-frontend/components/molecules/RoomList/index.tsx
@@ -154,7 +154,15 @@ export const RoomList: React.FC<RoomListProps> = ({
         </div>
         <div className={styles.roomList}>
           {filteredRooms.map((room) => {
-            const actualPlayerCount = room.players.filter(p => !p.isCOM).length;
+            const displayPlayers = room.players
+              .filter(
+                (player, index, players) =>
+                  players.findIndex(
+                    (candidate) => candidate.playerId === player.playerId,
+                  ) === index,
+              )
+              .slice(0, room.settings.maxPlayers);
+            const actualPlayerCount = displayPlayers.filter((p) => !p.isCOM).length;
             return (
               <div key={room.id} className={styles.roomItem}>
                 <div className={styles.roomInfo}>
@@ -164,7 +172,7 @@ export const RoomList: React.FC<RoomListProps> = ({
                     {t('room.status')}: {getStatusText(room.status, t)}
                   </p>
                   <ul className={styles.playerList}>
-                    {room.players.map((player, index) => (
+                    {displayPlayers.map((player, index) => (
                       <li
                         key={`${player.playerId}-${index}`}
                         className={styles.playerItem}
@@ -177,7 +185,7 @@ export const RoomList: React.FC<RoomListProps> = ({
                 </div>
                 {(() => {
                   const isPlayingRoom = room.status === RoomStatus.PLAYING;
-                  const hasComSeat = room.players.some((p) => p.isCOM === true);
+                  const hasComSeat = displayPlayers.some((p) => p.isCOM === true);
                   const canJoin =
                     (!isPlayingRoom && actualPlayerCount < room.settings.maxPlayers) ||
                     (isPlayingRoom && hasComSeat);

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -66,22 +66,6 @@ export const useGame = () => {
 
   const [paused, setPaused] = useState(false);
 
-  const mergePlayersWithMetadata = useCallback(
-    (nextPlayers: Player[], previousPlayers: Player[] = players) =>
-      nextPlayers.map((nextPlayer) => {
-        const previousPlayer = previousPlayers.find(
-          (candidate) => candidate.playerId === nextPlayer.playerId,
-        );
-
-        return {
-          ...previousPlayer,
-          ...nextPlayer,
-          isHost: previousPlayer?.isHost ?? nextPlayer.isHost,
-        };
-      }),
-    [players],
-  );
-
   const resetRoomState = useCallback(() => {
     gameOverShownRef.current = null;
     setGameStarted(false);
@@ -109,7 +93,6 @@ export const useGame = () => {
 
     if (selfByPlayerId) {
       setCurrentPlayerId(selfByPlayerId.playerId);
-      setIsHost(Boolean(selfByPlayerId.isHost));
       return;
     }
 
@@ -117,7 +100,6 @@ export const useGame = () => {
       const selfByUserId = nextPlayers.find((player) => player.userId === user.id);
       if (selfByUserId) {
         setCurrentPlayerId(selfByUserId.playerId);
-        setIsHost(Boolean(selfByUserId.isHost));
       }
     }
   }, [user?.id]);
@@ -180,16 +162,13 @@ export const useGame = () => {
         }
       },
       'update-players': (players: Player[]) => {
-        setPlayers((prev) => {
-          const mergedPlayers = mergePlayersWithMetadata(players, prev);
-          syncCurrentPlayerIdentity(mergedPlayers, currentPlayerId);
-          return mergedPlayers;
-        });
+        setPlayers(players);
         setIdlePlayerIds((prev) =>
           prev.filter((playerId) =>
             players.some((player) => player.playerId === playerId),
           ),
         );
+        syncCurrentPlayerIdentity(players, currentPlayerId);
       },
       'set-room-id': (roomId: string) => {
         setCurrentRoomId(roomId);
@@ -198,25 +177,11 @@ export const useGame = () => {
         if (room.id !== currentRoomId) {
           return;
         }
-
-        setPlayers((prev) => {
-          const mergedPlayers = prev.map((player) => {
-            const roomPlayer = room.players.find(
-              (candidate) => candidate.playerId === player.playerId,
-            );
-            if (!roomPlayer) {
-              return player;
-            }
-
-            return {
-              ...player,
-              ...roomPlayer,
-            };
-          });
-
-          syncCurrentPlayerIdentity(mergedPlayers, currentPlayerId);
-          return mergedPlayers;
-        });
+        const selfPlayerId =
+          currentPlayerId ??
+          room.players.find((player) => player.userId === user?.id)?.playerId ??
+          null;
+        setIsHost(Boolean(selfPlayerId && room.hostId === selfPlayerId));
       },
       'game-state': ({
         players,
@@ -229,6 +194,7 @@ export const useGame = () => {
         negriCard,
         fields,
         roomId,
+        hostId,
         pointsToWin,
       }: {
         players: Player[];
@@ -241,13 +207,11 @@ export const useGame = () => {
         negriCard: string | null;
         fields: CompletedField[];
         roomId: string;
+        hostId?: string;
         pointsToWin: number;
       }) => {
-        setPlayers((prev) => {
-          const mergedPlayers = mergePlayersWithMetadata(players, prev);
-          syncCurrentPlayerIdentity(mergedPlayers, you ?? currentPlayerId);
-          return mergedPlayers;
-        });
+        setPlayers(players);
+        syncCurrentPlayerIdentity(players, you ?? currentPlayerId);
         setGamePhase(gamePhase);
         setWhoseTurn(currentTurn);
         setCurrentField(currentField);
@@ -263,6 +227,7 @@ export const useGame = () => {
         setCurrentRoomId(roomId);
         setGameStarted(true);
         setPointsToWin(pointsToWin);
+        setIsHost(Boolean(hostId && hostId === (you ?? currentPlayerId)));
         setIdlePlayerIds((prev) =>
           prev.filter((playerId) =>
             players.some((player) => player.playerId === playerId),
@@ -310,11 +275,8 @@ export const useGame = () => {
       'game-started': (roomId: string, players: Player[], pointsToWin: number) => {
         gameOverShownRef.current = null;
         resetBlowState({ preservePlayers: true });
-        setPlayers((prev) => {
-          const mergedPlayers = mergePlayersWithMetadata(players, prev);
-          syncCurrentPlayerIdentity(mergedPlayers, currentPlayerId);
-          return mergedPlayers;
-        });
+        setPlayers(players);
+        syncCurrentPlayerIdentity(players, currentPlayerId);
 
         // Identify self by playerId (stable across reconnections), not socket.id
         const index = players.findIndex(p => p.playerId === currentPlayerId);
@@ -404,7 +366,7 @@ export const useGame = () => {
       },
       'blow-started': ({ startingPlayer, players }: { startingPlayer: string; players: Player[] }) => {
         setGamePhase('blow');
-        setPlayers((prev) => mergePlayersWithMetadata(players, prev));
+        setPlayers(players);
         setWhoseTurn(startingPlayer);
       },
       'blow-updated': ({ declarations, actionHistory, currentHighest }: { declarations: BlowDeclaration[]; actionHistory?: BlowAction[]; currentHighest: BlowDeclaration | null }) => {
@@ -420,7 +382,7 @@ export const useGame = () => {
           type: 'warning'
         });
         resetBlowState({ preservePlayers: true });
-        setPlayers((prev) => mergePlayersWithMetadata(players, prev));
+        setPlayers(players);
         setWhoseTurn(nextPlayerId);
         setGamePhase(gamePhase ?? 'blow');
         setCurrentTrump(null);
@@ -443,7 +405,7 @@ export const useGame = () => {
           type: 'warning'
         });
         resetBlowState({ preservePlayers: true });
-        setPlayers((prev) => mergePlayersWithMetadata(players, prev));
+        setPlayers(players);
         setWhoseTurn(nextDealer);
         setCurrentTrump(currentTrump ?? null);
         setCurrentHighestDeclaration(currentHighestDeclaration ?? null);
@@ -477,7 +439,7 @@ export const useGame = () => {
       'card-played': ({ field, players: updatedPlayers }: { field: Field, players: Player[] }) => {
         setCurrentField(field);
         // Update players with the latest data from server
-        setPlayers((prev) => mergePlayersWithMetadata(updatedPlayers, prev));
+        setPlayers(updatedPlayers);
       },
       'field-updated': (field: Field) => {
         setCurrentField(field);
@@ -516,7 +478,7 @@ export const useGame = () => {
         currentHighestDeclaration: BlowDeclaration | null;
         blowDeclarations: BlowDeclaration[];
       }) => {
-        setPlayers((prev) => mergePlayersWithMetadata(players, prev));
+        setPlayers(players);
         setWhoseTurn(currentTurn);
         setGamePhase(gamePhase);
         setCurrentField(currentField);
@@ -656,7 +618,6 @@ export const useGame = () => {
     currentPlayerId,
     currentRoomId,
     negriPlayerId,
-    mergePlayersWithMetadata,
     syncCurrentPlayerIdentity,
     resetRoomState,
     t,

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -6,6 +6,19 @@ import { BlowAction, BlowDeclaration, BlowState, CompletedField, Field, FieldCom
 import { Room } from '../types/room.types';
 import { getTeamDisplayName } from '../lib/utils/teamUtils';
 
+const dedupeCompletedFields = (fields: CompletedField[]): CompletedField[] => {
+  const seen = new Set<string>();
+
+  return fields.filter((field) => {
+    const signature = `${field.winnerId}|${field.winnerTeam}|${field.cards.join(',')}`;
+    if (seen.has(signature)) {
+      return false;
+    }
+    seen.add(signature);
+    return true;
+  });
+};
+
 export const useGame = () => {
   const tStatus = useTranslations('playerStatus');
   const t = useTranslations('game');
@@ -56,6 +69,7 @@ export const useGame = () => {
   const [currentPlayerId, setCurrentPlayerId] = useState<string | null>(null);
 
   const [currentRoomId, setCurrentRoomId] = useState<string | null>(null);
+  const [currentHostId, setCurrentHostId] = useState<string | null>(null);
   const [isHost, setIsHost] = useState(false);
   const [pointsToWin, setPointsToWin] = useState<number>(0);
   const [idlePlayerIds, setIdlePlayerIds] = useState<string[]>([]);
@@ -71,6 +85,7 @@ export const useGame = () => {
     setGameStarted(false);
     setGamePhase(null);
     setCurrentRoomId(null);
+    setCurrentHostId(null);
     setCurrentPlayerId(null);
     setIsHost(false);
     setIdlePlayerIds([]);
@@ -103,6 +118,15 @@ export const useGame = () => {
       }
     }
   }, [user?.id]);
+
+  useEffect(() => {
+    if (!currentHostId || !currentPlayerId) {
+      setIsHost(false);
+      return;
+    }
+
+    setIsHost(currentHostId === currentPlayerId);
+  }, [currentHostId, currentPlayerId]);
 
   useEffect(() => {
     setIsClient(true);
@@ -174,14 +198,29 @@ export const useGame = () => {
         setCurrentRoomId(roomId);
       },
       'room-updated': (room: Room) => {
-        if (room.id !== currentRoomId) {
-          return;
-        }
         const selfPlayerId =
           currentPlayerId ??
           room.players.find((player) => player.userId === user?.id)?.playerId ??
           null;
-        setIsHost(Boolean(selfPlayerId && room.hostId === selfPlayerId));
+        const isCurrentRoom =
+          room.id === currentRoomId ||
+          Boolean(
+            selfPlayerId &&
+              room.players.some((player) => player.playerId === selfPlayerId),
+          );
+
+        if (!isCurrentRoom) {
+          return;
+        }
+
+        if (!currentRoomId) {
+          setCurrentRoomId(room.id);
+        }
+
+        setCurrentHostId(room.hostId);
+        if (selfPlayerId) {
+          setCurrentPlayerId(selfPlayerId);
+        }
       },
       'game-state': ({
         players,
@@ -222,12 +261,12 @@ export const useGame = () => {
         setTeamScores(teamScores);
         if (you !== undefined) setCurrentPlayerId(you);
         setNegriCard(negriCard);
-        setCompletedFields(fields);
+        setCompletedFields(dedupeCompletedFields(fields));
         setNegriPlayerId(negriPlayerId);
         setCurrentRoomId(roomId);
+        setCurrentHostId(hostId ?? null);
         setGameStarted(true);
         setPointsToWin(pointsToWin);
-        setIsHost(Boolean(hostId && hostId === (you ?? currentPlayerId)));
         setIdlePlayerIds((prev) =>
           prev.filter((playerId) =>
             players.some((player) => player.playerId === playerId),
@@ -445,8 +484,14 @@ export const useGame = () => {
         setCurrentField(field);
       },
       'field-complete': ({ field, nextPlayerId }: FieldCompleteEvent) => {
-        setCompletedFields(prev => [...prev, field]);
-        setCurrentField({ cards: [], baseCard: '', dealerId: nextPlayerId, isComplete: false });
+        setCompletedFields((prev) => dedupeCompletedFields([...prev, field]));
+        setCurrentField({
+          cards: [],
+          playedBy: [],
+          baseCard: '',
+          dealerId: nextPlayerId,
+          isComplete: false,
+        });
       },
       'round-results': ({ scores }: {
         scores: { [key: number]: TeamScore };
@@ -482,7 +527,7 @@ export const useGame = () => {
         setWhoseTurn(currentTurn);
         setGamePhase(gamePhase);
         setCurrentField(currentField);
-        setCompletedFields(completedFields);
+        setCompletedFields(dedupeCompletedFields(completedFields));
         setNegriCard(negriCard);
         setNegriPlayerId(negriPlayerId);
         setRevealedAgari(revealedAgari);

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -66,6 +66,22 @@ export const useGame = () => {
 
   const [paused, setPaused] = useState(false);
 
+  const mergePlayersWithMetadata = useCallback(
+    (nextPlayers: Player[], previousPlayers: Player[] = players) =>
+      nextPlayers.map((nextPlayer) => {
+        const previousPlayer = previousPlayers.find(
+          (candidate) => candidate.playerId === nextPlayer.playerId,
+        );
+
+        return {
+          ...previousPlayer,
+          ...nextPlayer,
+          isHost: previousPlayer?.isHost ?? nextPlayer.isHost,
+        };
+      }),
+    [players],
+  );
+
   const resetRoomState = useCallback(() => {
     gameOverShownRef.current = null;
     setGameStarted(false);
@@ -164,13 +180,16 @@ export const useGame = () => {
         }
       },
       'update-players': (players: Player[]) => {
-        setPlayers(players);
+        setPlayers((prev) => {
+          const mergedPlayers = mergePlayersWithMetadata(players, prev);
+          syncCurrentPlayerIdentity(mergedPlayers, currentPlayerId);
+          return mergedPlayers;
+        });
         setIdlePlayerIds((prev) =>
           prev.filter((playerId) =>
             players.some((player) => player.playerId === playerId),
           ),
         );
-        syncCurrentPlayerIdentity(players, currentPlayerId);
       },
       'set-room-id': (roomId: string) => {
         setCurrentRoomId(roomId);
@@ -224,8 +243,11 @@ export const useGame = () => {
         roomId: string;
         pointsToWin: number;
       }) => {
-        setPlayers(players);
-        syncCurrentPlayerIdentity(players, you ?? currentPlayerId);
+        setPlayers((prev) => {
+          const mergedPlayers = mergePlayersWithMetadata(players, prev);
+          syncCurrentPlayerIdentity(mergedPlayers, you ?? currentPlayerId);
+          return mergedPlayers;
+        });
         setGamePhase(gamePhase);
         setWhoseTurn(currentTurn);
         setCurrentField(currentField);
@@ -288,8 +310,11 @@ export const useGame = () => {
       'game-started': (roomId: string, players: Player[], pointsToWin: number) => {
         gameOverShownRef.current = null;
         resetBlowState({ preservePlayers: true });
-        setPlayers(players);
-        syncCurrentPlayerIdentity(players, currentPlayerId);
+        setPlayers((prev) => {
+          const mergedPlayers = mergePlayersWithMetadata(players, prev);
+          syncCurrentPlayerIdentity(mergedPlayers, currentPlayerId);
+          return mergedPlayers;
+        });
 
         // Identify self by playerId (stable across reconnections), not socket.id
         const index = players.findIndex(p => p.playerId === currentPlayerId);
@@ -379,7 +404,7 @@ export const useGame = () => {
       },
       'blow-started': ({ startingPlayer, players }: { startingPlayer: string; players: Player[] }) => {
         setGamePhase('blow');
-        setPlayers(players);
+        setPlayers((prev) => mergePlayersWithMetadata(players, prev));
         setWhoseTurn(startingPlayer);
       },
       'blow-updated': ({ declarations, actionHistory, currentHighest }: { declarations: BlowDeclaration[]; actionHistory?: BlowAction[]; currentHighest: BlowDeclaration | null }) => {
@@ -395,7 +420,7 @@ export const useGame = () => {
           type: 'warning'
         });
         resetBlowState({ preservePlayers: true });
-        setPlayers(players);
+        setPlayers((prev) => mergePlayersWithMetadata(players, prev));
         setWhoseTurn(nextPlayerId);
         setGamePhase(gamePhase ?? 'blow');
         setCurrentTrump(null);
@@ -418,7 +443,7 @@ export const useGame = () => {
           type: 'warning'
         });
         resetBlowState({ preservePlayers: true });
-        setPlayers(players);
+        setPlayers((prev) => mergePlayersWithMetadata(players, prev));
         setWhoseTurn(nextDealer);
         setCurrentTrump(currentTrump ?? null);
         setCurrentHighestDeclaration(currentHighestDeclaration ?? null);
@@ -452,7 +477,7 @@ export const useGame = () => {
       'card-played': ({ field, players: updatedPlayers }: { field: Field, players: Player[] }) => {
         setCurrentField(field);
         // Update players with the latest data from server
-        setPlayers(updatedPlayers);
+        setPlayers((prev) => mergePlayersWithMetadata(updatedPlayers, prev));
       },
       'field-updated': (field: Field) => {
         setCurrentField(field);
@@ -491,7 +516,7 @@ export const useGame = () => {
         currentHighestDeclaration: BlowDeclaration | null;
         blowDeclarations: BlowDeclaration[];
       }) => {
-        setPlayers(players);
+        setPlayers((prev) => mergePlayersWithMetadata(players, prev));
         setWhoseTurn(currentTurn);
         setGamePhase(gamePhase);
         setCurrentField(currentField);
@@ -631,6 +656,7 @@ export const useGame = () => {
     currentPlayerId,
     currentRoomId,
     negriPlayerId,
+    mergePlayersWithMetadata,
     syncCurrentPlayerIdentity,
     resetRoomState,
     t,

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -6,6 +6,7 @@ import { BlowAction, BlowDeclaration, BlowState, CompletedField, Field, FieldCom
 import { getTeamDisplayName } from '../lib/utils/teamUtils';
 
 export const useGame = () => {
+  const tStatus = useTranslations('playerStatus');
   const t = useTranslations('game');
   const { socket, isConnected, isConnecting } = useSocket();
   const { user } = useAuth();
@@ -245,7 +246,13 @@ export const useGame = () => {
         } else {
           // Fallback: match by userId for authenticated users
           console.error('[useGame] Player not found in game-started by playerId', { currentPlayerId });
-          const userIndex = players.findIndex(p => p.userId && users.find(u => u.userId === p.userId && u.playerId === currentPlayerId));
+          const userIndex = players.findIndex(
+            (p) =>
+              p.userId &&
+              usersRef.current.find(
+                (u) => u.userId === p.userId && u.playerId === currentPlayerId,
+              ),
+          );
           if (userIndex !== -1) {
             setCurrentPlayerId(players[userIndex].playerId);
           }
@@ -473,10 +480,16 @@ export const useGame = () => {
         setGameStarted(true);
         setNotification({ message, type: 'success' });
       },
+      'player-disconnected': ({ playerId }: { playerId: string }) => {
+        setNotification({
+          message: tStatus('disconnectedNotice', { playerId }),
+          type: 'warning'
+        });
+      },
       'player-converted-to-com': ({ playerId, message }: { playerId: string; message: string }) => {
         console.log('[useGame] Player converted to COM:', playerId, message);
         setNotification({
-          message: `プレイヤー ${playerId} が長時間切断のため、COMプレイヤーに変換されました`,
+          message: message || tStatus('convertedToComNotice', { playerId }),
           type: 'warning'
         });
       },
@@ -499,7 +512,21 @@ export const useGame = () => {
         socket.off(event, socketHandlers[event as keyof typeof socketHandlers]);
       });
     };
-  }, [socket, name, currentHighestDeclaration, players, isConnecting, isConnected, currentPlayerId, negriPlayerId, user?.id, syncCurrentPlayerIdentity]);
+  }, [
+    socket,
+    name,
+    currentHighestDeclaration,
+    players,
+    isConnecting,
+    isConnected,
+    currentPlayerId,
+    currentRoomId,
+    negriPlayerId,
+    syncCurrentPlayerIdentity,
+    t,
+    tStatus,
+    user?.id,
+  ]);
 
   const resetBlowState = (options?: { preservePlayers?: boolean }) => {
     setBlowDeclarations([]);
@@ -520,6 +547,26 @@ export const useGame = () => {
   const startGame = () => {
     if (!currentRoomId || !currentPlayerId) return;
     socket?.emit('start-game', { roomId: currentRoomId, playerId: currentPlayerId });
+  };
+
+  const removePlayerFromRoom = (targetPlayerId: string) => {
+    if (!socket || !currentRoomId || !currentPlayerId) return;
+    socket.emit('moderate-player', {
+      roomId: currentRoomId,
+      requesterPlayerId: currentPlayerId,
+      targetPlayerId,
+      action: 'remove',
+    });
+  };
+
+  const replacePlayerWithCOM = (targetPlayerId: string) => {
+    if (!socket || !currentRoomId || !currentPlayerId) return;
+    socket.emit('moderate-player', {
+      roomId: currentRoomId,
+      requesterPlayerId: currentPlayerId,
+      targetPlayerId,
+      action: 'replace-with-com',
+    });
   };
 
   const shuffleTeams = () => {
@@ -667,6 +714,8 @@ export const useGame = () => {
     isHost,
     startGame,
     shuffleTeams,
+    removePlayerFromRoom,
+    replacePlayerWithCOM,
     pointsToWin,
     users,
     paused,

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -3,6 +3,7 @@ import { useTranslations } from 'next-intl';
 import { useSocket } from './useSocket';
 import { useAuth } from './useAuth';
 import { BlowAction, BlowDeclaration, BlowState, CompletedField, Field, FieldCompleteEvent, GamePhase, Player, TeamScore, TeamScores, TrumpType, User } from '../types/game.types';
+import { Room } from '../types/room.types';
 import { getTeamDisplayName } from '../lib/utils/teamUtils';
 
 export const useGame = () => {
@@ -173,6 +174,30 @@ export const useGame = () => {
       },
       'set-room-id': (roomId: string) => {
         setCurrentRoomId(roomId);
+      },
+      'room-updated': (room: Room) => {
+        if (room.id !== currentRoomId) {
+          return;
+        }
+
+        setPlayers((prev) => {
+          const mergedPlayers = prev.map((player) => {
+            const roomPlayer = room.players.find(
+              (candidate) => candidate.playerId === player.playerId,
+            );
+            if (!roomPlayer) {
+              return player;
+            }
+
+            return {
+              ...player,
+              ...roomPlayer,
+            };
+          });
+
+          syncCurrentPlayerIdentity(mergedPlayers, currentPlayerId);
+          return mergedPlayers;
+        });
       },
       'game-state': ({
         players,
@@ -499,38 +524,77 @@ export const useGame = () => {
         setGameStarted(true);
         setNotification({ message, type: 'success' });
       },
-      'player-disconnected': ({ playerId }: { playerId: string }) => {
+      'player-disconnected': ({
+        playerId,
+        playerName,
+      }: {
+        playerId: string;
+        playerName?: string;
+      }) => {
+        setPlayers((prev) =>
+          prev.map((player) =>
+            player.playerId === playerId
+              ? {
+                  ...player,
+                  id: '',
+                  name: playerName ?? player.name,
+                }
+              : player,
+          ),
+        );
         setIdlePlayerIds((prev) => prev.filter((id) => id !== playerId));
         setNotification({
-          message: tStatus('disconnectedNotice', { playerId }),
+          message: tStatus('disconnectedNotice', {
+            playerName: playerName ?? playerId,
+          }),
           type: 'warning'
         });
       },
-      'player-idle': ({ playerId }: { playerId: string }) => {
+      'player-idle': ({
+        playerId,
+        playerName,
+      }: {
+        playerId: string;
+        playerName?: string;
+      }) => {
         setIdlePlayerIds((prev) =>
           prev.includes(playerId) ? prev : [...prev, playerId],
         );
         setNotification({
-          message: tStatus('idleNotice', { playerId }),
+          message: tStatus('idleNotice', {
+            playerName: playerName ?? playerId,
+          }),
           type: 'warning',
         });
       },
       'player-idle-cleared': ({ playerId }: { playerId: string }) => {
         setIdlePlayerIds((prev) => prev.filter((id) => id !== playerId));
       },
-      'player-converted-to-com': ({ playerId, message }: { playerId: string; message: string }) => {
+      'player-converted-to-com': ({
+        playerId,
+        playerName,
+        message,
+      }: {
+        playerId: string;
+        playerName?: string;
+        message: string;
+      }) => {
         console.log('[useGame] Player converted to COM:', playerId, message);
         setIdlePlayerIds((prev) => prev.filter((id) => id !== playerId));
         if (playerId === currentPlayerId) {
           resetRoomState();
           setNotification({
-            message: message || tStatus('convertedToComNotice', { playerId }),
+            message: tStatus('convertedToComNotice', {
+              playerName: playerName ?? playerId,
+            }),
             type: 'warning'
           });
           return;
         }
         setNotification({
-          message: message || tStatus('convertedToComNotice', { playerId }),
+          message: tStatus('convertedToComNotice', {
+            playerName: playerName ?? playerId,
+          }),
           type: 'warning'
         });
       },

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -57,6 +57,7 @@ export const useGame = () => {
   const [currentRoomId, setCurrentRoomId] = useState<string | null>(null);
   const [isHost, setIsHost] = useState(false);
   const [pointsToWin, setPointsToWin] = useState<number>(0);
+  const [idlePlayerIds, setIdlePlayerIds] = useState<string[]>([]);
 
   const [users, setUsers] = useState<User[]>([]);
   // Keep a ref to users so event handlers always see the latest value (avoids stale closure)
@@ -147,6 +148,11 @@ export const useGame = () => {
       },
       'update-players': (players: Player[]) => {
         setPlayers(players);
+        setIdlePlayerIds((prev) =>
+          prev.filter((playerId) =>
+            players.some((player) => player.playerId === playerId),
+          ),
+        );
         syncCurrentPlayerIdentity(players, currentPlayerId);
       },
       'set-room-id': (roomId: string) => {
@@ -194,6 +200,11 @@ export const useGame = () => {
         setCurrentRoomId(roomId);
         setGameStarted(true);
         setPointsToWin(pointsToWin);
+        setIdlePlayerIds((prev) =>
+          prev.filter((playerId) =>
+            players.some((player) => player.playerId === playerId),
+          ),
+        );
       },
       'game-player-joined': (data: { playerId: string; roomId: string; isHost: boolean; roomStatus?: string; isSelf?: boolean; team?: number; name?: string }) => {
         // isSelf: true means the backend confirmed "this is YOUR player ID".
@@ -288,6 +299,9 @@ export const useGame = () => {
       },
       'update-turn': (playerId: string) => {
         setWhoseTurn(playerId);
+        if (socket && currentRoomId) {
+          socket.emit('turn-ack', { roomId: currentRoomId });
+        }
       },
       'game-over': ({ winner, finalScores }: { winner: string; finalScores: TeamScores }) => {
         // Prevent showing alert multiple times for the same game
@@ -462,6 +476,7 @@ export const useGame = () => {
         setGamePhase(null);
         setCurrentRoomId(null);
         setIsHost(false);
+        setIdlePlayerIds([]);
         setPlayers([]);
         setTeamScores({
           0: { deal: 0, blow: 0, play: 0, total: 0 },
@@ -481,23 +496,41 @@ export const useGame = () => {
         setNotification({ message, type: 'success' });
       },
       'player-disconnected': ({ playerId }: { playerId: string }) => {
+        setIdlePlayerIds((prev) => prev.filter((id) => id !== playerId));
         setNotification({
           message: tStatus('disconnectedNotice', { playerId }),
           type: 'warning'
         });
       },
+      'player-idle': ({ playerId }: { playerId: string }) => {
+        setIdlePlayerIds((prev) =>
+          prev.includes(playerId) ? prev : [...prev, playerId],
+        );
+        setNotification({
+          message: tStatus('idleNotice', { playerId }),
+          type: 'warning',
+        });
+      },
+      'player-idle-cleared': ({ playerId }: { playerId: string }) => {
+        setIdlePlayerIds((prev) => prev.filter((id) => id !== playerId));
+      },
       'player-converted-to-com': ({ playerId, message }: { playerId: string; message: string }) => {
         console.log('[useGame] Player converted to COM:', playerId, message);
+        setIdlePlayerIds((prev) => prev.filter((id) => id !== playerId));
         setNotification({
           message: message || tStatus('convertedToComNotice', { playerId }),
           type: 'warning'
         });
       },
       'player-left': ({ playerId }: { playerId: string; roomId: string }) => {
+        setIdlePlayerIds((prev) => prev.filter((id) => id !== playerId));
         if (playerId === currentPlayerId) {
           setCurrentRoomId(null);
           setIsHost(false);
         }
+      },
+      'turn-ping': ({ roomId }: { roomId: string }) => {
+        socket.emit('turn-ack', { roomId });
       },
     };
 
@@ -716,6 +749,7 @@ export const useGame = () => {
     shuffleTeams,
     removePlayerFromRoom,
     replacePlayerWithCOM,
+    idlePlayerIds,
     pointsToWin,
     users,
     paused,

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -65,6 +65,22 @@ export const useGame = () => {
 
   const [paused, setPaused] = useState(false);
 
+  const resetRoomState = useCallback(() => {
+    gameOverShownRef.current = null;
+    setGameStarted(false);
+    setGamePhase(null);
+    setCurrentRoomId(null);
+    setCurrentPlayerId(null);
+    setIsHost(false);
+    setIdlePlayerIds([]);
+    setPlayers([]);
+    setTeamScores({
+      0: { deal: 0, blow: 0, play: 0, total: 0 },
+      1: { deal: 0, blow: 0, play: 0, total: 0 }
+    });
+    sessionStorage.removeItem('roomId');
+  }, []);
+
   const syncCurrentPlayerIdentity = useCallback((
     nextPlayers: Player[],
     fallbackPlayerId?: string | null,
@@ -471,19 +487,7 @@ export const useGame = () => {
               ? sessionStorage.getItem('roomId')
               : null,
         });
-        gameOverShownRef.current = null;
-        setGameStarted(false);
-        setGamePhase(null);
-        setCurrentRoomId(null);
-        setIsHost(false);
-        setIdlePlayerIds([]);
-        setPlayers([]);
-        setTeamScores({
-          0: { deal: 0, blow: 0, play: 0, total: 0 },
-          1: { deal: 0, blow: 0, play: 0, total: 0 }
-        });
-        // Clear stored roomId so socket reconnects don't attempt to rejoin the old room
-        sessionStorage.removeItem('roomId');
+        resetRoomState();
       },
       'game-paused': ({ message }: { message: string }) => {
         setPaused(true);
@@ -517,6 +521,14 @@ export const useGame = () => {
       'player-converted-to-com': ({ playerId, message }: { playerId: string; message: string }) => {
         console.log('[useGame] Player converted to COM:', playerId, message);
         setIdlePlayerIds((prev) => prev.filter((id) => id !== playerId));
+        if (playerId === currentPlayerId) {
+          resetRoomState();
+          setNotification({
+            message: message || tStatus('convertedToComNotice', { playerId }),
+            type: 'warning'
+          });
+          return;
+        }
         setNotification({
           message: message || tStatus('convertedToComNotice', { playerId }),
           type: 'warning'
@@ -556,6 +568,7 @@ export const useGame = () => {
     currentRoomId,
     negriPlayerId,
     syncCurrentPlayerIdentity,
+    resetRoomState,
     t,
     tStatus,
     user?.id,

--- a/mei-tra-frontend/messages/en.json
+++ b/mei-tra-frontend/messages/en.json
@@ -275,7 +275,8 @@
       "starting": "Server is starting up. Please wait."
     },
     "shuffleTeams": "Shuffle",
-    "fillWithCOM": "Add COM"
+    "fillWithCOM": "Add COM",
+    "removePlayer": "Remove"
   },
   "game": {
     "initializing": "Initializing game...",
@@ -601,6 +602,12 @@
       "flow": "Game Flow\nDeal → Blow → Play → Waiting (until 10 fields completed)",
       "settings": "Basic Settings\n4 players 2 teams / Opposite = partner / First to 10 points wins / Minimum 6 pairs declaration"
     }
+  },
+  "playerStatus": {
+    "disconnected": "Disconnected",
+    "replaceWithCom": "Replace with COM",
+    "disconnectedNotice": "Player {playerId} disconnected. They will be replaced with COM after the timeout.",
+    "convertedToComNotice": "Player {playerId} was replaced with COM after being disconnected too long."
   },
   "profile": {
     "title": "Profile",

--- a/mei-tra-frontend/messages/en.json
+++ b/mei-tra-frontend/messages/en.json
@@ -607,9 +607,9 @@
     "disconnected": "Disconnected",
     "idle": "Unresponsive",
     "replaceWithCom": "Replace with COM",
-    "disconnectedNotice": "Player {playerId} disconnected. They will be replaced with COM after the timeout.",
-    "idleNotice": "Player {playerId} is not responding on their turn. The host can replace them with COM.",
-    "convertedToComNotice": "Player {playerId} was replaced with COM after being disconnected too long."
+    "disconnectedNotice": "{playerName} disconnected. They will be replaced with COM after the timeout.",
+    "idleNotice": "{playerName} is not responding on their turn. The host can replace them with COM.",
+    "convertedToComNotice": "{playerName} was replaced with COM after being disconnected too long."
   },
   "profile": {
     "title": "Profile",

--- a/mei-tra-frontend/messages/en.json
+++ b/mei-tra-frontend/messages/en.json
@@ -605,8 +605,10 @@
   },
   "playerStatus": {
     "disconnected": "Disconnected",
+    "idle": "Unresponsive",
     "replaceWithCom": "Replace with COM",
     "disconnectedNotice": "Player {playerId} disconnected. They will be replaced with COM after the timeout.",
+    "idleNotice": "Player {playerId} is not responding on their turn. The host can replace them with COM.",
     "convertedToComNotice": "Player {playerId} was replaced with COM after being disconnected too long."
   },
   "profile": {

--- a/mei-tra-frontend/messages/ja.json
+++ b/mei-tra-frontend/messages/ja.json
@@ -561,9 +561,9 @@
     "disconnected": "Disconnected",
     "idle": "応答なし",
     "replaceWithCom": "COMに切り替え",
-    "disconnectedNotice": "プレイヤー {playerId} の接続が切れました。一定時間後にCOMへ切り替わります。",
-    "idleNotice": "プレイヤー {playerId} が手番中に応答していません。ホストはCOMに切り替えできます。",
-    "convertedToComNotice": "プレイヤー {playerId} が長時間切断のため、COMプレイヤーに変換されました。"
+    "disconnectedNotice": "{playerName} の接続が切れました。一定時間後にCOMへ切り替わります。",
+    "idleNotice": "{playerName} が手番中に応答していません。ホストはCOMに切り替えできます。",
+    "convertedToComNotice": "{playerName} が長時間切断のため、COMプレイヤーに変換されました。"
   },
   "profile": {
     "title": "プロフィール",

--- a/mei-tra-frontend/messages/ja.json
+++ b/mei-tra-frontend/messages/ja.json
@@ -275,7 +275,8 @@
       "starting": "サーバーを起動しています。しばらくお待ちください。"
     },
     "shuffleTeams": "シャッフル",
-    "fillWithCOM": "COM追加"
+    "fillWithCOM": "COM追加",
+    "removePlayer": "退出させる"
   },
   "game": {
     "initializing": "ゲームを初期化中...",
@@ -555,6 +556,12 @@
       "flow": "ゲームフロー\nDeal → Blow → Play → Waiting（10フィールド完了まで）",
       "settings": "基本設定\n4人2チーム / 対面がパートナー / 10点先取勝利 / 最低6ペア宣言"
     }
+  },
+  "playerStatus": {
+    "disconnected": "Disconnected",
+    "replaceWithCom": "COMに切り替え",
+    "disconnectedNotice": "プレイヤー {playerId} の接続が切れました。一定時間後にCOMへ切り替わります。",
+    "convertedToComNotice": "プレイヤー {playerId} が長時間切断のため、COMプレイヤーに変換されました。"
   },
   "profile": {
     "title": "プロフィール",

--- a/mei-tra-frontend/messages/ja.json
+++ b/mei-tra-frontend/messages/ja.json
@@ -559,8 +559,10 @@
   },
   "playerStatus": {
     "disconnected": "Disconnected",
+    "idle": "応答なし",
     "replaceWithCom": "COMに切り替え",
     "disconnectedNotice": "プレイヤー {playerId} の接続が切れました。一定時間後にCOMへ切り替わります。",
+    "idleNotice": "プレイヤー {playerId} が手番中に応答していません。ホストはCOMに切り替えできます。",
     "convertedToComNotice": "プレイヤー {playerId} が長時間切断のため、COMプレイヤーに変換されました。"
   },
   "profile": {

--- a/mei-tra-frontend/types/game.types.ts
+++ b/mei-tra-frontend/types/game.types.ts
@@ -20,6 +20,7 @@ export interface CompletedField {
 
 export interface Field {
   cards: string[];
+  playedBy: string[];
   baseCard: string;
   baseSuit?: string;
   dealerId: string;


### PR DESCRIPTION
Summary:
- add host moderation actions for waiting rooms and disconnected in-game players
- shorten automatic COM replacement timeout and notify the room on disconnect
- align frontend labels/notifications with existing i18n patterns

Validation:
- cd mei-tra-backend && npm run lint
- cd mei-tra-backend && npm test -- --runTestsByPath src/services/__tests__/reconnection.spec.ts src/use-cases/__tests__/game.use-cases.spec.ts -t "LeaveRoomUseCase|reconnection"
- cd mei-tra-backend && npm run build
- cd mei-tra-frontend && npm run lint -- --file app/[locale]/page.tsx --file components/GameTable/index.tsx --file components/PlayerAvatar/index.tsx --file components/PlayerHand/index.tsx --file components/PreGameTable/index.tsx --file hooks/useGame.ts
- cd mei-tra-frontend && npx tsc --noEmit