### PR TITLE
fix: preload card SVGs and fix aspect ratio

### DIFF
--- a/mei-tra-frontend/components/Card/index.module.scss
+++ b/mei-tra-frontend/components/Card/index.module.scss
@@ -1,7 +1,6 @@
 .card {
   width: 1.8rem;
-  height: 2.5rem;
-  background: white;
+  aspect-ratio: 2 / 3;
   border-radius: 4px;
   display: flex;
   overflow: hidden;
@@ -22,7 +21,7 @@
 @media (max-width: 768px) {
   .card {
     width: 1.5rem;
-    height: 2.25rem;
+    aspect-ratio: 2 / 3;
     margin: 0 -8px;
   }
 }

--- a/mei-tra-frontend/components/CardFace/index.module.scss
+++ b/mei-tra-frontend/components/CardFace/index.module.scss
@@ -2,7 +2,7 @@
   width: 100%;
   height: 100%;
   display: block;
-  object-fit: contain;
+  object-fit: cover;
   user-select: none;
   -webkit-user-select: none;
   -webkit-touch-callout: none;

--- a/mei-tra-frontend/components/GameField/index.module.scss
+++ b/mei-tra-frontend/components/GameField/index.module.scss
@@ -79,8 +79,7 @@
 .card {
   position: relative;
   width: var(--card-width);
-  height: var(--card-height);
-  background: var(--color-white);
+  aspect-ratio: 2 / 3;
   border-radius: var(--radius-md);
   display: flex;
   overflow: hidden;
@@ -205,7 +204,7 @@
 
   .card {
     width: 68px;
-    height: 94px;
+    aspect-ratio: 2 / 3;
     box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
   }
 }

--- a/mei-tra-frontend/components/GameTable/index.tsx
+++ b/mei-tra-frontend/components/GameTable/index.tsx
@@ -8,6 +8,7 @@ import { PlayerHand } from '../PlayerHand';
 import { GameControls } from '../GameControls';
 import { BlowControls } from '../BlowControls';
 import { getSeatOrderWithSelfBottom } from '../../lib/utils/tableOrder';
+import { usePreloadCards } from '../../hooks/usePreloadCards';
 
 interface GameTableProps {
   whoseTurn: string | null;
@@ -70,6 +71,7 @@ export const GameTable: React.FC<GameTableProps> = ({
   onReplaceWithCOM,
 }) => {
   const tRoot = useTranslations();
+  usePreloadCards();
 
   if (!players || players.length === 0) {
     return null;

--- a/mei-tra-frontend/components/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/PlayerHand/index.module.scss
@@ -32,8 +32,7 @@
   cursor: pointer;
   transform: translateY(var(--card-translate-y, 0)) rotate(var(--card-rotation, 0deg)) !important;
   width: 72px;
-  height: 104px;
-  background: var(--color-white);
+  aspect-ratio: 2 / 3;
   border-radius: var(--radius-md);
   display: flex;
   overflow: hidden;
@@ -47,7 +46,7 @@
 
 .cardFaceDown{
   width: 1.7rem;
-  height: 2.5rem;
+  aspect-ratio: 2 / 3;
   border-radius: 0.25rem;
   display: flex;
   overflow: hidden;
@@ -479,7 +478,7 @@
 
   .card {
     width: 54px;
-    height: 72px;
+    aspect-ratio: 2 / 3;
   }
 
   .card.selected,
@@ -511,7 +510,7 @@
 
   .cardFaceDown{
     width: 1.25rem;
-    height: 1.8rem;
+    aspect-ratio: 2 / 3;
     border-radius: 0.25rem;
     margin-left: -0.9rem;
     border: 1px solid rgba(255, 255, 255, 0.25);
@@ -643,14 +642,12 @@
 
   .playerPosition.bottom .card {
     width: 63px;
-    height: 92px;
+    aspect-ratio: 2 / 3;
     margin: 0 -1.02rem;
-    padding: 0.24rem;
     z-index: calc(var(--card-index, 0) + 1);
     transform-origin: bottom center;
     transform: translateY(var(--card-translate-y, 0)) rotate(var(--card-rotation, 0deg)) !important;
     box-shadow: 0 10px 22px rgba(0, 0, 0, 0.3);
-    border: 1px solid rgba(0, 0, 0, 0.12);
   }
 
   .playerPosition.bottom .card.selected,

--- a/mei-tra-frontend/hooks/usePreloadCards.ts
+++ b/mei-tra-frontend/hooks/usePreloadCards.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import { CARD_BACK_PATH } from '../lib/utils/cardMapping';
+
+const ALL_SUITS = ['S', 'H', 'D', 'C'];
+const ALL_RANKS = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A'];
+
+export function usePreloadCards() {
+  useEffect(() => {
+    const paths = [
+      ...ALL_RANKS.flatMap(r => ALL_SUITS.map(s => `/cards/${r}_${s}.svg`)),
+      '/cards/joker_red.svg',
+      '/cards/joker_black.svg',
+      CARD_BACK_PATH,
+    ];
+    paths.forEach(src => {
+      const img = new Image();
+      img.src = src;
+    });
+  }, []);
+}


### PR DESCRIPTION
## Summary
- カードプレイ時の白フラッシュを解消（`usePreloadCards` hookで全SVGをゲーム画面マウント時にプリフェッチ）
- カードコンテナのアスペクト比を `aspect-ratio: 2/3` に統一し、SVGの210×315比率と一致させることで「透明スリーブ」現象を解消
- モバイルの `.card` に残っていた `padding` / `border` によるスリーブ効果を削除

## Test plan
- [ ] デスクトップ: カードプレイ時に白フラッシュが発生しないこと
- [ ] モバイル: カードが透明スリーブなしでクリーンに表示されること
- [ ] DevTools Network: ゲーム画面マウント時に全SVGがプリフェッチされていること
- [ ] ファンレイアウト・裏面カード・ネグリカードの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)