### PR TITLE
[codex] refine mobile navigation controls

### DIFF
--- a/mei-tra-frontend/__tests__/components/Navigation.test.tsx
+++ b/mei-tra-frontend/__tests__/components/Navigation.test.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { Navigation } from '@/components/layout/Navigation';
 
 const replaceMock = jest.fn();
@@ -56,6 +56,10 @@ jest.mock('next-intl', () => ({
     const labels: Record<string, string> = {
       rooms: 'ルーム一覧',
       tutorial: 'ドキュメント',
+      discord: 'Discord',
+      x: 'X',
+      community: 'コミュニティ',
+      externalLink: '外部リンク',
       menu: 'メニュー',
       themeLabel: 'テーマ',
       themeSystem: 'システム',
@@ -89,10 +93,20 @@ describe('Navigation', () => {
   it('opens the font size menu and updates the selected preset', () => {
     render(<Navigation />);
 
-    fireEvent.click(screen.getByRole('button', { name: /文字サイズ/ }));
-    fireEvent.click(screen.getByRole('menuitemradio', { name: /特大/ }));
+    fireEvent.click(screen.getByRole('button', { name: '文字サイズ: 大きめ' }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /大きい/ }));
 
-    expect(setFontSizePreferenceMock).toHaveBeenCalledWith('xxlarge');
+    expect(setFontSizePreferenceMock).toHaveBeenCalledWith('xlarge');
+    expect(screen.queryByRole('menuitemradio', { name: /特大/ })).not.toBeInTheDocument();
+  });
+
+  it('shows three icon buttons for mobile font size selection', () => {
+    render(<Navigation />);
+
+    expect(screen.getAllByRole('button', { name: /文字サイズ:/ })).toHaveLength(4);
+    expect(screen.getByRole('button', { name: '文字サイズ: 標準 100%' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '文字サイズ: 大きめ 120%' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '文字サイズ: 大きい 150%' })).toBeInTheDocument();
   });
 
   it('opens the theme menu and updates the theme', () => {
@@ -111,5 +125,15 @@ describe('Navigation', () => {
     fireEvent.click(screen.getByRole('menuitemradio', { name: /English/ }));
 
     expect(replaceMock).toHaveBeenCalledWith('/rooms', { locale: 'en' });
+  });
+
+  it('shows social links in the shared navigation', () => {
+    render(<Navigation />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'コミュニティ' }));
+
+    const communityMenu = screen.getByRole('menu', { name: 'コミュニティ' });
+    expect(within(communityMenu).getByRole('menuitem', { name: /^Discord/ })).toBeInTheDocument();
+    expect(within(communityMenu).getByRole('menuitem', { name: /^X/ })).toBeInTheDocument();
   });
 });

--- a/mei-tra-frontend/__tests__/lib/preferences.test.ts
+++ b/mei-tra-frontend/__tests__/lib/preferences.test.ts
@@ -30,10 +30,17 @@ describe('preferences helpers', () => {
 
   it('reads stored theme and font size when values are valid', () => {
     localStorage.setItem(THEME_STORAGE_KEY, 'system');
-    localStorage.setItem(FONT_SIZE_STORAGE_KEY, 'xxlarge');
+    localStorage.setItem(FONT_SIZE_STORAGE_KEY, 'xlarge');
 
     expect(readStoredThemePreference()).toBe('system');
-    expect(readStoredFontSizePreset()).toBe('xxlarge');
+    expect(readStoredFontSizePreset()).toBe('xlarge');
+  });
+
+  it('maps legacy xxlarge font size to xlarge', () => {
+    localStorage.setItem(FONT_SIZE_STORAGE_KEY, 'xxlarge');
+
+    expect(readStoredFontSizePreset()).toBe('xlarge');
+    expect(normalizeUserPreferences({ fontSize: 'xxlarge' }).fontSize).toBe('xlarge');
   });
 
   it('falls back to defaults when stored values are invalid', () => {

--- a/mei-tra-frontend/app/globals.scss
+++ b/mei-tra-frontend/app/globals.scss
@@ -15,11 +15,11 @@ html[data-font-size='large'] {
 }
 
 html[data-font-size='xlarge'] {
-  font-size: 140%;
+  font-size: 150%;
 }
 
 html[data-font-size='xxlarge'] {
-  font-size: 170%;
+  font-size: 150%;
 }
 
 body {

--- a/mei-tra-frontend/app/layout.tsx
+++ b/mei-tra-frontend/app/layout.tsx
@@ -33,9 +33,10 @@ const preferenceBootstrapScript = `
       var fontSize = localStorage.getItem('fontSize');
       var resolvedFontSize =
         fontSize === 'large' ||
-        fontSize === 'xlarge' ||
-        fontSize === 'xxlarge'
+        fontSize === 'xlarge'
           ? fontSize
+          : fontSize === 'xxlarge'
+            ? 'xlarge'
           : 'standard';
       root.setAttribute('data-font-size', resolvedFontSize);
     } catch (error) {

--- a/mei-tra-frontend/components/icons/UIIcons.tsx
+++ b/mei-tra-frontend/components/icons/UIIcons.tsx
@@ -96,6 +96,50 @@ export function CheckIcon({ size, ...props }: IconProps) {
   );
 }
 
+export function ExternalLinkIcon({ size, ...props }: IconProps) {
+  const iconSize = getIconSize(size, 16);
+  return (
+    <svg width={iconSize} height={iconSize} viewBox="0 0 16 16" fill="none" aria-hidden="true" {...props}>
+      <path
+        d="M6.25 4.25H4.3A1.3 1.3 0 0 0 3 5.55v6.15A1.3 1.3 0 0 0 4.3 13h6.15a1.3 1.3 0 0 0 1.3-1.3V9.75"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.35"
+      />
+      <path
+        d="M8.25 3h4.75v4.75M7.75 8.25 12.7 3.3"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.35"
+      />
+    </svg>
+  );
+}
+
+export function CommunityIcon({ size, ...props }: IconProps) {
+  const iconSize = getIconSize(size, 16);
+  return (
+    <svg width={iconSize} height={iconSize} viewBox="0 0 16 16" fill="none" aria-hidden="true" {...props}>
+      <circle cx="6.1" cy="5.5" r="2.25" stroke="currentColor" strokeWidth="1.35" />
+      <path
+        d="M2.5 13.1c.45-2.15 1.8-3.35 3.6-3.35s3.15 1.2 3.6 3.35"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.35"
+      />
+      <circle cx="11.25" cy="6.4" r="1.75" stroke="currentColor" strokeWidth="1.25" />
+      <path
+        d="M10.2 10.25c1.55.15 2.6 1.1 3.05 2.85"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.25"
+      />
+    </svg>
+  );
+}
+
 export function UserIcon({ size, ...props }: IconProps) {
   const iconSize = getIconSize(size, 16);
   return (

--- a/mei-tra-frontend/components/layout/Navigation.module.scss
+++ b/mei-tra-frontend/components/layout/Navigation.module.scss
@@ -117,6 +117,18 @@ $desktop-breakpoint: 960px;
   }
 }
 
+.externalLinkIcon {
+  flex-shrink: 0;
+  opacity: 0.78;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.utilityExternalOption:hover .externalLinkIcon,
+.mobileExternalLink:hover .externalLinkIcon {
+  opacity: 1;
+  transform: translate(1px, -1px);
+}
+
 .utilityRail {
   display: flex;
   align-items: center;
@@ -198,6 +210,7 @@ $desktop-breakpoint: 960px;
   background: transparent;
   color: #ededed;
   cursor: pointer;
+  text-decoration: none;
   text-align: left;
   transition: $transition-button;
 
@@ -205,6 +218,10 @@ $desktop-breakpoint: 960px;
     background: rgba(255, 255, 255, 0.05);
     border-color: rgba(255, 255, 255, 0.08);
   }
+}
+
+.utilityExternalOption {
+  font-weight: 700;
 }
 
 .activeUtilityOption {
@@ -291,8 +308,8 @@ $desktop-breakpoint: 960px;
   flex-direction: column;
   justify-content: space-around;
   align-items: center;
-  width: 32px;
-  height: 24px;
+  width: 28px;
+  height: 20px;
   background: transparent;
   border: none;
   cursor: pointer;
@@ -307,7 +324,7 @@ $desktop-breakpoint: 960px;
 
   span {
     display: block;
-    width: 24px;
+    width: 22px;
     height: 2px;
     background-color: #ededed;
     transition: all 0.3s ease;
@@ -319,7 +336,7 @@ $desktop-breakpoint: 960px;
     }
 
     &:nth-child(2) {
-      top: 11px;
+      top: 9px;
     }
 
     &:nth-child(3) {
@@ -329,7 +346,7 @@ $desktop-breakpoint: 960px;
 
   &.active {
     span:nth-child(1) {
-      transform: translateY(11px) rotate(45deg);
+      transform: translateY(9px) rotate(45deg);
       top: 0;
     }
 
@@ -338,7 +355,7 @@ $desktop-breakpoint: 960px;
     }
 
     span:nth-child(3) {
-      transform: translateY(-11px) rotate(-45deg);
+      transform: translateY(-9px) rotate(-45deg);
       bottom: 0;
     }
   }
@@ -362,11 +379,16 @@ $desktop-breakpoint: 960px;
   right: -320px;
   width: min(320px, calc(100vw - 1.25rem));
   height: 100vh;
+  height: 100dvh;
+  max-height: 100dvh;
   background-color: #111;
   box-shadow: -2px 0 5px rgba(0, 0, 0, 0.3);
   transition: right 0.3s ease;
   z-index: 1000;
   overflow-y: auto;
+  overscroll-behavior: contain;
+  touch-action: pan-y;
+  -webkit-overflow-scrolling: touch;
 
   &.open {
     right: 0;
@@ -378,22 +400,26 @@ $desktop-breakpoint: 960px;
 }
 
 .mobileMenuContent {
-  padding: 5rem $spacing-md $spacing-md;
+  min-height: 100%;
+  box-sizing: border-box;
+  padding: 3rem 0.75rem calc(0.75rem + env(safe-area-inset-bottom));
   display: flex;
   flex-direction: column;
-  gap: $spacing-md;
+  gap: 0.6rem;
 }
 
 .mobileNavLink {
-  display: block;
-  padding: $spacing-md;
+  display: flex;
+  align-items: center;
+  padding: 0.42rem 0.6rem;
   color: #888;
   text-decoration: none;
   font-size: 1rem;
   font-weight: 500;
+  line-height: 1.1;
   border-radius: $radius-md;
   transition: $transition-button;
-  min-height: 44px;
+  min-height: 36px;
 
   &:hover {
     background-color: rgba(255, 255, 255, 0.06);
@@ -401,10 +427,47 @@ $desktop-breakpoint: 960px;
   }
 }
 
+.mobileExternalSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+}
+
+.mobileExternalLinks {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.mobileExternalLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.03);
+  color: #9ca3af;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.1;
+  transition: $transition-button;
+
+  &:hover {
+    color: #ededed;
+    background-color: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.14);
+  }
+}
+
 .mobileSettingsSection {
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
+  gap: 0.7rem;
+  margin-top: 0.55rem;
 }
 
 .mobileSectionLabel {
@@ -419,28 +482,27 @@ $desktop-breakpoint: 960px;
   flex-wrap: wrap;
 }
 
-.mobileFontSizeList {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.mobileFontSizeButton {
+.mobileFontSizeRow {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  min-height: 3rem;
-  padding: 0.8rem 0.9rem;
-  border-radius: 0.8rem;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.mobileFontSizeIconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.03);
   color: #ededed;
-  font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;
   transition: $transition-button;
-  text-align: left;
+  padding: 0;
 
   &:hover {
     background-color: rgba(255, 255, 255, 0.06);
@@ -448,19 +510,21 @@ $desktop-breakpoint: 960px;
   }
 }
 
+.mobileFontSizeGlyph {
+  font-size: 0.78rem;
+  line-height: 1;
+  font-weight: 800;
+}
+
 .activeMobileFontSizeButton {
   background: rgba(255, 255, 255, 0.08);
   border-color: rgba(255, 255, 255, 0.18);
 }
 
-.mobileFontSizeScale {
-  font-size: 0.8rem;
-  color: #9ca3af;
-}
-
 .langSwitcherMobile {
   display: block;
-  padding: $spacing-md;
+  margin-top: 0.45rem;
+  padding: $spacing-sm;
   background-color: rgba(255, 255, 255, 0.03);
   color: #888;
   text-decoration: none;
@@ -531,12 +595,13 @@ $desktop-breakpoint: 960px;
   }
 
   .utilityPopoverTitle,
-  .utilityOptionMeta,
-  .mobileFontSizeScale {
+  .utilityOptionMeta {
     color: #6b7280;
   }
 
   .navLink,
+  .mobileNavLink,
+  .mobileExternalLink,
   .langSwitcherMobile,
   .themeButton,
   .utilityTrigger {
@@ -544,6 +609,8 @@ $desktop-breakpoint: 960px;
   }
 
   .navLink:hover,
+  .mobileNavLink:hover,
+  .mobileExternalLink:hover,
   .langSwitcherMobile:hover,
   .themeButton:hover,
   .utilityTrigger:hover {
@@ -561,14 +628,16 @@ $desktop-breakpoint: 960px;
   }
 
   .utilityPopover,
-  .mobileFontSizeButton,
+  .mobileExternalLink,
+  .mobileFontSizeIconButton,
   .langSwitcherMobile,
   .themeButton,
   .utilityTrigger {
     border-color: rgba(15, 23, 42, 0.1);
   }
 
-  .mobileFontSizeButton,
+  .mobileExternalLink,
+  .mobileFontSizeIconButton,
   .langSwitcherMobile,
   .themeButton,
   .utilityTrigger {
@@ -584,13 +653,13 @@ $desktop-breakpoint: 960px;
   .utilityOptionState,
   .utilityOptionPreview,
   .utilityOptionIcon,
-  .mobileFontSizeButton,
+  .mobileFontSizeIconButton,
   .mobileSectionLabel {
     color: #111827;
   }
 
   .utilityOption:hover,
-  .mobileFontSizeButton:hover {
+  .mobileFontSizeIconButton:hover {
     background: rgba(15, 23, 42, 0.05);
     border-color: rgba(15, 23, 42, 0.12);
   }

--- a/mei-tra-frontend/components/layout/Navigation.tsx
+++ b/mei-tra-frontend/components/layout/Navigation.tsx
@@ -9,6 +9,8 @@ import { FONT_SIZE_PRESETS, FONT_SIZE_PRESET_ORDER } from '@/lib/preferences';
 import { FontSizePreset } from '@/types/user.types';
 import {
   CheckIcon,
+  CommunityIcon,
+  ExternalLinkIcon,
   GlobeIcon,
   MoonIcon,
   SunIcon,
@@ -23,13 +25,18 @@ interface NavigationProps {
   inRoom?: boolean;
 }
 
-type UtilityMenu = 'theme' | 'fontSize' | 'language';
+type UtilityMenu = 'theme' | 'fontSize' | 'community' | 'language';
 
 type ThemeOption = {
   value: 'system' | 'light' | 'dark';
   label: string;
   Icon: typeof SystemIcon;
 };
+
+const socialLinks = [
+  { key: 'discord', href: 'https://discord.gg/4TP7wvwA6c' },
+  { key: 'x', href: 'https://x.com/meitra_' },
+] as const;
 
 export function Navigation({ gameStarted = false, inRoom = false }: NavigationProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -40,6 +47,7 @@ export function Navigation({ gameStarted = false, inRoom = false }: NavigationPr
   const router = useRouter();
   const themeMenuRef = useRef<HTMLDivElement | null>(null);
   const fontSizeMenuRef = useRef<HTMLDivElement | null>(null);
+  const communityMenuRef = useRef<HTMLDivElement | null>(null);
   const languageMenuRef = useRef<HTMLDivElement | null>(null);
   const {
     fontSizePreference,
@@ -108,7 +116,9 @@ export function Navigation({ gameStarted = false, inRoom = false }: NavigationPr
         ? themeMenuRef
         : openUtilityMenu === 'fontSize'
           ? fontSizeMenuRef
-          : languageMenuRef;
+          : openUtilityMenu === 'community'
+            ? communityMenuRef
+            : languageMenuRef;
 
     const handlePointerDown = (event: MouseEvent) => {
       if (!activeMenuRef.current?.contains(event.target as Node)) {
@@ -201,6 +211,40 @@ export function Navigation({ gameStarted = false, inRoom = false }: NavigationPr
             </div>
 
             <div className={styles.utilityRail}>
+              <div className={styles.utilityMenu} ref={communityMenuRef}>
+                <button
+                  type="button"
+                  className={`${styles.utilityTrigger} ${openUtilityMenu === 'community' ? styles.utilityTriggerOpen : ''}`}
+                  onClick={() => toggleUtilityMenu('community')}
+                  aria-expanded={openUtilityMenu === 'community'}
+                  aria-haspopup="menu"
+                  aria-label={t('community')}
+                  title={t('community')}
+                >
+                  <CommunityIcon size="1.2rem" />
+                  <span className={styles.srOnly}>{t('community')}</span>
+                </button>
+                {openUtilityMenu === 'community' && (
+                  <div className={`${styles.utilityPopover} ${styles.utilityPopoverCompact}`} role="menu" aria-label={t('community')}>
+                    <span className={styles.utilityPopoverTitle}>{t('community')}</span>
+                    {socialLinks.map((link) => (
+                      <a
+                        key={link.key}
+                        href={link.href}
+                        className={`${styles.utilityOption} ${styles.utilityExternalOption}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        role="menuitem"
+                        aria-label={`${t(link.key)} ${t('externalLink')}`}
+                      >
+                        <span className={styles.utilityOptionLabel}>{t(link.key)}</span>
+                        <ExternalLinkIcon size="0.95rem" className={styles.externalLinkIcon} />
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </div>
+
               <div className={styles.utilityMenu} ref={themeMenuRef}>
                 <button
                   type="button"
@@ -361,6 +405,25 @@ export function Navigation({ gameStarted = false, inRoom = false }: NavigationPr
           >
             {t('tutorial')}
           </Link>
+          <div className={styles.mobileExternalSection} aria-label={t('community')}>
+            <span className={styles.mobileSectionLabel}>{t('community')}</span>
+            <div className={styles.mobileExternalLinks}>
+              {socialLinks.map((link) => (
+                <a
+                  key={link.key}
+                  href={link.href}
+                  className={styles.mobileExternalLink}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={closeMobileMenu}
+                  aria-label={`${t(link.key)} ${t('externalLink')}`}
+                >
+                  <span>{t(link.key)}</span>
+                  <ExternalLinkIcon size="0.9rem" className={styles.externalLinkIcon} />
+                </a>
+              ))}
+            </div>
+          </div>
           <div className={styles.mobileSettingsSection}>
             <span className={styles.mobileSectionLabel}>{t('themeLabel')}</span>
             <div className={styles.mobileThemeRow}>
@@ -380,16 +443,23 @@ export function Navigation({ gameStarted = false, inRoom = false }: NavigationPr
           </div>
           <div className={styles.mobileSettingsSection}>
             <span className={styles.mobileSectionLabel}>{t('fontSizeLabel')}</span>
-            <div className={styles.mobileFontSizeList}>
+            <div className={styles.mobileFontSizeRow} role="group" aria-label={t('fontSizeLabel')}>
               {fontSizeOptions.map((option) => (
                 <button
                   key={option.value}
                   type="button"
-                  className={`${styles.mobileFontSizeButton} ${fontSizePreference === option.value ? styles.activeMobileFontSizeButton : ''}`}
+                  className={`${styles.mobileFontSizeIconButton} ${fontSizePreference === option.value ? styles.activeMobileFontSizeButton : ''}`}
                   onClick={() => handleFontSizeChange(option.value)}
+                  aria-label={`${t('fontSizeLabel')}: ${option.label} ${option.scale}`}
+                  aria-pressed={fontSizePreference === option.value}
+                  title={`${option.label} ${option.scale}`}
                 >
-                  <span>{option.label}</span>
-                  <span className={styles.mobileFontSizeScale}>{option.scale}</span>
+                  <span
+                    className={styles.mobileFontSizeGlyph}
+                    aria-hidden="true"
+                  >
+                    {FONT_SIZE_PRESETS[option.value].rootPercent}
+                  </span>
                 </button>
               ))}
             </div>

--- a/mei-tra-frontend/lib/preferences.ts
+++ b/mei-tra-frontend/lib/preferences.ts
@@ -22,12 +22,13 @@ export const FONT_SIZE_PRESETS: Record<
     rootPercent: 120,
   },
   xlarge: {
-    scale: 1.4,
-    rootPercent: 140,
+    scale: 1.5,
+    rootPercent: 150,
   },
+  // Legacy value kept so old persisted preferences do not break.
   xxlarge: {
-    scale: 1.7,
-    rootPercent: 170,
+    scale: 1.5,
+    rootPercent: 150,
   },
 };
 
@@ -35,7 +36,6 @@ export const FONT_SIZE_PRESET_ORDER: FontSizePreset[] = [
   'standard',
   'large',
   'xlarge',
-  'xxlarge',
 ];
 
 export const DEFAULT_USER_PREFERENCES: UserPreferences = {
@@ -50,7 +50,15 @@ export function isThemePreference(value: unknown): value is UserPreferences['the
 }
 
 export function isFontSizePreset(value: unknown): value is FontSizePreset {
-  return FONT_SIZE_PRESET_ORDER.includes(value as FontSizePreset);
+  return value === 'standard' || value === 'large' || value === 'xlarge' || value === 'xxlarge';
+}
+
+export function normalizeFontSizePreset(value: unknown): FontSizePreset {
+  if (value === 'xxlarge') {
+    return 'xlarge';
+  }
+
+  return isFontSizePreset(value) ? value : DEFAULT_FONT_SIZE_PRESET;
 }
 
 export function normalizeUserPreferences(
@@ -68,9 +76,7 @@ export function normalizeUserPreferences(
     theme: isThemePreference(preferences?.theme)
       ? preferences.theme
       : DEFAULT_USER_PREFERENCES.theme,
-    fontSize: isFontSizePreset(preferences?.fontSize)
-      ? preferences.fontSize
-      : DEFAULT_USER_PREFERENCES.fontSize,
+    fontSize: normalizeFontSizePreset(preferences?.fontSize),
   };
 }
 
@@ -89,7 +95,5 @@ export function readStoredFontSizePreset(): FontSizePreset {
   }
 
   const storedFontSize = localStorage.getItem(FONT_SIZE_STORAGE_KEY);
-  return isFontSizePreset(storedFontSize)
-    ? storedFontSize
-    : DEFAULT_FONT_SIZE_PRESET;
+  return normalizeFontSizePreset(storedFontSize);
 }

--- a/mei-tra-frontend/messages/en.json
+++ b/mei-tra-frontend/messages/en.json
@@ -17,6 +17,10 @@
   "nav": {
     "rooms": "Rooms",
     "tutorial": "Docs",
+    "discord": "Discord",
+    "x": "X",
+    "community": "Community",
+    "externalLink": "external link",
     "menu": "Menu",
     "themeLabel": "Theme",
     "themeSystem": "System",

--- a/mei-tra-frontend/messages/ja.json
+++ b/mei-tra-frontend/messages/ja.json
@@ -17,6 +17,10 @@
   "nav": {
     "rooms": "ルーム一覧",
     "tutorial": "ドキュメント",
+    "discord": "Discord",
+    "x": "X",
+    "community": "コミュニティ",
+    "externalLink": "外部リンク",
     "menu": "メニュー",
     "themeLabel": "テーマ",
     "themeSystem": "システム",


### PR DESCRIPTION
## Summary
- Fix iOS mobile navigation drawer scrolling by using dynamic viewport height, safe-area padding, and touch-friendly scroll behavior.
- Add login-visible community links and move desktop Discord/X access behind a Community popover alongside theme/text/language controls.
- Simplify text-size options to three presets and render mobile text-size controls as compact numeric buttons.
- Preserve legacy `xxlarge` preferences by mapping them to `xlarge`.

## Validation
- `cd mei-tra-frontend && npm run lint`
- `cd mei-tra-frontend && npm test -- --runInBand --watch=false Navigation.test.tsx`
- `cd mei-tra-frontend && npm test -- --runInBand --watch=false Navigation.test.tsx preferences.test.ts`
- `cd mei-tra-frontend && npm run build`

## Notes
- `.claude/` remains untracked and was intentionally excluded from this PR.
