### PR TITLE
Fix Fly backend start command

### DIFF
--- a/.github/workflows/backend-fly-smoke.yml
+++ b/.github/workflows/backend-fly-smoke.yml
@@ -1,0 +1,55 @@
+name: Backend Fly Smoke
+
+on:
+  pull_request:
+    paths:
+      - '.dockerignore'
+      - '.github/workflows/backend-fly-smoke.yml'
+      - 'contracts/**'
+      - 'mei-tra-backend/**'
+  workflow_dispatch:
+
+jobs:
+  docker-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Fly backend image
+        run: docker build -t meitra-backend-fly-smoke -f mei-tra-backend/Dockerfile.fly .
+
+      - name: Start container and check health
+        run: |
+          set -euo pipefail
+
+          docker run -d --name meitra-backend-fly-smoke \
+            -e NODE_ENV=production \
+            -e PORT=3333 \
+            -e SUPABASE_URL_PROD=https://prod-project.supabase.co \
+            -e SUPABASE_ANON_KEY_PROD=dummy-anon \
+            -e SUPABASE_SERVICE_ROLE_KEY_PROD=dummy-service \
+            -e FRONTEND_URL_PROD=http://localhost:3000 \
+            -p 3339:3333 \
+            meitra-backend-fly-smoke
+
+          cleanup() {
+            exit_code=$?
+            if [ "$exit_code" -ne 0 ]; then
+              docker logs meitra-backend-fly-smoke || true
+            fi
+            docker rm -f meitra-backend-fly-smoke || true
+            exit "$exit_code"
+          }
+          trap cleanup EXIT
+
+          for _ in {1..30}; do
+            if curl -fsS http://127.0.0.1:3339/api/health; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Backend container did not pass /api/health smoke check"
+          exit 1

--- a/mei-tra-backend/Dockerfile
+++ b/mei-tra-backend/Dockerfile
@@ -43,4 +43,4 @@ RUN npm ci --omit=dev
 
 # Start the server with explicit heap size limit
 EXPOSE 3333
-CMD [ "node", "--max-old-space-size=320", "dist/src/main.js" ]
+CMD [ "node", "--max-old-space-size=320", "dist/main.js" ]

--- a/mei-tra-backend/Dockerfile.fly
+++ b/mei-tra-backend/Dockerfile.fly
@@ -34,4 +34,4 @@ COPY --from=build /app/package.json /app/package-lock.json /app/
 RUN npm ci --omit=dev
 
 EXPOSE 3333
-CMD [ "node", "--max-old-space-size=320", "dist/src/main.js" ]
+CMD [ "node", "--max-old-space-size=320", "dist/main.js" ]


### PR DESCRIPTION
## Summary\n- Fix Fly backend container CMD to use Nest webpack output at dist/main.js\n- Add Backend Fly Smoke GitHub Actions check that builds the Fly image, starts it, and verifies /api/health before merge\n\n## Validation\n- npm run build in mei-tra-backend\n- docker build -t meitra-backend-fly-test -f mei-tra-backend/Dockerfile.fly .\n- local container smoke check against /api/health