### PR TITLE
Fix base suit badge contrast

### DIFF
--- a/mei-tra-frontend/components/game/GameField/index.module.scss
+++ b/mei-tra-frontend/components/game/GameField/index.module.scss
@@ -146,14 +146,12 @@
   align-items: center;
 }
 
-.suitButtons button[onClick*="♥"],
-.suitButtons button[onClick*="♦"] {
-  color: red;
+.suitButtons button.redSuit {
+  color: #dc2626;
 }
 
-.suitButtons button[onClick*="♠"],
-.suitButtons button[onClick*="♣"] {
-  color: #ededed;
+.suitButtons button.blackSuit {
+  color: #111827;
 }
 
 .suitButtons button.selectedSuit {
@@ -205,6 +203,14 @@
   font-size: 1.05rem;
   font-weight: 800;
   line-height: 1;
+}
+
+.baseSuitBadgeSymbol.redSuit {
+  color: #dc2626;
+}
+
+.baseSuitBadgeSymbol.blackSuit {
+  color: #111827;
 }
 
 @media (max-width: 768px) {

--- a/mei-tra-frontend/components/game/GameField/index.tsx
+++ b/mei-tra-frontend/components/game/GameField/index.tsx
@@ -67,10 +67,10 @@ export const GameField: React.FC<GameFieldProps> = ({
           <div className={styles.baseSuitSelection}>
             <h3>{t('selectBaseSuit')}</h3>
             <div className={styles.suitButtons}>
-              <button onClick={() => onBaseSuitSelect('♠')}>♠</button>
-              <button onClick={() => onBaseSuitSelect('♥')}>♥</button>
-              <button onClick={() => onBaseSuitSelect('♦')}>♦</button>
-              <button onClick={() => onBaseSuitSelect('♣')}>♣</button>
+              <button className={styles.blackSuit} onClick={() => onBaseSuitSelect('♠')}>♠</button>
+              <button className={styles.redSuit} onClick={() => onBaseSuitSelect('♥')}>♥</button>
+              <button className={styles.redSuit} onClick={() => onBaseSuitSelect('♦')}>♦</button>
+              <button className={styles.blackSuit} onClick={() => onBaseSuitSelect('♣')}>♣</button>
             </div>
           </div>
         ) : currentField?.baseSuit && (


### PR DESCRIPTION
## Summary\n- Make the base suit badge symbol visible on its white chip in production dark theme\n- Replace non-functional CSS attribute selectors for suit buttons with explicit red/black suit classes\n\n## Validation\n- cd mei-tra-frontend && npm run lint\n- cd mei-tra-frontend && npm run build