### PR TITLE
[codex] clarify socket id identity model

### DIFF
--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -14,7 +14,7 @@ import { IBlowService } from './services/interfaces/blow-service.interface';
 import { IPlayService } from './services/interfaces/play-service.interface';
 import { IRoomService } from './services/interfaces/room-service.interface';
 import { IChomboService } from './services/interfaces/chombo-service.interface';
-import { Player, TrumpType, User } from './types/game.types';
+import { ConnectionUser, Player, TrumpType } from './types/game.types';
 import { RoomStatus } from './types/room.types';
 import { ConnectedSocket, MessageBody } from '@nestjs/websockets';
 import { AuthService } from './auth/auth.service';
@@ -224,8 +224,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const targetPlayer = room?.players.find(
       (player) => player.playerId === playerId,
     );
-    const targetSocket = targetPlayer?.id
-      ? this.server.sockets.sockets.get(targetPlayer.id)
+    const targetSocket = targetPlayer?.socketId
+      ? this.server.sockets.sockets.get(targetPlayer.socketId)
       : undefined;
 
     if (targetSocket) {
@@ -281,14 +281,17 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     if (
       !currentPlayer ||
       currentPlayer.isCOM ||
-      !currentPlayer.id ||
+      !currentPlayer.socketId ||
       (state.gamePhase !== 'play' && state.gamePhase !== 'blow')
     ) {
       return;
     }
 
     const emitPing = () => {
-      this.server.to(currentPlayer.id).emit('turn-ping', { roomId, playerId });
+      this.server.to(currentPlayer.socketId).emit('turn-ping', {
+        roomId,
+        playerId,
+      });
     };
 
     const monitor: TurnAckMonitor = {
@@ -756,7 +759,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
           .getUsers()
           .find((u) => u.userId === authenticatedUser.id);
         if (existingUser) {
-          existingUser.id = client.id;
+          existingUser.socketId = client.id;
         } else {
           this.gameState.addPlayer(
             client.id,
@@ -838,7 +841,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         await roomGameState.saveState();
       }
 
-      const player = players.find((p) => p.id === client.id);
+      const player = players.find((p) => p.socketId === client.id);
       const authenticatedUser = (client.data as { user?: AuthenticatedUser })
         .user;
 
@@ -855,7 +858,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         state.teamAssignments[player.playerId] = player.team;
 
         // ソケットIDをクリア（切断状態を示す）
-        player.id = '';
+        player.socketId = '';
 
         const room = await this.roomService.getRoom(roomId);
         if (room?.hostId === player.playerId) {
@@ -995,8 +998,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       }
 
       const { room } = result.data;
-      const hostUser: User = {
-        id: client.id,
+      const hostUser: ConnectionUser = {
+        socketId: client.id,
         playerId: authenticatedUser.id,
         name: playerName || authenticatedUser.email || 'User',
         userId: authenticatedUser.id,
@@ -1076,7 +1079,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @SubscribeMessage('join-room')
   async handleJoinRoom(
     @ConnectedSocket() client: Socket,
-    @MessageBody() data: { roomId: string; user: User },
+    @MessageBody() data: { roomId: string; user: ConnectionUser },
   ) {
     this.activityTracker.recordActivity();
 
@@ -1362,12 +1365,12 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
           };
         }
 
-        const targetSocket = targetPlayer.id
-          ? this.server.sockets.sockets.get(targetPlayer.id)
+        const targetSocket = targetPlayer.socketId
+          ? this.server.sockets.sockets.get(targetPlayer.socketId)
           : undefined;
         if (targetSocket) {
           await targetSocket.leave(data.roomId);
-          this.playerRooms.delete(targetPlayer.id);
+          this.playerRooms.delete(targetPlayer.socketId);
           targetSocket.emit(
             'error-message',
             'You were removed from the room by the host',
@@ -1422,7 +1425,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       const canReplaceDisconnected = Boolean(
         room.status === RoomStatus.PLAYING &&
           targetStatePlayer &&
-          !targetStatePlayer.id,
+          !targetStatePlayer.socketId,
       );
       const canReplaceIdle = Boolean(
         room.status === RoomStatus.PLAYING &&
@@ -1487,7 +1490,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const userId = (client.data as { user?: AuthenticatedUser }).user?.id;
     const matchesCurrentTurnPlayer =
       currentPlayer &&
-      (currentPlayer.id === client.id ||
+      (currentPlayer.socketId === client.id ||
         (Boolean(userId) && currentPlayer.userId === userId));
 
     if (!matchesCurrentTurnPlayer) {

--- a/mei-tra-backend/src/repositories/implementations/supabase-room.repository.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-room.repository.ts
@@ -296,7 +296,7 @@ export class SupabaseRoomRepository implements IRoomRepository {
       const { error } = await this.supabase.from('room_players').insert({
         room_id: roomId,
         player_id: player.playerId,
-        socket_id: player.id,
+        socket_id: player.socketId,
         user_id: player.userId ?? null,
         name: player.name,
         hand: player.hand,
@@ -352,7 +352,9 @@ export class SupabaseRoomRepository implements IRoomRepository {
     try {
       const updateData: Partial<RoomPlayerUpdate> = {};
 
-      if (updates.id) updateData.socket_id = updates.id;
+      if (updates.socketId !== undefined) {
+        updateData.socket_id = updates.socketId;
+      }
       if (updates.userId !== undefined) updateData.user_id = updates.userId;
       if (updates.name) updateData.name = updates.name;
       if (updates.hand) updateData.hand = updates.hand;
@@ -445,7 +447,7 @@ export class SupabaseRoomRepository implements IRoomRepository {
     const playerInserts = players.map((player) => ({
       room_id: roomId,
       player_id: player.playerId,
-      socket_id: player.id,
+      socket_id: player.socketId,
       user_id: player.userId ?? null,
       name: player.name,
       hand: player.hand,
@@ -484,7 +486,7 @@ export class SupabaseRoomRepository implements IRoomRepository {
 
   private mapDatabaseToPlayers(dbPlayers: RoomPlayerRow[]): RoomPlayer[] {
     return dbPlayers.map((dbPlayer) => ({
-      id: dbPlayer.socket_id || '',
+      socketId: dbPlayer.socket_id || '',
       playerId: dbPlayer.player_id,
       userId: dbPlayer.user_id ?? undefined,
       name: dbPlayer.name,

--- a/mei-tra-backend/src/services/com-player.service.ts
+++ b/mei-tra-backend/src/services/com-player.service.ts
@@ -12,7 +12,7 @@ export class ComPlayerService implements IComPlayerService {
 
   createComPlayer(seatIndex: number, team: Team): Player {
     return {
-      id: `com-${seatIndex}`,
+      socketId: `com-${seatIndex}`,
       playerId: `com-${seatIndex}`,
       name: `COM ${seatIndex + 1}`,
       hand: [],

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -9,7 +9,7 @@ import {
   CompletedField,
   TeamScore,
   ScoreRecord,
-  User,
+  ConnectionUser,
 } from '../types/game.types';
 import { CardService } from './card.service';
 import { ChomboService } from './chombo.service';
@@ -19,7 +19,7 @@ import { IGameStateService } from './interfaces/game-state-service.interface';
 @Injectable()
 export class GameStateService implements IGameStateService {
   private readonly logger = new Logger(GameStateService.name);
-  private users: User[] = [];
+  private users: ConnectionUser[] = [];
   private state: GameState;
   private playerIds: Map<string, string> = new Map(); // token -> playerId
   private disconnectedPlayers: Map<string, NodeJS.Timeout> = new Map(); // 切断されたプレイヤーのタイマーを管理
@@ -102,9 +102,15 @@ export class GameStateService implements IGameStateService {
         continue;
       }
 
+      const legacySocketId = (rawPlayer as Player & { id?: string }).id;
       const normalizedPlayer: Player = {
         ...rawPlayer,
-        id: typeof rawPlayer.id === 'string' ? rawPlayer.id : '',
+        socketId:
+          typeof rawPlayer.socketId === 'string'
+            ? rawPlayer.socketId
+            : typeof legacySocketId === 'string'
+              ? legacySocketId
+              : '',
         hand: Array.isArray(rawPlayer.hand) ? rawPlayer.hand : [],
         isPasser: rawPlayer.isPasser ?? false,
         hasBroken: rawPlayer.hasBroken ?? false,
@@ -112,7 +118,7 @@ export class GameStateService implements IGameStateService {
       };
 
       if (
-        normalizedPlayer.id !== rawPlayer.id ||
+        normalizedPlayer.socketId !== rawPlayer.socketId ||
         normalizedPlayer.hand !== rawPlayer.hand ||
         normalizedPlayer.isPasser !== rawPlayer.isPasser ||
         normalizedPlayer.hasBroken !== rawPlayer.hasBroken ||
@@ -156,8 +162,16 @@ export class GameStateService implements IGameStateService {
     return this.state;
   }
 
-  getUsers(): User[] {
+  getUsers(): ConnectionUser[] {
     return this.users;
+  }
+
+  findConnectionUserBySocketId(socketId: string): ConnectionUser | null {
+    return this.users.find((user) => user.socketId === socketId) || null;
+  }
+
+  findConnectionUserByUserId(userId: string): ConnectionUser | null {
+    return this.users.find((user) => user.userId === userId) || null;
   }
 
   async updateState(newState: Partial<GameState>): Promise<void> {
@@ -249,7 +263,7 @@ export class GameStateService implements IGameStateService {
     const playerId = userId || this.generateReconnectToken();
     const users = this.getUsers();
     users.push({
-      id: socketId,
+      socketId,
       playerId,
       name,
       userId,
@@ -264,8 +278,8 @@ export class GameStateService implements IGameStateService {
     return true;
   }
 
-  updateUserName(socketId: string, name: string): boolean {
-    const user = this.users.find((u) => u.id === socketId);
+  updateUserNameBySocketId(socketId: string, name: string): boolean {
+    const user = this.findConnectionUserBySocketId(socketId);
     if (!user) {
       return false;
     }
@@ -293,7 +307,7 @@ export class GameStateService implements IGameStateService {
     ); // 15秒待ってから削除
 
     // ソケットIDだけ即時クリア（切断状態を示す）
-    player.id = '';
+    player.socketId = '';
   }
 
   // プレイヤーの再接続トークンを登録
@@ -333,7 +347,7 @@ export class GameStateService implements IGameStateService {
 
   async updatePlayerSocketId(
     playerId: string,
-    newId: string,
+    socketId: string,
     userId?: string,
   ): Promise<void> {
     // Find the player by playerId, not by socket id
@@ -348,7 +362,7 @@ export class GameStateService implements IGameStateService {
       }
 
       // Update the socket ID
-      player.id = newId;
+      player.socketId = socketId;
 
       // Update userId if provided (for authenticated users)
       if (userId) {
@@ -367,7 +381,9 @@ export class GameStateService implements IGameStateService {
       // Persist the player update
       if (this.roomId) {
         try {
-          const updates: { id: string; userId?: string } = { id: newId };
+          const updates: { socketId: string; userId?: string } = {
+            socketId,
+          };
           if (userId) {
             updates.userId = userId;
           }

--- a/mei-tra-backend/src/services/interfaces/game-state-service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/game-state-service.interface.ts
@@ -1,4 +1,4 @@
-import { Player, User } from '../../types/game.types';
+import { ConnectionUser, Player } from '../../types/game.types';
 
 export interface IGameStateService {
   addPlayer(
@@ -7,13 +7,15 @@ export interface IGameStateService {
     userId?: string,
     isAuthenticated?: boolean,
   ): boolean;
-  getUsers(): User[];
-  updateUserName(socketId: string, name: string): boolean;
+  getUsers(): ConnectionUser[];
+  findConnectionUserBySocketId(socketId: string): ConnectionUser | null;
+  findConnectionUserByUserId(userId: string): ConnectionUser | null;
+  updateUserNameBySocketId(socketId: string, name: string): boolean;
   findPlayerByUserId(userId: string): Player | null;
   findPlayerByReconnectToken(token: string): Player | null;
   updatePlayerSocketId(
     playerId: string,
-    newId: string,
+    socketId: string,
     userId?: string,
   ): Promise<void>;
 }

--- a/mei-tra-backend/src/services/interfaces/room-service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/room-service.interface.ts
@@ -1,5 +1,5 @@
 import { Room, RoomPlayer, RoomStatus } from '../../types/room.types';
-import { User } from '../../types/game.types';
+import { ConnectionUser } from '../../types/game.types';
 import { GameStateService } from '../game-state.service';
 
 export interface IRoomService {
@@ -15,7 +15,7 @@ export interface IRoomService {
     teamAssignmentMethod: 'random' | 'host-choice',
   ): Promise<Room>;
   leaveRoom(roomId: string, playerId: string): Promise<boolean>;
-  joinRoom(roomId: string, user: User): Promise<boolean>;
+  joinRoom(roomId: string, user: ConnectionUser): Promise<boolean>;
   updateRoomStatus(roomId: string, status: RoomStatus): Promise<boolean>;
   updatePlayerInRoom(
     roomId: string,

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -3,7 +3,7 @@ import { Room, RoomPlayer } from '../types/room.types';
 import { RoomStatus } from '../types/room.types';
 import { GameStateService } from './game-state.service';
 import { GameStateFactory } from './game-state.factory';
-import { GameState, User, Team, Player } from '../types/game.types';
+import { GameState, ConnectionUser, Team, Player } from '../types/game.types';
 import { IRoomRepository } from '../repositories/interfaces/room.repository.interface';
 import { IUserProfileRepository } from '../repositories/interfaces/user-profile.repository.interface';
 import { IRoomService } from './interfaces/room-service.interface';
@@ -172,7 +172,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
   ): RoomPlayer {
     const idStr = String(index);
     return {
-      id: `com-${idStr}`,
+      socketId: `com-${idStr}`,
       playerId: `com-${idStr}`,
       name: 'COM',
       isCOM: true,
@@ -238,7 +238,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
   private cloneRoomPlayer(player: RoomPlayer): RoomPlayer {
     return {
       ...player,
-      id: '',
+      socketId: '',
       hand: [...player.hand],
       joinedAt: new Date(player.joinedAt),
     };
@@ -247,7 +247,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
   private cloneGamePlayer(player: Player): Player {
     return {
       ...player,
-      id: '',
+      socketId: '',
       hand: [...player.hand],
     };
   }
@@ -614,7 +614,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     return true;
   }
 
-  async joinRoom(roomId: string, user: User): Promise<boolean> {
+  async joinRoom(roomId: string, user: ConnectionUser): Promise<boolean> {
     const room = await this.getRoom(roomId);
     if (!room) {
       return false;
@@ -764,7 +764,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     const player: RoomPlayer = {
       ...(seatRoomSnapshot ?? {}),
       ...user,
-      id: user.id,
+      socketId: user.socketId,
       playerId: user.playerId,
       team: currentSeatRoomPlayer?.team ?? team,
       hand: [...(currentSeatRoomHand ?? hand)],
@@ -924,7 +924,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     const comPlayerId = currentSeatPlayer.playerId;
     const restoredRoomPlayer: RoomPlayer = {
       ...seatData.roomPlayer,
-      id: '',
+      socketId: '',
       playerId,
       hand: [
         ...(currentSeatPlayer.hand.length
@@ -958,7 +958,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     const restoredGamePlayerBase: Player = seatData.gamePlayer
       ? {
           ...seatData.gamePlayer,
-          id: '',
+          socketId: '',
           playerId,
           hand: [
             ...(state.players[gsIndex]?.hand.length
@@ -967,7 +967,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
           ],
         }
       : {
-          id: '',
+          socketId: '',
           playerId,
           name: restoredRoomPlayer.name,
           team: restoredRoomPlayer.team,
@@ -980,7 +980,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     if (gsIndex !== -1) {
       state.players[gsIndex] = {
         ...restoredGamePlayerBase,
-        id: '',
+        socketId: '',
         playerId,
         name: restoredRoomPlayer.name,
         team: restoredRoomPlayer.team,
@@ -1001,7 +1001,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     } else {
       state.players.push({
         ...restoredGamePlayerBase,
-        id: '',
+        socketId: '',
       });
     }
 
@@ -1144,7 +1144,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     void roomGameState.updatePlayerSocketId(playerId, socketId, userId);
 
     // Update player's socket ID and userId in database directly
-    const updates: { id: string; userId?: string } = { id: socketId };
+    const updates: { socketId: string; userId?: string } = { socketId };
     if (userId) {
       updates.userId = userId;
     }

--- a/mei-tra-backend/src/types/game.types.ts
+++ b/mei-tra-backend/src/types/game.types.ts
@@ -1,14 +1,14 @@
 export type Team = 0 | 1;
 
-export interface User {
-  id: string; // Socket ID
-  playerId: string; // Legacy player identifier
+export interface ConnectionUser {
+  socketId: string; // Connection/session identifier only
+  playerId: string; // Table participant identifier (future participantId equivalent)
   name: string;
-  userId?: string; // Supabase auth user ID (optional for backward compatibility)
-  isAuthenticated?: boolean; // Whether user is authenticated with Supabase
+  userId?: string; // Canonical authenticated account ID
+  isAuthenticated?: boolean;
 }
 
-export interface Player extends User {
+export interface Player extends ConnectionUser {
   hand: string[];
   team: Team;
   isPasser: boolean;

--- a/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
@@ -3,7 +3,7 @@ import { AuthService } from '../../auth/auth.service';
 import { IRoomService } from '../../services/interfaces/room-service.interface';
 import { IGameStateService } from '../../services/interfaces/game-state-service.interface';
 import { AuthenticatedUser } from '../../types/user.types';
-import { Player } from '../../types/game.types';
+import { ConnectionUser, Player } from '../../types/game.types';
 import { Room, RoomStatus } from '../../types/room.types';
 import { GameStateService } from '../../services/game-state.service';
 
@@ -44,21 +44,26 @@ describe('UpdateAuthUseCase', () => {
 
   it('updates connected user and room players when display name changes', async () => {
     const authService = createAuthServiceMock();
-    const users: Player[] = [
+    const users: ConnectionUser[] = [
       {
-        id: 'socket-1',
+        socketId: 'socket-1',
         playerId: 'player-1',
         name: 'Old Name',
         userId: 'user-1',
         isAuthenticated: true,
-        hand: [],
-        team: 0,
-        isPasser: false,
-      } as Player,
+      },
     ];
     const gameState = {
       getUsers: jest.fn(() => users),
-      updateUserName: jest.fn(() => {
+      findConnectionUserByUserId: jest.fn(
+        (userId: string) =>
+          users.find((user) => user.userId === userId) ?? null,
+      ),
+      findConnectionUserBySocketId: jest.fn(
+        (socketId: string) =>
+          users.find((user) => user.socketId === socketId) ?? null,
+      ),
+      updateUserNameBySocketId: jest.fn(() => {
         users[0].name = 'User Display';
         return true;
       }),
@@ -67,7 +72,7 @@ describe('UpdateAuthUseCase', () => {
     const roomState = {
       players: [
         {
-          id: 'socket-1',
+          socketId: 'socket-1',
           playerId: 'player-1',
           name: 'Old Name',
           userId: 'user-1',
@@ -89,7 +94,7 @@ describe('UpdateAuthUseCase', () => {
       status: RoomStatus.WAITING,
       players: [
         {
-          id: 'socket-1',
+          socketId: 'socket-1',
           playerId: 'player-1',
           name: 'User Display',
           userId: 'user-1',
@@ -118,9 +123,7 @@ describe('UpdateAuthUseCase', () => {
     authService.getUserFromSocketToken = jest
       .fn()
       .mockResolvedValue(authenticatedUser);
-    roomService.getRoomGameState = jest
-      .fn()
-      .mockResolvedValue(roomGameState);
+    roomService.getRoomGameState = jest.fn().mockResolvedValue(roomGameState);
     roomService.updatePlayerInRoom = jest.fn().mockResolvedValue(true);
     roomService.getRoom = jest.fn().mockResolvedValue(updatedRoom);
 
@@ -136,7 +139,7 @@ describe('UpdateAuthUseCase', () => {
     expect(authService.getUserFromSocketToken).toHaveBeenCalledWith('token', {
       bypassCache: true,
     });
-    expect(gameState.updateUserName).toHaveBeenCalledWith(
+    expect(gameState.updateUserNameBySocketId).toHaveBeenCalledWith(
       'socket-1',
       'User Display',
     );
@@ -144,6 +147,7 @@ describe('UpdateAuthUseCase', () => {
       'room-1',
       'player-1',
       expect.objectContaining({
+        socketId: 'socket-1',
         name: 'User Display',
         userId: 'user-1',
         isAuthenticated: true,

--- a/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
+++ b/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
@@ -70,7 +70,7 @@ export async function transitionToPlayPhase({
   const delayedEvents: GatewayEvent[] = [
     {
       scope: 'socket',
-      socketId: winningPlayer.id,
+      socketId: winningPlayer.socketId,
       event: 'reveal-agari',
       payload: {
         agari: state.agari,

--- a/mei-tra-backend/src/use-cases/interfaces/join-room.use-case.interface.ts
+++ b/mei-tra-backend/src/use-cases/interfaces/join-room.use-case.interface.ts
@@ -1,6 +1,6 @@
 import { AuthenticatedUser } from '../../types/user.types';
 import {
-  User,
+  ConnectionUser,
   Player,
   TeamScores,
   Field,
@@ -16,7 +16,7 @@ export interface JoinRoomRequest {
   socketId: string;
   targetRoomId: string;
   currentRoomId?: string;
-  user: User;
+  user: ConnectionUser;
   authenticatedUser?: Nullable<AuthenticatedUser>;
 }
 
@@ -52,7 +52,7 @@ export interface JoinRoomSuccess {
 export interface JoinRoomResponse {
   success: boolean;
   errorMessage?: string;
-  normalizedUser?: User;
+  normalizedUser?: ConnectionUser;
   previousRoomNotification?: PreviousRoomNotification;
   data?: JoinRoomSuccess;
 }

--- a/mei-tra-backend/src/use-cases/join-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/join-room.use-case.ts
@@ -7,7 +7,7 @@ import {
   JoinRoomSuccess,
   ResumeGamePayload,
 } from './interfaces/join-room.use-case.interface';
-import { User } from '../types/game.types';
+import { ConnectionUser } from '../types/game.types';
 import { AuthenticatedUser } from '../types/user.types';
 import { RoomStatus } from '../types/room.types';
 
@@ -90,9 +90,9 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
   }
 
   private normalizeUser(
-    user: User,
+    user: ConnectionUser,
     authenticatedUser?: AuthenticatedUser | null,
-  ): User {
+  ): ConnectionUser {
     if (!authenticatedUser) {
       return { ...user };
     }

--- a/mei-tra-backend/src/use-cases/update-auth.use-case.ts
+++ b/mei-tra-backend/src/use-cases/update-auth.use-case.ts
@@ -87,8 +87,9 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
       },
     ];
 
-    const users = this.gameState.getUsers();
-    const existingUser = users.find((user) => user.id === socketId);
+    const existingUser =
+      this.gameState.findConnectionUserByUserId(authenticatedUser.id) ??
+      this.gameState.findConnectionUserBySocketId(socketId);
 
     if (!existingUser) {
       const added = this.gameState.addPlayer(
@@ -113,32 +114,33 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
       }
     }
 
-    const currentUser =
-      existingUser ??
-      this.gameState.getUsers().find((user) => user.id === socketId);
-
-    if (!currentUser) {
+    if (!existingUser) {
       return {
         clientEvents,
         broadcastEvents: [],
       };
     }
 
-    const nameChanged = currentUser.name !== displayName;
+    const socketChanged = existingUser.socketId !== socketId;
+    if (socketChanged) {
+      existingUser.socketId = socketId;
+    }
+
+    const nameChanged = existingUser.name !== displayName;
     const authChanged =
-      currentUser.userId !== authenticatedUser.id ||
-      currentUser.isAuthenticated !== true;
+      existingUser.userId !== authenticatedUser.id ||
+      existingUser.isAuthenticated !== true;
 
     if (nameChanged) {
-      this.gameState.updateUserName(socketId, displayName);
+      this.gameState.updateUserNameBySocketId(socketId, displayName);
     }
 
     if (authChanged) {
-      currentUser.userId = authenticatedUser.id;
-      currentUser.isAuthenticated = true;
+      existingUser.userId = authenticatedUser.id;
+      existingUser.isAuthenticated = true;
     }
 
-    if (nameChanged || authChanged) {
+    if (socketChanged || nameChanged || authChanged) {
       return {
         clientEvents,
         broadcastEvents: [
@@ -169,9 +171,9 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
     const roomGameState =
       await this.roomService.getRoomGameState(currentRoomId);
     const state = roomGameState.getState();
-    const currentPlayer = state.players.find(
-      (player) => player.id === socketId,
-    );
+    const currentPlayer =
+      state.players.find((player) => player.userId === authenticatedUser.id) ??
+      state.players.find((player) => player.socketId === socketId);
 
     if (!currentPlayer) {
       return undefined;
@@ -181,6 +183,7 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
       authenticatedUser.profile?.displayName ||
       authenticatedUser.email ||
       currentPlayer.name;
+    currentPlayer.socketId = socketId;
     currentPlayer.name = displayName;
     currentPlayer.userId = authenticatedUser.id;
     currentPlayer.isAuthenticated = true;
@@ -190,6 +193,7 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
       currentRoomId,
       currentPlayer.playerId,
       {
+        socketId,
         name: displayName,
         userId: authenticatedUser.id,
         isAuthenticated: true,

--- a/mei-tra-frontend/components/GameTable/index.tsx
+++ b/mei-tra-frontend/components/GameTable/index.tsx
@@ -88,7 +88,7 @@ export const GameTable: React.FC<GameTableProps> = ({
 
   // During waiting, fill undefined slots with COM placeholders
   const createCOMSlot = (idx: number): Player => ({
-    id: `com-${idx}`,
+    socketId: `com-${idx}`,
     playerId: `com-${idx}`,
     name: 'COM',
     team: (idx % 2) as Player['team'],

--- a/mei-tra-frontend/components/PlayerHand/index.tsx
+++ b/mei-tra-frontend/components/PlayerHand/index.tsx
@@ -64,7 +64,7 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
   );
   const isCurrentPlayer = currentPlayerId === player.playerId;
   const isWinningPlayer = currentHighestDeclaration?.playerId === player.playerId;
-  const isDisconnected = !player.isCOM && !player.id;
+  const isDisconnected = !player.isCOM && !player.socketId;
 
   useEffect(() => {
     if (gamePhase !== 'blow' || !isCurrentPlayer || !player.hasRequiredBroken) {

--- a/mei-tra-frontend/components/PreGameTable/index.tsx
+++ b/mei-tra-frontend/components/PreGameTable/index.tsx
@@ -21,7 +21,7 @@ const positions = ['bottom', 'left', 'top', 'right'] as const;
 
 function createEmptySlot(index: number): Player {
   return {
-    id: `empty-${index}`,
+    socketId: `empty-${index}`,
     playerId: `empty-${index}`,
     name: 'COM',
     team: 0,

--- a/mei-tra-frontend/components/molecules/RoomList/index.tsx
+++ b/mei-tra-frontend/components/molecules/RoomList/index.tsx
@@ -4,7 +4,7 @@ import { useRoom } from '../../../hooks/useRoom';
 import { useBackendStatus } from '../../../hooks/useBackendStatus';
 import { useAuth } from '../../../hooks/useAuth';
 import { RoomStatus } from '../../../types/room.types';
-import { User } from '../../../types/game.types';
+import { ConnectionUser } from '../../../types/game.types';
 import styles from './index.module.scss';
 
 const getStatusText = (status: RoomStatus, t: (key: string) => string) => {
@@ -36,7 +36,7 @@ const getStatusClass = (status: RoomStatus) => {
 interface RoomListProps {
   isConnected?: boolean;
   isConnecting?: boolean;
-  users?: User[];
+  users?: ConnectionUser[];
   currentPlayerId?: string | null;
   onRoomEntered?: (roomId: string) => void;
 }

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSocket } from './useSocket';
 import { useAuth } from './useAuth';
-import { BlowAction, BlowDeclaration, BlowState, CompletedField, Field, FieldCompleteEvent, GamePhase, Player, TeamScore, TeamScores, TrumpType, User } from '../types/game.types';
+import { BlowAction, BlowDeclaration, BlowState, CompletedField, ConnectionUser, Field, FieldCompleteEvent, GamePhase, Player, TeamScore, TeamScores, TrumpType } from '../types/game.types';
 import { Room } from '../types/room.types';
 import { getTeamDisplayName } from '../lib/utils/teamUtils';
 import { reconnectSocket } from '../app/socket';
@@ -76,9 +76,9 @@ export const useGame = () => {
   const [pointsToWin, setPointsToWin] = useState<number>(0);
   const [idlePlayerIds, setIdlePlayerIds] = useState<string[]>([]);
 
-  const [users, setUsers] = useState<User[]>([]);
+  const [users, setUsers] = useState<ConnectionUser[]>([]);
   // Keep a ref to users so event handlers always see the latest value (avoids stale closure)
-  const usersRef = useRef<User[]>([]);
+  const usersRef = useRef<ConnectionUser[]>([]);
 
   const [paused, setPaused] = useState(false);
 
@@ -199,7 +199,7 @@ export const useGame = () => {
 
     const socketHandlers = {
       // ユーザーの更新
-      'update-users': (users: User[]) => {
+      'update-users': (users: ConnectionUser[]) => {
         usersRef.current = users;
         setUsers(users);
       },
@@ -208,7 +208,7 @@ export const useGame = () => {
           setUsers((prev) => {
             const existingIndex = prev.findIndex((u) => u.playerId === playerId);
             const baseUser = {
-              id: playerId,
+              socketId: '',
               playerId,
               name,
               isAuthenticated: false,
@@ -343,7 +343,7 @@ export const useGame = () => {
           const knownUser = usersRef.current.find(u => u.playerId === data.playerId);
 
           return [...prev, {
-            id: data.playerId,
+            socketId: knownUser?.socketId ?? '',
             playerId: data.playerId,
             name: data.name || knownUser?.name || data.playerId,
             team: (data.team ?? 0) as Player['team'],
@@ -609,7 +609,7 @@ export const useGame = () => {
             player.playerId === playerId
               ? {
                   ...player,
-                  id: '',
+                  socketId: '',
                   name: playerName ?? player.name,
                 }
               : player,

--- a/mei-tra-frontend/hooks/useRoom.ts
+++ b/mei-tra-frontend/hooks/useRoom.ts
@@ -2,11 +2,11 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useSocket } from './useSocket';
 import { Room, RoomPlayer } from '../types/room.types';
 import { useAuth } from '../contexts/AuthContext';
-import { Player, Team, User } from '../types/game.types';
+import { ConnectionUser, Player, Team } from '../types/game.types';
 import { RoomStatus } from '../types/room.types';
 
 interface UseRoomOptions {
-  users?: User[];
+  users?: ConnectionUser[];
   currentPlayerId?: string | null;
 }
 
@@ -89,7 +89,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
           const existingPlayers = room.players.map((p, index) => {
             if (typeof p === 'string') {
               return {
-                id: p,
+                socketId: '',
                 playerId: p,
                 name: p,
                 hand: [],
@@ -109,7 +109,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
           // 空いている席（COMプレースホルダー）を探す
           const comIndex = existingPlayers.findIndex(p => p.isCOM === true && !p.isReady);
           const newPlayer: RoomPlayer = {
-            id: playerId,
+            socketId: '',
             playerId,
             name: playerId,
             hand: [],
@@ -173,7 +173,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
           const updatedPlayers = prev.players.map(p =>
             p.playerId === playerId
               ? {
-                  id: `com-disconnected-${playerId}`,
+                  socketId: '',
                   playerId: `com-disconnected-${playerId}`,
                   name: 'COM',
                   hand: [],
@@ -250,7 +250,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
             if (updatedPlayer) {
               return {
                 ...roomPlayer,
-                id: updatedPlayer.id,
+                socketId: updatedPlayer.socketId,
                 team: updatedPlayer.team,
                 name: updatedPlayer.name,
                 userId: updatedPlayer.userId,
@@ -406,7 +406,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
 
     const displayName = user.profile?.displayName || user.email || 'User';
     const userToJoin = {
-      id: socket.id ?? '',
+      socketId: socket.id ?? '',
       playerId: user.id,  // Supabase userId — must match room.hostId set during createRoom
       name: displayName,
       userId: user.id,

--- a/mei-tra-frontend/types/game.types.ts
+++ b/mei-tra-frontend/types/game.types.ts
@@ -4,12 +4,12 @@ export type GamePhase = 'deal' | 'blow' | 'play' | 'complete' | null;
 
 export type TrumpType = 'tra' | 'herz' | 'daiya' | 'club' | 'zuppe';
 
-export interface User {
-  id: string; // Socket ID
-  playerId: string; // Legacy player identifier
+export interface ConnectionUser {
+  socketId: string; // Connection/session identifier only
+  playerId: string; // Table participant identifier (future participantId equivalent)
   name: string;
-  userId?: string; // Supabase auth user ID (optional for backward compatibility)
-  isAuthenticated?: boolean; // Whether user is authenticated with Supabase
+  userId?: string; // Canonical authenticated account ID
+  isAuthenticated?: boolean;
 }
 
 export interface CompletedField {
@@ -34,7 +34,7 @@ export interface FieldCompleteEvent {
   nextPlayerId: string;
 }
 
-export interface Player extends User {
+export interface Player extends ConnectionUser {
   team: Team;
   hand: string[];
   isHost?: boolean;


### PR DESCRIPTION
## What changed
- replaced ambiguous game/room connection `id` fields with explicit `socketId` fields in frontend and backend game-related types
- updated backend game state, room service, gateway, and room repository flows to treat `userId` as the canonical authenticated identity, `playerId` as the stable table participant identity, and `socketId` as transport-only connection state
- updated frontend room/game hooks and table components to consume `socketId` consistently for disconnect/reconnect state
- refreshed the focused `update-auth` spec to match the new contract

## Why
The codebase had mixed meanings for `id`: some paths treated it as a socket identifier, while other paths treated identity as `userId` or `playerId`. That makes reconnects, ownership checks, and future spectator support harder to reason about. This PR makes the layers explicit:
- `userId`: canonical account identity
- `playerId`: stable table participant identity
- `socketId`: live connection identity only

## Impact
- authenticated flows now prefer `userId` when re-binding a live socket to an existing participant
- disconnect state now clears only `socketId`, keeping `playerId` / `userId` stable
- frontend/backend payloads are clearer and less likely to regress toward socket-based domain identity

## Validation
- `cd /Users/hikaruendo/Projects/old-maid/mei-tra-backend && npm run build`
- `cd /Users/hikaruendo/Projects/old-maid/mei-tra-backend && npm test -- update-auth.use-case.spec.ts`
- `cd /Users/hikaruendo/Projects/old-maid/mei-tra-backend && npm test -- social.gateway.spec.ts`
- `cd /Users/hikaruendo/Projects/old-maid/mei-tra-backend && npm test -- create-room-with-chat.spec.ts`
- `cd /Users/hikaruendo/Projects/old-maid/mei-tra-frontend && npm run lint`
- `cd /Users/hikaruendo/Projects/old-maid/mei-tra-frontend && npm run build`
- `cd /Users/hikaruendo/Projects/old-maid && git diff --check`

## Notes
- frontend lint still shows the pre-existing warnings for `<img>` usage and the tutorial hook dependency warning
- project memory was also updated locally to record the identity model rules for future agent work
