### PR TITLE
[codex] fix display name and room UI sync

### DIFF
--- a/mei-tra-backend/src/auth/auth.service.ts
+++ b/mei-tra-backend/src/auth/auth.service.ts
@@ -14,6 +14,10 @@ interface CachedTokenValidation {
   expiresAt: number;
 }
 
+interface TokenValidationOptions {
+  bypassCache?: boolean;
+}
+
 @Injectable()
 export class AuthService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(AuthService.name);
@@ -39,11 +43,14 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
     clearInterval(this.cleanupInterval);
   }
 
-  async validateToken(token: string): Promise<AuthenticatedUser | null> {
+  async validateToken(
+    token: string,
+    options?: TokenValidationOptions,
+  ): Promise<AuthenticatedUser | null> {
     try {
       // Check cache first
       const cached = this.tokenCache.get(token);
-      if (cached && cached.expiresAt > Date.now()) {
+      if (!options?.bypassCache && cached && cached.expiresAt > Date.now()) {
         this.logger.debug(
           `[AuthService] Using cached token for user: ${cached.user.id}`,
         );
@@ -206,6 +213,7 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
 
   async getUserFromSocketToken(
     token: string,
+    options?: TokenValidationOptions,
   ): Promise<AuthenticatedUser | null> {
     try {
       if (!token) {
@@ -220,7 +228,7 @@ export class AuthService implements OnModuleInit, OnModuleDestroy {
       );
 
       // For WebSocket connections, token might be passed directly
-      const result = await this.validateToken(token);
+      const result = await this.validateToken(token, options);
 
       if (!result) {
         this.logger.warn('[AuthService] Token validation returned null');

--- a/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
@@ -1,0 +1,171 @@
+import { UpdateAuthUseCase } from '../update-auth.use-case';
+import { AuthService } from '../../auth/auth.service';
+import { IRoomService } from '../../services/interfaces/room-service.interface';
+import { IGameStateService } from '../../services/interfaces/game-state-service.interface';
+import { AuthenticatedUser } from '../../types/user.types';
+import { Player } from '../../types/game.types';
+import { Room, RoomStatus } from '../../types/room.types';
+import { GameStateService } from '../../services/game-state.service';
+
+describe('UpdateAuthUseCase', () => {
+  const createAuthServiceMock = () =>
+    ({
+      getUserFromSocketToken: jest.fn(),
+    }) as unknown as jest.Mocked<AuthService>;
+
+  const createRoomServiceMock = () =>
+    ({
+      getRoomGameState: jest.fn(),
+      updatePlayerInRoom: jest.fn(),
+      getRoom: jest.fn(),
+    }) as unknown as jest.Mocked<IRoomService>;
+
+  const authenticatedUser: AuthenticatedUser = {
+    id: 'user-1',
+    email: 'user@example.com',
+    profile: {
+      id: 'profile-1',
+      username: 'user',
+      displayName: 'User Display',
+      avatarUrl: undefined,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      lastSeenAt: new Date(),
+      gamesPlayed: 0,
+      gamesWon: 0,
+      totalScore: 0,
+      preferences: {
+        notifications: true,
+        sound: true,
+        theme: 'light',
+      },
+    },
+  };
+
+  it('updates connected user and room players when display name changes', async () => {
+    const authService = createAuthServiceMock();
+    const users: Player[] = [
+      {
+        id: 'socket-1',
+        playerId: 'player-1',
+        name: 'Old Name',
+        userId: 'user-1',
+        isAuthenticated: true,
+        hand: [],
+        team: 0,
+        isPasser: false,
+      } as Player,
+    ];
+    const gameState = {
+      getUsers: jest.fn(() => users),
+      updateUserName: jest.fn(() => {
+        users[0].name = 'User Display';
+        return true;
+      }),
+    } as unknown as jest.Mocked<IGameStateService>;
+    const roomService = createRoomServiceMock();
+    const roomState = {
+      players: [
+        {
+          id: 'socket-1',
+          playerId: 'player-1',
+          name: 'Old Name',
+          userId: 'user-1',
+          isAuthenticated: true,
+          hand: [],
+          team: 0,
+          isPasser: false,
+        } as Player,
+      ],
+    };
+    const roomGameState = {
+      getState: jest.fn(() => roomState),
+      saveState: jest.fn().mockResolvedValue(undefined),
+    } as unknown as GameStateService;
+    const updatedRoom: Room = {
+      id: 'room-1',
+      name: 'Room',
+      hostId: 'player-1',
+      status: RoomStatus.WAITING,
+      players: [
+        {
+          id: 'socket-1',
+          playerId: 'player-1',
+          name: 'User Display',
+          userId: 'user-1',
+          isAuthenticated: true,
+          hand: [],
+          team: 0,
+          isPasser: false,
+          isReady: false,
+          isHost: true,
+          joinedAt: new Date(),
+        },
+      ],
+      settings: {
+        maxPlayers: 4,
+        isPrivate: false,
+        password: null,
+        teamAssignmentMethod: 'random',
+        pointsToWin: 30,
+        allowSpectators: true,
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      lastActivityAt: new Date(),
+    };
+
+    authService.getUserFromSocketToken = jest
+      .fn()
+      .mockResolvedValue(authenticatedUser);
+    roomService.getRoomGameState = jest
+      .fn()
+      .mockResolvedValue(roomGameState);
+    roomService.updatePlayerInRoom = jest.fn().mockResolvedValue(true);
+    roomService.getRoom = jest.fn().mockResolvedValue(updatedRoom);
+
+    const useCase = new UpdateAuthUseCase(authService, gameState, roomService);
+
+    const result = await useCase.execute({
+      socketId: 'socket-1',
+      token: 'token',
+      currentRoomId: 'room-1',
+    });
+
+    expect(result.success).toBe(true);
+    expect(authService.getUserFromSocketToken).toHaveBeenCalledWith('token', {
+      bypassCache: true,
+    });
+    expect(gameState.updateUserName).toHaveBeenCalledWith(
+      'socket-1',
+      'User Display',
+    );
+    expect(roomService.updatePlayerInRoom).toHaveBeenCalledWith(
+      'room-1',
+      'player-1',
+      expect.objectContaining({
+        name: 'User Display',
+        userId: 'user-1',
+        isAuthenticated: true,
+      }),
+    );
+    expect(roomGameState.saveState).toHaveBeenCalled();
+    expect(result.broadcastEvents).toContainEqual(
+      expect.objectContaining({
+        event: 'update-users',
+      }),
+    );
+    expect(result.roomEvents).toContainEqual(
+      expect.objectContaining({
+        event: 'update-players',
+        payload: roomState.players,
+      }),
+    );
+    expect(result.roomEvents).toContainEqual(
+      expect.objectContaining({
+        event: 'room-updated',
+        payload: updatedRoom,
+      }),
+    );
+  });
+});

--- a/mei-tra-backend/src/use-cases/update-auth.use-case.ts
+++ b/mei-tra-backend/src/use-cases/update-auth.use-case.ts
@@ -28,6 +28,7 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
 
       const authenticatedUser = await this.authService.getUserFromSocketToken(
         request.token,
+        { bypassCache: true },
       );
 
       if (!authenticatedUser) {
@@ -112,6 +113,44 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
       }
     }
 
+    const currentUser =
+      existingUser ??
+      this.gameState.getUsers().find((user) => user.id === socketId);
+
+    if (!currentUser) {
+      return {
+        clientEvents,
+        broadcastEvents: [],
+      };
+    }
+
+    const nameChanged = currentUser.name !== displayName;
+    const authChanged =
+      currentUser.userId !== authenticatedUser.id ||
+      currentUser.isAuthenticated !== true;
+
+    if (nameChanged) {
+      this.gameState.updateUserName(socketId, displayName);
+    }
+
+    if (authChanged) {
+      currentUser.userId = authenticatedUser.id;
+      currentUser.isAuthenticated = true;
+    }
+
+    if (nameChanged || authChanged) {
+      return {
+        clientEvents,
+        broadcastEvents: [
+          {
+            scope: 'all',
+            event: 'update-users',
+            payload: this.gameState.getUsers(),
+          },
+        ],
+      };
+    }
+
     return {
       clientEvents,
       broadcastEvents: [],
@@ -138,13 +177,27 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
       return undefined;
     }
 
-    currentPlayer.name =
+    const displayName =
       authenticatedUser.profile?.displayName ||
       authenticatedUser.email ||
       currentPlayer.name;
+    currentPlayer.name = displayName;
     currentPlayer.userId = authenticatedUser.id;
+    currentPlayer.isAuthenticated = true;
 
-    return [
+    await roomGameState.saveState();
+    await this.roomService.updatePlayerInRoom(
+      currentRoomId,
+      currentPlayer.playerId,
+      {
+        name: displayName,
+        userId: authenticatedUser.id,
+        isAuthenticated: true,
+      },
+    );
+    const updatedRoom = await this.roomService.getRoom(currentRoomId);
+
+    const roomEvents: GatewayEvent[] = [
       {
         scope: 'room',
         roomId: currentRoomId,
@@ -152,5 +205,16 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
         payload: state.players,
       },
     ];
+
+    if (updatedRoom) {
+      roomEvents.push({
+        scope: 'room',
+        roomId: currentRoomId,
+        event: 'room-updated',
+        payload: updatedRoom,
+      });
+    }
+
+    return roomEvents;
   }
 }

--- a/mei-tra-frontend/app/socket.ts
+++ b/mei-tra-frontend/app/socket.ts
@@ -1,6 +1,7 @@
 import { io, Socket } from 'socket.io-client';
 
 let socket: Socket | null = null;
+let latestAuthToken: string | undefined;
 
 function detectSafari(): boolean {
   if (typeof window === 'undefined') return false;
@@ -13,6 +14,8 @@ function detectSafari(): boolean {
 }
 
 export function getSocket(authToken?: string): Socket {
+  latestAuthToken = authToken ?? latestAuthToken;
+
   if (!socket && typeof window !== 'undefined') {
     const socketUrl = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3333';
 
@@ -27,7 +30,7 @@ export function getSocket(authToken?: string): Socket {
       auth: (cb: (data: { roomId: string; token?: string }) => void) => {
         const currentRoomId = sessionStorage.getItem('roomId') || '';
         console.log('[Socket] Auth callback — roomId from sessionStorage:', currentRoomId || 'none');
-        cb({ roomId: currentRoomId, token: authToken });
+        cb({ roomId: currentRoomId, token: latestAuthToken });
       },
       autoConnect: false,
       reconnection: true,
@@ -71,12 +74,27 @@ export function getSocket(authToken?: string): Socket {
   return socket!;
 }
 
-export function reconnectSocket(authToken?: string): void {
+export function getExistingSocket(): Socket | null {
+  return socket;
+}
+
+export function reconnectSocket(authToken?: string): Socket {
+  latestAuthToken = authToken ?? latestAuthToken;
+
   if (socket) {
+    socket.auth = (cb: (data: { roomId: string; token?: string }) => void) => {
+      const currentRoomId = sessionStorage.getItem('roomId') || '';
+      console.log('[Socket] Reconnect auth callback — roomId from sessionStorage:', currentRoomId || 'none');
+      cb({ roomId: currentRoomId, token: latestAuthToken });
+    };
     socket.disconnect();
-    socket = null;
+    socket.connect();
+    return socket;
   }
-  getSocket(authToken);
+
+  const nextSocket = getSocket(authToken);
+  nextSocket.connect();
+  return nextSocket;
 }
 
 export function disconnectSocket(): void {
@@ -84,4 +102,5 @@ export function disconnectSocket(): void {
     socket.disconnect();
     socket = null;
   }
+  latestAuthToken = undefined;
 }

--- a/mei-tra-frontend/components/PlayerAvatar/index.tsx
+++ b/mei-tra-frontend/components/PlayerAvatar/index.tsx
@@ -75,7 +75,6 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
       {showName && (
         <PlayerIdentityChip
           name={displayName}
-          team={player.team}
           className={styles.playerName}
         />
       )}

--- a/mei-tra-frontend/components/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/PlayerHand/index.module.scss
@@ -136,8 +136,20 @@
 
 .currentTurn{
   border: 2px solid #FFD700 !important;
+  background:
+    linear-gradient(180deg, rgba(9, 45, 32, 0.94) 0%, rgba(5, 24, 17, 0.98) 100%) !important;
   box-shadow: 0 0 8px rgba(255, 215, 0, 0.6) !important;
   transition: all 0.3s ease;
+}
+
+.currentTurn .playerName {
+  color: #ffffff;
+}
+
+.currentTurn .cardCount {
+  color: rgba(255, 255, 255, 0.86);
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
 .playerName{
@@ -272,8 +284,21 @@
   }
 
   .currentTurn {
-    border-color: #60a5fa !important;
-    box-shadow: 0 0 10px rgba(96, 165, 250, 0.45) !important;
+    border-color: #FFD700 !important;
+    border-width: 2px !important;
+    background:
+      linear-gradient(180deg, rgba(10, 43, 31, 0.94) 0%, rgba(6, 27, 19, 0.98) 100%) !important;
+    box-shadow: 0 0 8px rgba(255, 215, 0, 0.6) !important;
+  }
+
+  .currentTurn .playerName {
+    color: #ffffff;
+  }
+
+  .currentTurn .cardCount {
+    color: rgba(255, 255, 255, 0.86);
+    background: rgba(15, 23, 42, 0.58);
+    border: 1px solid rgba(255, 255, 255, 0.12);
   }
 
   .playerName {

--- a/mei-tra-frontend/components/PlayerIdentityChip/index.module.scss
+++ b/mei-tra-frontend/components/PlayerIdentityChip/index.module.scss
@@ -1,7 +1,6 @@
 .chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
   max-width: 100%;
   box-sizing: border-box;
   padding: 0.2rem 0.6rem;
@@ -19,21 +18,6 @@
 .compact {
   min-height: 24px;
   padding: 0.15rem 0.5rem;
-}
-
-.teamDot {
-  flex-shrink: 0;
-  width: 0.55rem;
-  height: 0.55rem;
-  border-radius: 999px;
-}
-
-.team0 {
-  background: #38bdf8;
-}
-
-.team1 {
-  background: #f59e0b;
 }
 
 .label {

--- a/mei-tra-frontend/components/PlayerIdentityChip/index.tsx
+++ b/mei-tra-frontend/components/PlayerIdentityChip/index.tsx
@@ -1,25 +1,19 @@
 import React from 'react';
-import { Team } from '../../types/game.types';
 import styles from './index.module.scss';
 
 interface PlayerIdentityChipProps {
   name: string;
-  team: Team;
   size?: 'default' | 'compact';
   className?: string;
 }
 
 export const PlayerIdentityChip: React.FC<PlayerIdentityChipProps> = ({
   name,
-  team,
   size = 'default',
   className = '',
 }) => {
   return (
     <div className={`${styles.chip} ${styles[size]} ${className}`}>
-      <span
-        className={`${styles.teamDot} ${styles[`team${team}` as keyof typeof styles]}`}
-      />
       <span className={styles.label}>{name}</span>
     </div>
   );

--- a/mei-tra-frontend/components/profile/ProfileEditForm.tsx
+++ b/mei-tra-frontend/components/profile/ProfileEditForm.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useCallback } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { UserProfile, UserPreferences } from '@/types/user.types';
 import { supabase } from '@/lib/supabase';
+import { getExistingSocket } from '@/app/socket';
 import { useTranslations } from 'next-intl';
 import {
   optimizeImage,
@@ -40,7 +41,7 @@ interface DatabaseUserProfileResponse {
 }
 
 export function ProfileEditForm({ profile, onSave, onCancel }: ProfileEditFormProps) {
-  const { user, refreshUserProfile } = useAuth();
+  const { user, refreshUserProfile, getAccessToken } = useAuth();
   const t = useTranslations('profile');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -224,6 +225,13 @@ export function ProfileEditForm({ profile, onSave, onCancel }: ProfileEditFormPr
 
       // Refresh user profile in AuthContext to update avatar in header
       await refreshUserProfile();
+
+      const socket = getExistingSocket();
+      const token = await getAccessToken();
+
+      if (socket?.connected && token) {
+        socket.emit('update-auth', { token });
+      }
     } catch (error) {
       setError(error instanceof Error ? error.message : t('saveFailed'));
     } finally {

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -5,6 +5,7 @@ import { useAuth } from './useAuth';
 import { BlowAction, BlowDeclaration, BlowState, CompletedField, Field, FieldCompleteEvent, GamePhase, Player, TeamScore, TeamScores, TrumpType, User } from '../types/game.types';
 import { Room } from '../types/room.types';
 import { getTeamDisplayName } from '../lib/utils/teamUtils';
+import { reconnectSocket } from '../app/socket';
 
 const dedupeCompletedFields = (fields: CompletedField[]): CompletedField[] => {
   const seen = new Set<string>();
@@ -23,8 +24,9 @@ export const useGame = () => {
   const tStatus = useTranslations('playerStatus');
   const t = useTranslations('game');
   const { socket, isConnected, isConnecting } = useSocket();
-  const { user } = useAuth();
+  const { user, getAccessToken } = useAuth();
   const gameOverShownRef = useRef<string | null>(null);
+  const roomBootstrapRef = useRef<string | null>(null);
 
   // Player and Game State
   const [name, setName] = useState('');
@@ -82,6 +84,7 @@ export const useGame = () => {
 
   const resetRoomState = useCallback(() => {
     gameOverShownRef.current = null;
+    roomBootstrapRef.current = null;
     setGameStarted(false);
     setGamePhase(null);
     setCurrentRoomId(null);
@@ -127,6 +130,44 @@ export const useGame = () => {
 
     setIsHost(currentHostId === currentPlayerId);
   }, [currentHostId, currentPlayerId]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !user || !socket?.connected || currentRoomId) {
+      return;
+    }
+
+    const storedRoomId = sessionStorage.getItem('roomId');
+    if (!storedRoomId || roomBootstrapRef.current === storedRoomId) {
+      return;
+    }
+
+    roomBootstrapRef.current = storedRoomId;
+
+    let cancelled = false;
+
+    void (async () => {
+      const token = await getAccessToken();
+      if (cancelled || !token) {
+        if (!token) {
+          roomBootstrapRef.current = null;
+        }
+        return;
+      }
+
+      console.log('[useGame] Bootstrapping room state from stored roomId:', storedRoomId);
+      reconnectSocket(token);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentRoomId, getAccessToken, socket, user]);
+
+  useEffect(() => {
+    if (currentRoomId) {
+      roomBootstrapRef.current = null;
+    }
+  }, [currentRoomId]);
 
   useEffect(() => {
     setIsClient(true);


### PR DESCRIPTION
## Summary
- sync updated profile display names into connected game and waiting-room state
- recover room state after creating a room from `/rooms` and refine player identity visuals
- improve current-turn highlighting across themes

## Validation
- `cd mei-tra-backend && npm test -- update-auth.use-case.spec.ts`
- `cd mei-tra-backend && npm run build`
- `cd mei-tra-frontend && npm run lint`
- `cd mei-tra-frontend && npm run build`