### PR TITLE
Improve COM strategy and play validation

### DIFF
--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -298,13 +298,44 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     return this.turnMonitorService.isPlayerIdle(roomId, playerId);
   }
 
-  private async triggerRevealBrokenHand(request?: RevealBrokenRequest) {
+  private finalizeBrokenHandAfterDelay(
+    followUp: { roomId: string; playerId: string },
+    delayMs: number,
+  ): void {
+    setTimeout(() => {
+      void this.revealBrokenHandUseCase
+        .finalize(followUp)
+        .then((completion) => {
+          if (!completion.success) {
+            console.error(
+              'Failed to finalize broken hand sequence:',
+              completion.error,
+            );
+            return;
+          }
+
+          this.dispatchEvents(completion.events);
+          this.triggerComAutoPlayIfNeeded(followUp.roomId);
+        })
+        .catch((error) =>
+          console.error('Error finalizing broken hand sequence:', error),
+        );
+    }, delayMs);
+  }
+
+  private async triggerRevealBrokenHand(
+    request?: RevealBrokenRequest,
+  ): Promise<boolean> {
     if (!request) {
-      return;
+      return false;
     }
 
     const roomGameState = await this.roomService.getRoomGameState(
       request.roomId,
+    );
+    const state = roomGameState.getState();
+    const targetPlayer = state.players.find(
+      (player) => player.playerId === request.playerId,
     );
     const sessionUser =
       roomGameState.findSessionUserByUserId(request.actorId) ??
@@ -313,12 +344,23 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const clientSocket = sessionUser?.socketId
       ? this.server.sockets.sockets.get(sessionUser.socketId)
       : undefined;
+    if (
+      !clientSocket &&
+      (targetPlayer?.isCOM || targetPlayer?.playerId.startsWith('com-'))
+    ) {
+      this.finalizeBrokenHandAfterDelay(
+        { roomId: request.roomId, playerId: request.playerId },
+        3000,
+      );
+      return true;
+    }
+
     if (!clientSocket) {
       console.warn(
         '[GameGateway] Socket not found when handling required broken hand',
         request,
       );
-      return;
+      return false;
     }
 
     try {
@@ -326,8 +368,10 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         roomId: request.roomId,
         playerId: request.playerId,
       });
+      return true;
     } catch (error) {
       console.error('Failed to trigger reveal-broken-hand flow:', error);
+      return false;
     }
   }
 
@@ -434,7 +478,15 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       // イベント配信（遅延含む）
       this.dispatchEvents(result.events);
       this.dispatchEvents(result.delayedEvents);
-      await this.triggerRevealBrokenHand(result.revealBrokenRequest);
+      const revealBrokenScheduled = await this.triggerRevealBrokenHand(
+        result.revealBrokenRequest,
+      );
+
+      const delayedEvents = result.delayedEvents ?? [];
+      const maxDelay = delayedEvents.reduce(
+        (max, event) => Math.max(max, event.delayMs ?? 0),
+        0,
+      );
 
       if (result.completeFieldTrigger) {
         const trigger = result.completeFieldTrigger;
@@ -452,6 +504,18 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
             });
         }, trigger.delayMs);
         return; // Wait for completion result before continuing loop
+      }
+
+      if (maxDelay > 0 && !revealBrokenScheduled) {
+        setTimeout(
+          () => this.triggerComAutoPlayIfNeeded(roomId),
+          maxDelay + 100,
+        );
+        return;
+      }
+
+      if (revealBrokenScheduled) {
+        return;
       }
 
       if (!result.shouldContinue) {
@@ -1156,8 +1220,12 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
       this.dispatchEvents(result.events);
       this.dispatchEvents(result.delayedEvents);
-      await this.triggerRevealBrokenHand(result.revealBrokenRequest);
-      this.triggerComAutoPlayIfNeeded(data.roomId);
+      const revealBrokenScheduled = await this.triggerRevealBrokenHand(
+        result.revealBrokenRequest,
+      );
+      if (!revealBrokenScheduled) {
+        this.triggerComAutoPlayIfNeeded(data.roomId);
+      }
     } catch (error) {
       console.error('Error in handleDeclareBlow:', error);
       client.emit('error-message', 'Failed to declare blow');
@@ -1188,8 +1256,12 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
       this.dispatchEvents(result.events);
       this.dispatchEvents(result.delayedEvents);
-      await this.triggerRevealBrokenHand(result.revealBrokenRequest);
-      this.triggerComAutoPlayIfNeeded(data.roomId);
+      const revealBrokenScheduled = await this.triggerRevealBrokenHand(
+        result.revealBrokenRequest,
+      );
+      if (!revealBrokenScheduled) {
+        this.triggerComAutoPlayIfNeeded(data.roomId);
+      }
     } catch (error) {
       console.error('Error in handlePassBlow:', error);
       client.emit('error-message', 'Failed to pass blow');
@@ -1366,25 +1438,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
       const delay = preparation.delayMs ?? 0;
       const followUp = preparation.followUp;
-      setTimeout(() => {
-        void this.revealBrokenHandUseCase
-          .finalize(followUp)
-          .then((completion) => {
-            if (!completion.success) {
-              console.error(
-                'Failed to finalize broken hand sequence:',
-                completion.error,
-              );
-              return;
-            }
-
-            this.dispatchEvents(completion.events);
-            this.triggerComAutoPlayIfNeeded(data.roomId);
-          })
-          .catch((error) =>
-            console.error('Error finalizing broken hand sequence:', error),
-          );
-      }, delay);
+      this.finalizeBrokenHandAfterDelay(followUp, delay);
     } catch (error) {
       console.error('Error in handleRevealBrokenHand:', error);
       client.emit('error-message', 'Failed to process broken hand');

--- a/mei-tra-backend/src/game.module.ts
+++ b/mei-tra-backend/src/game.module.ts
@@ -9,6 +9,7 @@ import { PlayService } from './services/play.service';
 import { RoomService } from './services/room.service';
 import { GameStateFactory } from './services/game-state.factory';
 import { ComPlayerService } from './services/com-player.service';
+import { ComStrategyService } from './services/com-strategy.service';
 import { ComAutoPlayService } from './services/com-autoplay.service';
 import { RepositoriesModule } from './repositories/repositories.module';
 import { AuthModule } from './auth/auth.module';
@@ -114,6 +115,11 @@ import { GetUserRecentGameHistoryUseCase } from './use-cases/get-user-recent-gam
     {
       provide: 'IComPlayerService',
       useExisting: ComPlayerService,
+    },
+    ComStrategyService,
+    {
+      provide: 'IComStrategyService',
+      useExisting: ComStrategyService,
     },
     ComAutoPlayService,
     {

--- a/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
@@ -1,0 +1,249 @@
+import { BlowService } from '../blow.service';
+import { CardService } from '../card.service';
+import { ComStrategyService } from '../com-strategy.service';
+import { PlayService } from '../play.service';
+import {
+  BlowState,
+  DomainPlayer,
+  Field,
+  GamePhase,
+  GameState,
+  PlayState,
+  Team,
+  TrumpType,
+} from '../../types/game.types';
+
+describe('ComStrategyService', () => {
+  const cardService = new CardService();
+  const blowService = new BlowService(cardService);
+  const playService = new PlayService(cardService);
+  const strategy = new ComStrategyService(
+    cardService,
+    playService,
+    blowService,
+  );
+
+  const player = (
+    playerId: string,
+    team: Team,
+    hand: string[] = [],
+    overrides: Partial<DomainPlayer> = {},
+  ): DomainPlayer => ({
+    playerId,
+    name: playerId,
+    team,
+    hand,
+    isPasser: false,
+    hasBroken: false,
+    hasRequiredBroken: false,
+    ...overrides,
+  });
+
+  const state = (overrides: Partial<GameState> = {}): GameState => {
+    const players = overrides.players ?? [
+      player('com-0', 0, [], { isCOM: true }),
+      player('enemy-1', 1),
+      player('partner-0', 0),
+      player('enemy-2', 1),
+    ];
+
+    const blowState: BlowState = {
+      currentTrump: null,
+      currentHighestDeclaration: null,
+      declarations: [],
+      actionHistory: [],
+      lastPasser: null,
+      isRoundCancelled: false,
+      currentBlowIndex: 0,
+      ...overrides.blowState,
+    };
+
+    return {
+      currentPlayerIndex: 0,
+      gamePhase: 'blow' as GamePhase,
+      deck: [],
+      teamScores: {
+        0: { play: 0, total: 0 },
+        1: { play: 0, total: 0 },
+      },
+      teamScoreRecords: { 0: [], 1: [] },
+      playState: overrides.playState,
+      roundNumber: 1,
+      pointsToWin: 5,
+      teamAssignments: Object.fromEntries(
+        players.map((statePlayer) => [statePlayer.playerId, statePlayer.team]),
+      ),
+      ...overrides,
+      players,
+      blowState,
+    };
+  };
+
+  it('declares with a strong hand instead of always passing', () => {
+    const com = player(
+      'com-0',
+      0,
+      ['JOKER', 'J♥', 'J♦', 'A♥', 'K♥', 'Q♥', '10♥', 'A♠', '5♣', '6♦'],
+      { isCOM: true },
+    );
+    const gameState = state({
+      players: [com, player('e1', 1), player('p1', 0), player('e2', 1)],
+    });
+
+    const action = strategy.chooseBlowAction(gameState, com);
+
+    expect(action.type).toBe('declare');
+    if (action.type === 'declare') {
+      expect(action.declaration.numberOfPairs).toBeGreaterThanOrEqual(6);
+    }
+  });
+
+  it('passes with weak or broken hands', () => {
+    const weakCom = player(
+      'com-0',
+      0,
+      ['5♠', '6♠', '7♣', '8♣', '9♦', '10♦', '5♥', '6♥', '7♥', '8♠'],
+      { isCOM: true },
+    );
+    const brokenCom = { ...weakCom, hasBroken: true };
+
+    expect(
+      strategy.chooseBlowAction(state({ players: [weakCom] }), weakCom),
+    ).toEqual({
+      type: 'pass',
+    });
+    expect(
+      strategy.chooseBlowAction(state({ players: [brokenCom] }), brokenCom),
+    ).toEqual({
+      type: 'pass',
+    });
+  });
+
+  it('does not overcall a partner declaration without a clear upgrade', () => {
+    const com = player(
+      'com-0',
+      0,
+      ['A♥', 'K♥', 'Q♣', '10♣', '9♠', '8♠', '7♦', '6♦', '5♣', '5♥'],
+      { isCOM: true },
+    );
+    const partner = player('partner-0', 0);
+    const gameState = state({
+      players: [com, player('e1', 1), partner, player('e2', 1)],
+      blowState: {
+        currentHighestDeclaration: {
+          playerId: partner.playerId,
+          trumpType: 'club',
+          numberOfPairs: 6,
+          timestamp: Date.now(),
+        },
+      } as Partial<BlowState> as BlowState,
+    });
+
+    expect(strategy.chooseBlowAction(gameState, com)).toEqual({ type: 'pass' });
+  });
+
+  it('selects low off-trump negri and avoids Joker, jacks, and high trump', () => {
+    const com = player(
+      'com-0',
+      0,
+      ['JOKER', 'J♥', 'J♦', 'A♥', 'K♠', '5♣', '6♥'],
+      { isCOM: true },
+    );
+    const gameState = state({
+      blowState: {
+        currentTrump: 'herz',
+        currentHighestDeclaration: {
+          playerId: com.playerId,
+          trumpType: 'herz',
+          numberOfPairs: 6,
+          timestamp: Date.now(),
+        },
+      } as Partial<BlowState> as BlowState,
+    });
+
+    expect(strategy.chooseNegriCard(gameState, com)).toBe('5♣');
+  });
+
+  it('does not waste a winner when the partner is already winning the field', () => {
+    const field: Field = {
+      cards: ['A♠', 'K♠'],
+      playedBy: ['partner-0', 'enemy-1'],
+      baseCard: 'A♠',
+      dealerId: 'partner-0',
+      isComplete: false,
+    };
+    const com = player('com-0', 0, ['5♠', 'JOKER', 'K♥'], { isCOM: true });
+    const gameState = playState(field, com, 'club');
+
+    expect(strategy.choosePlayCard(gameState, com)).toBe('5♠');
+  });
+
+  it('beats an opponent with the cheapest winning legal card', () => {
+    const field: Field = {
+      cards: ['K♠'],
+      playedBy: ['enemy-1'],
+      baseCard: 'K♠',
+      dealerId: 'enemy-1',
+      isComplete: false,
+    };
+    const com = player('com-0', 0, ['A♠', '5♠', 'JOKER'], { isCOM: true });
+    const gameState = playState(field, com, 'club');
+
+    expect(strategy.choosePlayCard(gameState, com)).toBe('A♠');
+  });
+
+  it('throws the lowest discard when it cannot win the field', () => {
+    const field: Field = {
+      cards: ['K♠'],
+      playedBy: ['enemy-1'],
+      baseCard: 'K♠',
+      dealerId: 'enemy-1',
+      isComplete: false,
+    };
+    const com = player('com-0', 0, ['5♣', '6♦', 'Q♥'], { isCOM: true });
+    const gameState = playState(field, com, 'club');
+
+    expect(strategy.choosePlayCard(gameState, com)).toBe('5♣');
+  });
+
+  it('selects the strongest supported suit after leading Joker', () => {
+    const com = player('com-0', 0, ['A♣', 'K♣', '5♣', 'A♠', '6♥'], {
+      isCOM: true,
+    });
+    const gameState = state({
+      players: [com, player('e1', 1), player('p1', 0), player('e2', 1)],
+      blowState: { currentTrump: 'club' } as Partial<BlowState> as BlowState,
+    });
+
+    expect(strategy.chooseBaseSuit(gameState, com)).toBe('♣');
+  });
+
+  function playState(
+    field: Field,
+    com: DomainPlayer,
+    trump: TrumpType | null,
+  ): GameState {
+    const players = [
+      com,
+      player('enemy-1', 1),
+      player('partner-0', 0),
+      player('enemy-2', 1),
+    ];
+    const playStateValue: PlayState = {
+      currentField: field,
+      negriCard: null,
+      neguri: {},
+      fields: [],
+      lastWinnerId: null,
+      openDeclared: false,
+      openDeclarerId: null,
+    };
+
+    return state({
+      players,
+      gamePhase: 'play',
+      blowState: { currentTrump: trump } as Partial<BlowState> as BlowState,
+      playState: playStateValue,
+    });
+  }
+});

--- a/mei-tra-backend/src/services/__tests__/play.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/play.service.spec.ts
@@ -55,4 +55,35 @@ describe('PlayService', () => {
 
     expect(winner?.playerId).toBe('com-1');
   });
+
+  it('returns only base-suit cards when the hand can follow suit', () => {
+    const field: Field = {
+      cards: ['K♠'],
+      playedBy: ['player-2'],
+      baseCard: 'K♠',
+      dealerId: 'player-2',
+      isComplete: false,
+    };
+
+    expect(
+      playService.getLegalPlayCards(['5♠', 'A♥'], field, 'club'),
+    ).toEqual(['5♠']);
+  });
+
+  it('requires Joker in Tanzen when the hand has it', () => {
+    const field: Field = {
+      cards: [],
+      playedBy: [],
+      baseCard: '',
+      dealerId: 'player-1',
+      isComplete: false,
+    };
+
+    expect(
+      playService.getLegalPlayCards(['JOKER', 'A♥'], field, 'club'),
+    ).toEqual(['JOKER']);
+    expect(
+      playService.getCardPlayError(['JOKER', 'A♥'], field, 'club', 'A♥'),
+    ).toContain('must play the Joker');
+  });
 });

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -4,7 +4,7 @@ import { IGameStateRepository } from '../../repositories/interfaces/game-state.r
 import { IRoomRepository } from '../../repositories/interfaces/room.repository.interface';
 import { IUserProfileRepository } from '../../repositories/interfaces/user-profile.repository.interface';
 import { GameStateFactory } from '../game-state.factory';
-import { DomainPlayer, GameState, TrumpType } from '../../types/game.types';
+import { DomainPlayer, GameState } from '../../types/game.types';
 import { Room, RoomStatus, RoomPlayer } from '../../types/room.types';
 import { CardService } from '../card.service';
 import { ChomboService } from '../chombo.service';
@@ -324,12 +324,6 @@ describe('Reconnection Token Management', () => {
       const chomboService = new ChomboService(playService);
       const comPlayerService: jest.Mocked<IComPlayerService> = {
         createComPlayer: jest.fn(),
-        selectBestCard: jest.fn(),
-        selectBaseSuit: jest.fn((hand: string[], trump: TrumpType | null) => {
-          void hand;
-          void trump;
-          return '♠';
-        }),
         isComPlayer: jest.fn(),
       };
       gameStateFactory = new GameStateFactory(

--- a/mei-tra-backend/src/services/com-player.service.ts
+++ b/mei-tra-backend/src/services/com-player.service.ts
@@ -1,15 +1,9 @@
-import { Injectable, Inject } from '@nestjs/common';
-import { DomainPlayer, Team, Field, TrumpType } from '../types/game.types';
-import { ICardService } from './interfaces/card-service.interface';
+import { Injectable } from '@nestjs/common';
+import { DomainPlayer, Team } from '../types/game.types';
 import { IComPlayerService } from './interfaces/com-player-service.interface';
 
 @Injectable()
 export class ComPlayerService implements IComPlayerService {
-  constructor(
-    @Inject('ICardService')
-    private readonly cardService: ICardService,
-  ) {}
-
   createComPlayer(seatIndex: number, team: Team): DomainPlayer {
     return {
       playerId: `com-${seatIndex}`,
@@ -21,99 +15,6 @@ export class ComPlayerService implements IComPlayerService {
       hasBroken: false,
       hasRequiredBroken: false,
     };
-  }
-
-  selectBestCard(
-    hand: string[],
-    field: Field | null,
-    trump: TrumpType | null,
-  ): string {
-    if (hand.length === 0) {
-      throw new Error('COM player has no cards in hand');
-    }
-
-    const baseSuit = field?.baseCard
-      ? this.cardService.getCardSuit(field.baseCard, trump, undefined)
-      : '';
-
-    let validCards = hand;
-    if (baseSuit && field?.baseCard) {
-      const suitCards = hand.filter(
-        (card) =>
-          this.cardService.getCardSuit(card, trump, baseSuit) === baseSuit,
-      );
-      if (suitCards.length > 0) {
-        validCards = suitCards;
-      }
-    }
-
-    let bestCard = validCards[0];
-    let bestStrength = this.cardService.getCardStrength(
-      bestCard,
-      baseSuit,
-      trump,
-    );
-
-    for (const card of validCards.slice(1)) {
-      const strength = this.cardService.getCardStrength(card, baseSuit, trump);
-      if (strength > bestStrength) {
-        bestCard = card;
-        bestStrength = strength;
-      }
-    }
-
-    return bestCard;
-  }
-
-  selectBaseSuit(hand: string[], trump: TrumpType | null): string {
-    const suitStats = new Map<
-      string,
-      {
-        count: number;
-        bestStrength: number;
-      }
-    >();
-
-    for (const card of hand) {
-      if (card === 'JOKER') {
-        continue;
-      }
-
-      const suit = this.cardService.getCardSuit(card, trump, undefined);
-      if (!suit) {
-        continue;
-      }
-
-      const strength = this.cardService.getCardStrength(card, suit, trump);
-      const stats = suitStats.get(suit) ?? { count: 0, bestStrength: -1 };
-      suitStats.set(suit, {
-        count: stats.count + 1,
-        bestStrength: Math.max(stats.bestStrength, strength),
-      });
-    }
-
-    const preferredSuits = ['♠', '♥', '♦', '♣'];
-    let selectedSuit = preferredSuits[0];
-    let selectedCount = -1;
-    let selectedStrength = -1;
-
-    for (const suit of preferredSuits) {
-      const stats = suitStats.get(suit);
-      if (!stats) {
-        continue;
-      }
-
-      if (
-        stats.count > selectedCount ||
-        (stats.count === selectedCount && stats.bestStrength > selectedStrength)
-      ) {
-        selectedSuit = suit;
-        selectedCount = stats.count;
-        selectedStrength = stats.bestStrength;
-      }
-    }
-
-    return selectedSuit;
   }
 
   isComPlayer(

--- a/mei-tra-backend/src/services/com-strategy.service.ts
+++ b/mei-tra-backend/src/services/com-strategy.service.ts
@@ -21,34 +21,30 @@ type TrumpEvaluation = {
   score: number;
 };
 
+const TRUMP_TYPES: TrumpType[] = ['zuppe', 'club', 'daiya', 'herz', 'tra'];
+const TRUMP_STRENGTH: Record<TrumpType, number> = {
+  zuppe: 1,
+  club: 2,
+  daiya: 3,
+  herz: 4,
+  tra: 5,
+};
+const TRUMP_TO_SUIT: Record<TrumpType, string> = {
+  zuppe: '♠',
+  club: '♣',
+  daiya: '♦',
+  herz: '♥',
+  tra: '',
+};
+const SUITS = ['♠', '♥', '♦', '♣'];
+const NON_DECLARABLE_PAIRS = 5;
+const MIN_DECLARATION_SCORE = 3.8;
+const SCORE_PER_ESTIMATED_PAIR = 1.35;
+const ESTIMATED_PAIR_BASELINE = 5;
+const MAX_ESTIMATED_PAIRS = 10;
+
 @Injectable()
 export class ComStrategyService implements IComStrategyService {
-  private readonly trumpTypes: TrumpType[] = [
-    'zuppe',
-    'club',
-    'daiya',
-    'herz',
-    'tra',
-  ];
-
-  private readonly trumpStrength: Record<TrumpType, number> = {
-    zuppe: 1,
-    club: 2,
-    daiya: 3,
-    herz: 4,
-    tra: 5,
-  };
-
-  private readonly trumpToSuit: Record<TrumpType, string> = {
-    zuppe: '♠',
-    club: '♣',
-    daiya: '♦',
-    herz: '♥',
-    tra: '',
-  };
-
-  private readonly suits = ['♠', '♥', '♦', '♣'];
-
   constructor(
     @Inject('ICardService')
     private readonly cardService: ICardService,
@@ -69,16 +65,14 @@ export class ComStrategyService implements IComStrategyService {
       : null;
     const currentHighestIsPartner =
       currentHighestPlayer?.team === comPlayer.team;
-    const evaluations = this.trumpTypes
-      .map((trumpType) => this.evaluateHandForTrump(comPlayer.hand, trumpType))
-      .sort((a, b) => {
-        if (b.score !== a.score) {
-          return b.score - a.score;
-        }
-        return (
-          this.trumpStrength[b.trumpType] - this.trumpStrength[a.trumpType]
-        );
-      });
+    const evaluations = TRUMP_TYPES.map((trumpType) =>
+      this.evaluateHandForTrump(comPlayer.hand, trumpType),
+    ).sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      return TRUMP_STRENGTH[b.trumpType] - TRUMP_STRENGTH[a.trumpType];
+    });
 
     if (evaluations.length === 0 || evaluations[0].estimatedPairs < 6) {
       return { type: 'pass' };
@@ -120,7 +114,11 @@ export class ComStrategyService implements IComStrategyService {
   choosePlayCard(state: GameState, comPlayer: DomainPlayer): string {
     const field = state.playState?.currentField ?? null;
     const trump = state.blowState.currentTrump;
-    const legalCards = this.getLegalPlayCards(comPlayer.hand, field, trump);
+    const legalCards = this.playService.getLegalPlayCards(
+      comPlayer.hand,
+      field,
+      trump,
+    );
 
     if (legalCards.length === 0) {
       throw new Error('COM player has no legal cards to play');
@@ -178,76 +176,24 @@ export class ComStrategyService implements IComStrategyService {
 
   chooseBaseSuit(state: GameState, comPlayer: DomainPlayer): string {
     const trump = state.blowState.currentTrump;
-    const preferredTrumpSuit = trump ? this.trumpToSuit[trump] : '';
-    const rankedSuits = this.suits
-      .map((suit) => ({
-        suit,
-        score: this.baseSuitControlScore(comPlayer.hand, suit, trump),
-      }))
-      .sort((a, b) => {
-        if (b.score !== a.score) {
-          return b.score - a.score;
-        }
-        if (a.suit === preferredTrumpSuit) {
-          return -1;
-        }
-        if (b.suit === preferredTrumpSuit) {
-          return 1;
-        }
-        return this.suits.indexOf(a.suit) - this.suits.indexOf(b.suit);
-      });
+    const preferredTrumpSuit = trump ? TRUMP_TO_SUIT[trump] : '';
+    const rankedSuits = SUITS.map((suit) => ({
+      suit,
+      score: this.baseSuitControlScore(comPlayer.hand, suit, trump),
+    })).sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      if (a.suit === preferredTrumpSuit) {
+        return -1;
+      }
+      if (b.suit === preferredTrumpSuit) {
+        return 1;
+      }
+      return SUITS.indexOf(a.suit) - SUITS.indexOf(b.suit);
+    });
 
     return rankedSuits[0]?.suit ?? '♠';
-  }
-
-  getLegalPlayCards(
-    hand: string[],
-    field: Field | null,
-    trump: TrumpType | null,
-  ): string[] {
-    if (hand.length === 0) {
-      return [];
-    }
-
-    if (hand.length === 2 && hand.includes('JOKER')) {
-      return ['JOKER'];
-    }
-
-    if (!field || field.cards.length === 0 || !field.baseCard) {
-      return [...hand];
-    }
-
-    const baseSuit = this.resolveFieldBaseSuit(field, trump);
-    if (!baseSuit) {
-      return [...hand];
-    }
-
-    const suitCards = hand.filter(
-      (card) =>
-        card !== 'JOKER' &&
-        this.cardService.getCardSuit(card, trump, baseSuit) === baseSuit,
-    );
-    const jokerCards = hand.filter((card) => card === 'JOKER');
-
-    if (suitCards.length > 0) {
-      return [...suitCards, ...jokerCards];
-    }
-
-    const trumpSuit = trump ? this.trumpToSuit[trump] : '';
-    const hasJoker = hand.includes('JOKER');
-    const hasTrumpSuit = trumpSuit
-      ? hand.some(
-          (card) =>
-            card !== 'JOKER' &&
-            this.cardService.getCardSuit(card, trump, baseSuit) === trumpSuit,
-        )
-      : false;
-
-    if (hasJoker && baseSuit === trumpSuit && !hasTrumpSuit) {
-      return ['JOKER'];
-    }
-
-    return [...hand];
   }
 
   private chooseLeadCard(
@@ -319,7 +265,7 @@ export class ComStrategyService implements IComStrategyService {
         candidates.push({
           ...declaration,
           risk: pairs - evaluation.estimatedPairs,
-          trumpStrength: this.trumpStrength[evaluation.trumpType],
+          trumpStrength: TRUMP_STRENGTH[evaluation.trumpType],
         });
       }
     }
@@ -344,7 +290,7 @@ export class ComStrategyService implements IComStrategyService {
     hand: string[],
     trumpType: TrumpType,
   ): TrumpEvaluation {
-    const trumpSuit = this.trumpToSuit[trumpType];
+    const trumpSuit = TRUMP_TO_SUIT[trumpType];
     const suitCounts = this.countSuits(hand, trumpType);
     let score = 0;
 
@@ -379,7 +325,7 @@ export class ComStrategyService implements IComStrategyService {
     score += Math.max(0, trumpCount - 2) * 0.25;
 
     if (trumpSuit) {
-      for (const suit of this.suits) {
+      for (const suit of SUITS) {
         if (suit === trumpSuit) {
           continue;
         }
@@ -393,13 +339,23 @@ export class ComStrategyService implements IComStrategyService {
     }
 
     const estimatedPairs =
-      score < 3.8 ? 5 : Math.min(10, Math.max(6, Math.floor(5 + score / 1.35)));
+      score < MIN_DECLARATION_SCORE
+        ? NON_DECLARABLE_PAIRS
+        : Math.min(
+            MAX_ESTIMATED_PAIRS,
+            Math.max(
+              6,
+              Math.floor(
+                ESTIMATED_PAIR_BASELINE + score / SCORE_PER_ESTIMATED_PAIR,
+              ),
+            ),
+          );
 
     return { trumpType, estimatedPairs, score };
   }
 
   private scoreNeededForPairs(numberOfPairs: number): number {
-    return (numberOfPairs - 5) * 1.35;
+    return (numberOfPairs - ESTIMATED_PAIR_BASELINE) * SCORE_PER_ESTIMATED_PAIR;
   }
 
   private trumpCardValue(rank: string): number {
@@ -478,7 +434,7 @@ export class ComStrategyService implements IComStrategyService {
 
     const rank = this.getRank(card);
     const suit = this.cardService.getCardSuit(card, trump);
-    const trumpSuit = trump ? this.trumpToSuit[trump] : '';
+    const trumpSuit = trump ? TRUMP_TO_SUIT[trump] : '';
     const suitCount = hand.filter(
       (handCard) =>
         handCard !== 'JOKER' &&
@@ -543,7 +499,7 @@ export class ComStrategyService implements IComStrategyService {
     }
     const rank = this.getRank(card);
     const suit = this.cardService.getCardSuit(card, trump);
-    const trumpSuit = trump ? this.trumpToSuit[trump] : '';
+    const trumpSuit = trump ? TRUMP_TO_SUIT[trump] : '';
     return (
       rank === 'A' ||
       rank === 'K' ||
@@ -638,7 +594,7 @@ export class ComStrategyService implements IComStrategyService {
   }
 
   private getPrimaryJack(trump: TrumpType): string {
-    return `J${this.trumpToSuit[trump]}`;
+    return `J${TRUMP_TO_SUIT[trump]}`;
   }
 
   private getSecondaryJack(trump: TrumpType): string {

--- a/mei-tra-backend/src/services/com-strategy.service.ts
+++ b/mei-tra-backend/src/services/com-strategy.service.ts
@@ -1,0 +1,685 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  BlowDeclaration,
+  DomainPlayer,
+  Field,
+  GameState,
+  Team,
+  TrumpType,
+} from '../types/game.types';
+import { IBlowService } from './interfaces/blow-service.interface';
+import { ICardService } from './interfaces/card-service.interface';
+import { IPlayService } from './interfaces/play-service.interface';
+import {
+  ComBlowAction,
+  IComStrategyService,
+} from './interfaces/com-strategy-service.interface';
+
+type TrumpEvaluation = {
+  trumpType: TrumpType;
+  estimatedPairs: number;
+  score: number;
+};
+
+@Injectable()
+export class ComStrategyService implements IComStrategyService {
+  private readonly trumpTypes: TrumpType[] = [
+    'zuppe',
+    'club',
+    'daiya',
+    'herz',
+    'tra',
+  ];
+
+  private readonly trumpStrength: Record<TrumpType, number> = {
+    zuppe: 1,
+    club: 2,
+    daiya: 3,
+    herz: 4,
+    tra: 5,
+  };
+
+  private readonly trumpToSuit: Record<TrumpType, string> = {
+    zuppe: '♠',
+    club: '♣',
+    daiya: '♦',
+    herz: '♥',
+    tra: '',
+  };
+
+  private readonly suits = ['♠', '♥', '♦', '♣'];
+
+  constructor(
+    @Inject('ICardService')
+    private readonly cardService: ICardService,
+    @Inject('IPlayService')
+    private readonly playService: IPlayService,
+    @Inject('IBlowService')
+    private readonly blowService: IBlowService,
+  ) {}
+
+  chooseBlowAction(state: GameState, comPlayer: DomainPlayer): ComBlowAction {
+    if (comPlayer.hasBroken || comPlayer.hasRequiredBroken) {
+      return { type: 'pass' };
+    }
+
+    const currentHighest = state.blowState.currentHighestDeclaration;
+    const currentHighestPlayer = currentHighest
+      ? this.findPlayer(state, currentHighest.playerId)
+      : null;
+    const currentHighestIsPartner =
+      currentHighestPlayer?.team === comPlayer.team;
+    const evaluations = this.trumpTypes
+      .map((trumpType) => this.evaluateHandForTrump(comPlayer.hand, trumpType))
+      .sort((a, b) => {
+        if (b.score !== a.score) {
+          return b.score - a.score;
+        }
+        return (
+          this.trumpStrength[b.trumpType] - this.trumpStrength[a.trumpType]
+        );
+      });
+
+    if (evaluations.length === 0 || evaluations[0].estimatedPairs < 6) {
+      return { type: 'pass' };
+    }
+
+    if (currentHighestIsPartner) {
+      const best = evaluations[0];
+      const shouldOvercallPartner =
+        currentHighest != null &&
+        best.estimatedPairs >= currentHighest.numberOfPairs + 2 &&
+        best.score >=
+          this.scoreNeededForPairs(currentHighest.numberOfPairs + 2);
+
+      if (!shouldOvercallPartner) {
+        return { type: 'pass' };
+      }
+    }
+
+    const declaration = this.findLowestValidDeclaration(
+      evaluations,
+      currentHighest,
+      currentHighestIsPartner,
+    );
+
+    return declaration ? { type: 'declare', declaration } : { type: 'pass' };
+  }
+
+  chooseNegriCard(state: GameState, comPlayer: DomainPlayer): string {
+    const trump =
+      state.blowState.currentTrump ??
+      state.blowState.currentHighestDeclaration?.trumpType ??
+      null;
+
+    return this.minBy(comPlayer.hand, (card) =>
+      this.discardValue(card, trump, comPlayer.hand),
+    );
+  }
+
+  choosePlayCard(state: GameState, comPlayer: DomainPlayer): string {
+    const field = state.playState?.currentField ?? null;
+    const trump = state.blowState.currentTrump;
+    const legalCards = this.getLegalPlayCards(comPlayer.hand, field, trump);
+
+    if (legalCards.length === 0) {
+      throw new Error('COM player has no legal cards to play');
+    }
+
+    if (!field || field.cards.length === 0) {
+      return this.chooseLeadCard(state, comPlayer, legalCards, trump);
+    }
+
+    const currentWinner = this.playService.determineFieldWinner(
+      field,
+      state.players,
+      trump,
+    );
+    if (!currentWinner) {
+      return this.chooseLeadCard(state, comPlayer, legalCards, trump);
+    }
+
+    const baseSuit = this.resolveFieldBaseSuit(field, trump);
+    const currentWinningStrength = this.getCurrentWinningStrength(
+      field,
+      baseSuit,
+      trump,
+    );
+    const cardsThatWin = legalCards
+      .filter(
+        (card) =>
+          this.cardService.getCardStrength(card, baseSuit, trump) >
+          currentWinningStrength,
+      )
+      .sort(
+        (a, b) =>
+          this.cardService.getCardStrength(a, baseSuit, trump) -
+          this.cardService.getCardStrength(b, baseSuit, trump),
+      );
+
+    if (currentWinner.team === comPlayer.team) {
+      const safeCards = legalCards.filter(
+        (card) =>
+          this.cardService.getCardStrength(card, baseSuit, trump) <=
+          currentWinningStrength,
+      );
+      return this.chooseLowestDiscard(
+        safeCards.length > 0 ? safeCards : legalCards,
+        trump,
+      );
+    }
+
+    if (cardsThatWin.length > 0) {
+      return cardsThatWin[0];
+    }
+
+    return this.chooseLowestDiscard(legalCards, trump);
+  }
+
+  chooseBaseSuit(state: GameState, comPlayer: DomainPlayer): string {
+    const trump = state.blowState.currentTrump;
+    const preferredTrumpSuit = trump ? this.trumpToSuit[trump] : '';
+    const rankedSuits = this.suits
+      .map((suit) => ({
+        suit,
+        score: this.baseSuitControlScore(comPlayer.hand, suit, trump),
+      }))
+      .sort((a, b) => {
+        if (b.score !== a.score) {
+          return b.score - a.score;
+        }
+        if (a.suit === preferredTrumpSuit) {
+          return -1;
+        }
+        if (b.suit === preferredTrumpSuit) {
+          return 1;
+        }
+        return this.suits.indexOf(a.suit) - this.suits.indexOf(b.suit);
+      });
+
+    return rankedSuits[0]?.suit ?? '♠';
+  }
+
+  getLegalPlayCards(
+    hand: string[],
+    field: Field | null,
+    trump: TrumpType | null,
+  ): string[] {
+    if (hand.length === 0) {
+      return [];
+    }
+
+    if (hand.length === 2 && hand.includes('JOKER')) {
+      return ['JOKER'];
+    }
+
+    if (!field || field.cards.length === 0 || !field.baseCard) {
+      return [...hand];
+    }
+
+    const baseSuit = this.resolveFieldBaseSuit(field, trump);
+    if (!baseSuit) {
+      return [...hand];
+    }
+
+    const suitCards = hand.filter(
+      (card) =>
+        card !== 'JOKER' &&
+        this.cardService.getCardSuit(card, trump, baseSuit) === baseSuit,
+    );
+    const jokerCards = hand.filter((card) => card === 'JOKER');
+
+    if (suitCards.length > 0) {
+      return [...suitCards, ...jokerCards];
+    }
+
+    const trumpSuit = trump ? this.trumpToSuit[trump] : '';
+    const hasJoker = hand.includes('JOKER');
+    const hasTrumpSuit = trumpSuit
+      ? hand.some(
+          (card) =>
+            card !== 'JOKER' &&
+            this.cardService.getCardSuit(card, trump, baseSuit) === trumpSuit,
+        )
+      : false;
+
+    if (hasJoker && baseSuit === trumpSuit && !hasTrumpSuit) {
+      return ['JOKER'];
+    }
+
+    return [...hand];
+  }
+
+  private chooseLeadCard(
+    state: GameState,
+    comPlayer: DomainPlayer,
+    legalCards: string[],
+    trump: TrumpType | null,
+  ): string {
+    const declaringTeam = this.findDeclaringTeam(state);
+    const teamTaken = this.countCompletedFieldsByTeam(state, comPlayer.team);
+    const declaration = state.blowState.currentHighestDeclaration;
+    const remainingTricks = comPlayer.hand.length;
+    const needsWins =
+      declaringTeam === comPlayer.team &&
+      declaration != null &&
+      declaration.numberOfPairs - teamTaken >= remainingTricks - 1;
+
+    if (needsWins || remainingTricks <= 3) {
+      return this.chooseStrongestControlCard(legalCards, trump);
+    }
+
+    if (declaringTeam === comPlayer.team) {
+      const nonJoker = legalCards.filter((card) => card !== 'JOKER');
+      return this.chooseMiddleControlCard(
+        nonJoker.length > 0 ? nonJoker : legalCards,
+        trump,
+      );
+    }
+
+    const nonControlCards = legalCards.filter(
+      (card) => !this.isControlCard(card, trump),
+    );
+    return this.chooseLowestDiscard(
+      nonControlCards.length > 0 ? nonControlCards : legalCards,
+      trump,
+    );
+  }
+
+  private findLowestValidDeclaration(
+    evaluations: TrumpEvaluation[],
+    currentHighest: BlowDeclaration | null,
+    currentHighestIsPartner: boolean,
+  ): { trumpType: TrumpType; numberOfPairs: number } | null {
+    const candidates: Array<{
+      trumpType: TrumpType;
+      numberOfPairs: number;
+      risk: number;
+      trumpStrength: number;
+    }> = [];
+
+    for (const evaluation of evaluations) {
+      for (let pairs = 6; pairs <= evaluation.estimatedPairs; pairs++) {
+        const declaration = {
+          trumpType: evaluation.trumpType,
+          numberOfPairs: pairs,
+        };
+        if (!this.blowService.isValidDeclaration(declaration, currentHighest)) {
+          continue;
+        }
+
+        if (
+          currentHighestIsPartner &&
+          currentHighest != null &&
+          pairs < currentHighest.numberOfPairs + 2
+        ) {
+          continue;
+        }
+
+        candidates.push({
+          ...declaration,
+          risk: pairs - evaluation.estimatedPairs,
+          trumpStrength: this.trumpStrength[evaluation.trumpType],
+        });
+      }
+    }
+
+    candidates.sort((a, b) => {
+      if (a.numberOfPairs !== b.numberOfPairs) {
+        return a.numberOfPairs - b.numberOfPairs;
+      }
+      if (a.risk !== b.risk) {
+        return a.risk - b.risk;
+      }
+      return a.trumpStrength - b.trumpStrength;
+    });
+
+    const best = candidates[0];
+    return best
+      ? { trumpType: best.trumpType, numberOfPairs: best.numberOfPairs }
+      : null;
+  }
+
+  private evaluateHandForTrump(
+    hand: string[],
+    trumpType: TrumpType,
+  ): TrumpEvaluation {
+    const trumpSuit = this.trumpToSuit[trumpType];
+    const suitCounts = this.countSuits(hand, trumpType);
+    let score = 0;
+
+    for (const card of hand) {
+      if (card === 'JOKER') {
+        score += 2.2;
+        continue;
+      }
+
+      const rank = this.getRank(card);
+      const suit = this.cardService.getCardSuit(card, trumpType);
+      const isTrump = trumpSuit !== '' && suit === trumpSuit;
+
+      if (this.isPrimaryJack(card, trumpType)) {
+        score += 1.5;
+        continue;
+      }
+
+      if (this.isSecondaryJack(card, trumpType)) {
+        score += 1.2;
+        continue;
+      }
+
+      if (isTrump) {
+        score += this.trumpCardValue(rank);
+      } else {
+        score += this.offTrumpCardValue(rank);
+      }
+    }
+
+    const trumpCount = trumpSuit ? (suitCounts.get(trumpSuit) ?? 0) : 0;
+    score += Math.max(0, trumpCount - 2) * 0.25;
+
+    if (trumpSuit) {
+      for (const suit of this.suits) {
+        if (suit === trumpSuit) {
+          continue;
+        }
+        const count = suitCounts.get(suit) ?? 0;
+        if (count === 0) {
+          score += 0.35;
+        } else if (count === 1) {
+          score += 0.2;
+        }
+      }
+    }
+
+    const estimatedPairs =
+      score < 3.8 ? 5 : Math.min(10, Math.max(6, Math.floor(5 + score / 1.35)));
+
+    return { trumpType, estimatedPairs, score };
+  }
+
+  private scoreNeededForPairs(numberOfPairs: number): number {
+    return (numberOfPairs - 5) * 1.35;
+  }
+
+  private trumpCardValue(rank: string): number {
+    switch (rank) {
+      case 'A':
+        return 1.0;
+      case 'K':
+        return 0.8;
+      case 'Q':
+        return 0.6;
+      case 'J':
+        return 0.5;
+      case '10':
+        return 0.35;
+      default:
+        return 0.2;
+    }
+  }
+
+  private offTrumpCardValue(rank: string): number {
+    switch (rank) {
+      case 'A':
+        return 0.45;
+      case 'K':
+        return 0.3;
+      case 'Q':
+        return 0.2;
+      default:
+        return 0;
+    }
+  }
+
+  private chooseLowestDiscard(
+    cards: string[],
+    trump: TrumpType | null,
+  ): string {
+    return this.minBy(cards, (card) => this.discardValue(card, trump, cards));
+  }
+
+  private chooseStrongestControlCard(
+    cards: string[],
+    trump: TrumpType | null,
+  ): string {
+    return this.maxBy(cards, (card) => this.controlValue(card, trump));
+  }
+
+  private chooseMiddleControlCard(
+    cards: string[],
+    trump: TrumpType | null,
+  ): string {
+    const sorted = [...cards].sort(
+      (a, b) => this.controlValue(a, trump) - this.controlValue(b, trump),
+    );
+    const nonJoker = sorted.filter((card) => card !== 'JOKER');
+    const source = nonJoker.length > 0 ? nonJoker : sorted;
+    return source[Math.floor((source.length - 1) / 2)];
+  }
+
+  private controlValue(card: string, trump: TrumpType | null): number {
+    if (card === 'JOKER') {
+      return 10000;
+    }
+
+    const suit = this.cardService.getCardSuit(card, trump);
+    return this.cardService.getCardStrength(card, suit, trump);
+  }
+
+  private discardValue(
+    card: string,
+    trump: TrumpType | null,
+    hand: string[],
+  ): number {
+    if (card === 'JOKER') {
+      return 10000;
+    }
+
+    const rank = this.getRank(card);
+    const suit = this.cardService.getCardSuit(card, trump);
+    const trumpSuit = trump ? this.trumpToSuit[trump] : '';
+    const suitCount = hand.filter(
+      (handCard) =>
+        handCard !== 'JOKER' &&
+        this.cardService.getCardSuit(handCard, trump) === suit,
+    ).length;
+
+    let value = this.rankDiscardValue(rank);
+
+    if (trump && trump !== 'tra') {
+      if (this.isPrimaryJack(card, trump)) {
+        value += 9000;
+      } else if (this.isSecondaryJack(card, trump)) {
+        value += 8500;
+      }
+    }
+
+    if (rank === 'J') {
+      value += 1500;
+    }
+
+    if (trumpSuit && suit === trumpSuit) {
+      value += 3000;
+    }
+
+    if (suitCount <= 1) {
+      value -= 20;
+    }
+
+    return value;
+  }
+
+  private rankDiscardValue(rank: string): number {
+    switch (rank) {
+      case 'A':
+        return 700;
+      case 'K':
+        return 600;
+      case 'Q':
+        return 500;
+      case 'J':
+        return 650;
+      case '10':
+        return 200;
+      case '9':
+        return 90;
+      case '8':
+        return 80;
+      case '7':
+        return 70;
+      case '6':
+        return 60;
+      case '5':
+        return 50;
+      default:
+        return 0;
+    }
+  }
+
+  private isControlCard(card: string, trump: TrumpType | null): boolean {
+    if (card === 'JOKER') {
+      return true;
+    }
+    const rank = this.getRank(card);
+    const suit = this.cardService.getCardSuit(card, trump);
+    const trumpSuit = trump ? this.trumpToSuit[trump] : '';
+    return (
+      rank === 'A' ||
+      rank === 'K' ||
+      this.isPrimaryJack(card, trump) ||
+      this.isSecondaryJack(card, trump) ||
+      (trumpSuit !== '' && suit === trumpSuit)
+    );
+  }
+
+  private baseSuitControlScore(
+    hand: string[],
+    suit: string,
+    trump: TrumpType | null,
+  ): number {
+    const cards = hand.filter(
+      (card) =>
+        card !== 'JOKER' && this.cardService.getCardSuit(card, trump) === suit,
+    );
+
+    return cards.reduce((score, card) => {
+      const rank = this.getRank(card);
+      const strength = this.cardService.getCardStrength(card, suit, trump);
+      const highBonus = ['A', 'K', 'Q', 'J', '10'].includes(rank) ? 18 : 0;
+      return score + 20 + highBonus + strength / 10;
+    }, 0);
+  }
+
+  private getCurrentWinningStrength(
+    field: Field,
+    baseSuit: string,
+    trump: TrumpType | null,
+  ): number {
+    return Math.max(
+      ...field.cards.map((card) =>
+        this.cardService.getCardStrength(card, baseSuit, trump),
+      ),
+    );
+  }
+
+  private resolveFieldBaseSuit(field: Field, trump: TrumpType | null): string {
+    if (field.baseCard === 'JOKER') {
+      return field.baseSuit ?? '';
+    }
+
+    return this.cardService.getCardSuit(field.baseCard, trump, field.baseSuit);
+  }
+
+  private findDeclaringTeam(state: GameState): Team | null {
+    const declaration = state.blowState.currentHighestDeclaration;
+    if (!declaration) {
+      return null;
+    }
+    return this.findPlayer(state, declaration.playerId)?.team ?? null;
+  }
+
+  private countCompletedFieldsByTeam(state: GameState, team: Team): number {
+    return (
+      state.playState?.fields.filter((field) => field.winnerTeam === team)
+        .length ?? 0
+    );
+  }
+
+  private findPlayer(state: GameState, playerId: string): DomainPlayer | null {
+    return state.players.find((player) => player.playerId === playerId) ?? null;
+  }
+
+  private countSuits(
+    hand: string[],
+    trump: TrumpType | null,
+  ): Map<string, number> {
+    const counts = new Map<string, number>();
+    for (const card of hand) {
+      if (card === 'JOKER') {
+        continue;
+      }
+      const suit = this.cardService.getCardSuit(card, trump);
+      counts.set(suit, (counts.get(suit) ?? 0) + 1);
+    }
+    return counts;
+  }
+
+  private isPrimaryJack(card: string, trump: TrumpType | null): boolean {
+    return (
+      trump != null && trump !== 'tra' && card === this.getPrimaryJack(trump)
+    );
+  }
+
+  private isSecondaryJack(card: string, trump: TrumpType | null): boolean {
+    return (
+      trump != null && trump !== 'tra' && card === this.getSecondaryJack(trump)
+    );
+  }
+
+  private getPrimaryJack(trump: TrumpType): string {
+    return `J${this.trumpToSuit[trump]}`;
+  }
+
+  private getSecondaryJack(trump: TrumpType): string {
+    switch (trump) {
+      case 'herz':
+        return 'J♦';
+      case 'daiya':
+        return 'J♥';
+      case 'club':
+        return 'J♠';
+      case 'zuppe':
+        return 'J♣';
+      case 'tra':
+        return '';
+    }
+  }
+
+  private getRank(card: string): string {
+    if (card === 'JOKER') {
+      return 'JOKER';
+    }
+    return card.startsWith('10') ? '10' : card[0];
+  }
+
+  private minBy<T>(items: T[], getValue: (item: T) => number): T {
+    if (items.length === 0) {
+      throw new Error('Cannot choose from an empty list');
+    }
+
+    return items.reduce((best, item) =>
+      getValue(item) < getValue(best) ? item : best,
+    );
+  }
+
+  private maxBy<T>(items: T[], getValue: (item: T) => number): T {
+    if (items.length === 0) {
+      throw new Error('Cannot choose from an empty list');
+    }
+
+    return items.reduce((best, item) =>
+      getValue(item) > getValue(best) ? item : best,
+    );
+  }
+}

--- a/mei-tra-backend/src/services/interfaces/com-player-service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/com-player-service.interface.ts
@@ -1,13 +1,7 @@
-import { DomainPlayer, Team, Field, TrumpType } from '../../types/game.types';
+import { DomainPlayer, Team } from '../../types/game.types';
 
 export interface IComPlayerService {
   createComPlayer(seatIndex: number, team: Team): DomainPlayer;
-  selectBestCard(
-    hand: string[],
-    field: Field | null,
-    trump: TrumpType | null,
-  ): string;
-  selectBaseSuit(hand: string[], trump: TrumpType | null): string;
   isComPlayer(
     player: DomainPlayer | { isCOM?: boolean; playerId: string },
   ): boolean;

--- a/mei-tra-backend/src/services/interfaces/com-strategy-service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/com-strategy-service.interface.ts
@@ -1,9 +1,4 @@
-import {
-  DomainPlayer,
-  Field,
-  GameState,
-  TrumpType,
-} from '../../types/game.types';
+import { DomainPlayer, GameState, TrumpType } from '../../types/game.types';
 
 export type ComBlowAction =
   | {
@@ -20,9 +15,4 @@ export interface IComStrategyService {
   chooseNegriCard(state: GameState, comPlayer: DomainPlayer): string;
   choosePlayCard(state: GameState, comPlayer: DomainPlayer): string;
   chooseBaseSuit(state: GameState, comPlayer: DomainPlayer): string;
-  getLegalPlayCards(
-    hand: string[],
-    field: Field | null,
-    trump: TrumpType | null,
-  ): string[];
 }

--- a/mei-tra-backend/src/services/interfaces/com-strategy-service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/com-strategy-service.interface.ts
@@ -1,0 +1,28 @@
+import {
+  DomainPlayer,
+  Field,
+  GameState,
+  TrumpType,
+} from '../../types/game.types';
+
+export type ComBlowAction =
+  | {
+      type: 'declare';
+      declaration: {
+        trumpType: TrumpType;
+        numberOfPairs: number;
+      };
+    }
+  | { type: 'pass' };
+
+export interface IComStrategyService {
+  chooseBlowAction(state: GameState, comPlayer: DomainPlayer): ComBlowAction;
+  chooseNegriCard(state: GameState, comPlayer: DomainPlayer): string;
+  choosePlayCard(state: GameState, comPlayer: DomainPlayer): string;
+  chooseBaseSuit(state: GameState, comPlayer: DomainPlayer): string;
+  getLegalPlayCards(
+    hand: string[],
+    field: Field | null,
+    trump: TrumpType | null,
+  ): string[];
+}

--- a/mei-tra-backend/src/services/interfaces/play-service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/play-service.interface.ts
@@ -6,4 +6,17 @@ export interface IPlayService {
     players: DomainPlayer[],
     trumpSuit: TrumpType | null,
   ): DomainPlayer | null;
+
+  getLegalPlayCards(
+    hand: string[],
+    field: Field | null,
+    trump: TrumpType | null,
+  ): string[];
+
+  getCardPlayError(
+    hand: string[],
+    field: Field,
+    trump: TrumpType | null,
+    card: string,
+  ): string | null;
 }

--- a/mei-tra-backend/src/services/play.service.ts
+++ b/mei-tra-backend/src/services/play.service.ts
@@ -5,6 +5,14 @@ import { IPlayService } from './interfaces/play-service.interface';
 
 @Injectable()
 export class PlayService implements IPlayService {
+  private readonly trumpToSuit: Record<TrumpType, string> = {
+    tra: '',
+    herz: '♥',
+    daiya: '♦',
+    club: '♣',
+    zuppe: '♠',
+  };
+
   constructor(private readonly cardService: CardService) {}
 
   determineFieldWinner(
@@ -62,5 +70,88 @@ export class PlayService implements IPlayService {
     });
 
     return winner;
+  }
+
+  getLegalPlayCards(
+    hand: string[],
+    field: Field | null,
+    trump: TrumpType | null,
+  ): string[] {
+    if (hand.length === 0) {
+      return [];
+    }
+
+    if (hand.length === 2 && hand.includes('JOKER')) {
+      return ['JOKER'];
+    }
+
+    if (!field || field.cards.length === 0 || !field.baseCard) {
+      return [...hand];
+    }
+
+    const baseSuit = this.resolveFieldBaseSuit(field, trump);
+    if (!baseSuit) {
+      return [...hand];
+    }
+
+    const suitCards = hand.filter(
+      (card) =>
+        card !== 'JOKER' &&
+        this.cardService.getCardSuit(card, trump, baseSuit) === baseSuit,
+    );
+    const jokerCards = hand.filter((card) => card === 'JOKER');
+
+    if (suitCards.length > 0) {
+      return [...suitCards, ...jokerCards];
+    }
+
+    const trumpSuit = trump ? this.trumpToSuit[trump] : '';
+    const hasJoker = hand.includes('JOKER');
+    const hasTrumpSuit = trumpSuit
+      ? hand.some(
+          (card) =>
+            card !== 'JOKER' &&
+            this.cardService.getCardSuit(card, trump, baseSuit) === trumpSuit,
+        )
+      : false;
+
+    if (hasJoker && baseSuit === trumpSuit && !hasTrumpSuit) {
+      return ['JOKER'];
+    }
+
+    return [...hand];
+  }
+
+  getCardPlayError(
+    hand: string[],
+    field: Field,
+    trump: TrumpType | null,
+    card: string,
+  ): string | null {
+    if (hand.length === 2 && hand.includes('JOKER') && card !== 'JOKER') {
+      return 'In Tanzen round, you must play the Joker if you have it.';
+    }
+
+    const legalCards = this.getLegalPlayCards(hand, field, trump);
+    if (legalCards.includes(card)) {
+      return null;
+    }
+
+    const baseSuit = this.resolveFieldBaseSuit(field, trump);
+    const trumpSuit = trump ? this.trumpToSuit[trump] : '';
+
+    if (baseSuit && baseSuit === trumpSuit && hand.includes('JOKER')) {
+      return `You must play the Joker since you have no ${trumpSuit} cards.`;
+    }
+
+    return baseSuit ? `You must play a card of suit ${baseSuit}.` : null;
+  }
+
+  private resolveFieldBaseSuit(field: Field, trump: TrumpType | null): string {
+    if (field.baseCard === 'JOKER') {
+      return field.baseSuit ?? '';
+    }
+
+    return this.cardService.getCardSuit(field.baseCard, trump, field.baseSuit);
   }
 }

--- a/mei-tra-backend/src/use-cases/__tests__/game-event-instrumentation.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game-event-instrumentation.spec.ts
@@ -3,6 +3,24 @@ import { PlayCardUseCase } from '../play-card.use-case';
 import { ProcessGameOverUseCase } from '../process-game-over.use-case';
 import { IRoomService } from '../../services/interfaces/room-service.interface';
 import { IGameEventLogService } from '../../services/interfaces/game-event-log.service.interface';
+import { ICardService } from '../../services/interfaces/card-service.interface';
+
+const createCardServiceMock = () =>
+  ({
+    getCardSuit: (
+      card: string,
+      _trumpType?: Parameters<ICardService['getCardSuit']>[1],
+      baseSuit?: string,
+    ): string => {
+      if (card === 'JOKER') {
+        return baseSuit ?? '';
+      }
+      if (card.startsWith('10')) {
+        return card.slice(2);
+      }
+      return card.slice(-1);
+    },
+  }) as unknown as ICardService;
 
 describe('Game event instrumentation', () => {
   it('logs game_started when a game begins', async () => {
@@ -108,7 +126,11 @@ describe('Game event instrumentation', () => {
       log: jest.fn().mockResolvedValue(undefined),
     } as unknown as IGameEventLogService;
 
-    const useCase = new PlayCardUseCase(roomService, gameEventLogService);
+    const useCase = new PlayCardUseCase(
+      roomService,
+      createCardServiceMock(),
+      gameEventLogService,
+    );
 
     await useCase.execute({ roomId: 'room-1', actorId: 'user-1', card: 'AS' });
 

--- a/mei-tra-backend/src/use-cases/__tests__/game-event-instrumentation.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game-event-instrumentation.spec.ts
@@ -3,24 +3,8 @@ import { PlayCardUseCase } from '../play-card.use-case';
 import { ProcessGameOverUseCase } from '../process-game-over.use-case';
 import { IRoomService } from '../../services/interfaces/room-service.interface';
 import { IGameEventLogService } from '../../services/interfaces/game-event-log.service.interface';
-import { ICardService } from '../../services/interfaces/card-service.interface';
-
-const createCardServiceMock = () =>
-  ({
-    getCardSuit: (
-      card: string,
-      _trumpType?: Parameters<ICardService['getCardSuit']>[1],
-      baseSuit?: string,
-    ): string => {
-      if (card === 'JOKER') {
-        return baseSuit ?? '';
-      }
-      if (card.startsWith('10')) {
-        return card.slice(2);
-      }
-      return card.slice(-1);
-    },
-  }) as unknown as ICardService;
+import { CardService } from '../../services/card.service';
+import { PlayService } from '../../services/play.service';
 
 describe('Game event instrumentation', () => {
   it('logs game_started when a game begins', async () => {
@@ -128,7 +112,7 @@ describe('Game event instrumentation', () => {
 
     const useCase = new PlayCardUseCase(
       roomService,
-      createCardServiceMock(),
+      new PlayService(new CardService()),
       gameEventLogService,
     );
 

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -69,6 +69,15 @@ describe('Game Use Cases', () => {
       generateDeck: jest.fn(() =>
         Array.from({ length: 52 }, (_, idx) => `C${idx}`),
       ),
+      getCardSuit: jest.fn((card: string, _trumpType, baseSuit) => {
+        if (card === 'JOKER') {
+          return baseSuit ?? '';
+        }
+        if (card.startsWith('10')) {
+          return card.slice(2);
+        }
+        return card.slice(-1);
+      }),
     };
     return mock as jest.Mocked<ICardService>;
   };
@@ -986,7 +995,7 @@ describe('Game Use Cases', () => {
   describe('PlayCardUseCase', () => {
     it('plays a card and advances turn when field not complete', async () => {
       const roomService = createRoomServiceMock();
-      const useCase = new PlayCardUseCase(roomService);
+      const useCase = new PlayCardUseCase(roomService, createCardServiceMock());
 
       const currentField: Field = {
         cards: [],
@@ -1077,7 +1086,7 @@ describe('Game Use Cases', () => {
 
     it('returns complete field trigger when field reaches four cards', async () => {
       const roomService = createRoomServiceMock();
-      const useCase = new PlayCardUseCase(roomService);
+      const useCase = new PlayCardUseCase(roomService, createCardServiceMock());
 
       const fieldBefore: Field = {
         cards: ['C1', 'C2', 'C3'],
@@ -1136,6 +1145,149 @@ describe('Game Use Cases', () => {
       expect(result.completeFieldTrigger).toBeDefined();
       expect(result.completeFieldTrigger?.delayMs).toBe(3000);
     });
+
+    it('rejects off-suit play when the player has the base suit', async () => {
+      const roomService = createRoomServiceMock();
+      const useCase = new PlayCardUseCase(roomService, createCardServiceMock());
+      const currentField: Field = {
+        cards: ['K♠'],
+        playedBy: ['player-2'],
+        baseCard: 'K♠',
+        dealerId: 'player-2',
+        isComplete: false,
+      };
+      const state = {
+        players: [
+          {
+            playerId: 'player-1',
+            name: 'Player 1',
+            hand: ['5♠', 'A♥'],
+            team: 0 as Team,
+            isPasser: false,
+          },
+        ],
+        blowState: { currentTrump: 'club' as const },
+        playState: { currentField },
+        currentPlayerIndex: 0,
+      };
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        saveState: jest.fn(),
+        nextTurn: jest.fn(),
+        findPlayerByActorId: jest.fn(() => state.players[0]),
+        isPlayerTurn: jest.fn(() => true),
+      } as unknown as GameStateService;
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const result = await useCase.execute({
+        roomId: 'room-1',
+        actorId: 'user-1',
+        card: 'A♥',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('You must play a card of suit ♠');
+      expect(state.players[0].hand).toEqual(['5♠', 'A♥']);
+      expect(roomGameState.saveState).not.toHaveBeenCalled();
+    });
+
+    it('allows off-suit play when the player has no base suit', async () => {
+      const roomService = createRoomServiceMock();
+      const useCase = new PlayCardUseCase(roomService, createCardServiceMock());
+      const currentField: Field = {
+        cards: ['K♠'],
+        playedBy: ['player-2'],
+        baseCard: 'K♠',
+        dealerId: 'player-2',
+        isComplete: false,
+      };
+      const state = {
+        players: [
+          {
+            playerId: 'player-1',
+            name: 'Player 1',
+            hand: ['A♥'],
+            team: 0 as Team,
+            isPasser: false,
+          },
+          {
+            playerId: 'player-2',
+            name: 'Player 2',
+            hand: [],
+            team: 1 as Team,
+            isPasser: false,
+          },
+        ],
+        blowState: { currentTrump: 'club' as const },
+        playState: { currentField },
+        currentPlayerIndex: 0,
+      };
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        saveState: jest.fn(),
+        nextTurn: jest.fn(() => {
+          state.currentPlayerIndex = 1;
+        }),
+        findPlayerByActorId: jest.fn(() => state.players[0]),
+        isPlayerTurn: jest.fn(() => true),
+      } as unknown as GameStateService;
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const result = await useCase.execute({
+        roomId: 'room-1',
+        actorId: 'user-1',
+        card: 'A♥',
+      });
+
+      expect(result.success).toBe(true);
+      expect(currentField.cards).toEqual(['K♠', 'A♥']);
+      expect(roomGameState.saveState).toHaveBeenCalled();
+    });
+
+    it('requires Joker in Tanzen when the player has it', async () => {
+      const roomService = createRoomServiceMock();
+      const useCase = new PlayCardUseCase(roomService, createCardServiceMock());
+      const currentField: Field = {
+        cards: [],
+        playedBy: [],
+        baseCard: '',
+        dealerId: 'player-1',
+        isComplete: false,
+      };
+      const state = {
+        players: [
+          {
+            playerId: 'player-1',
+            name: 'Player 1',
+            hand: ['JOKER', 'A♥'],
+            team: 0 as Team,
+            isPasser: false,
+          },
+        ],
+        blowState: { currentTrump: 'club' as const },
+        playState: { currentField },
+        currentPlayerIndex: 0,
+      };
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        saveState: jest.fn(),
+        nextTurn: jest.fn(),
+        findPlayerByActorId: jest.fn(() => state.players[0]),
+        isPlayerTurn: jest.fn(() => true),
+      } as unknown as GameStateService;
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const result = await useCase.execute({
+        roomId: 'room-1',
+        actorId: 'user-1',
+        card: 'A♥',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('must play the Joker');
+      expect(state.players[0].hand).toEqual(['JOKER', 'A♥']);
+      expect(roomGameState.saveState).not.toHaveBeenCalled();
+    });
   });
 
   describe('ComAutoPlayUseCase', () => {
@@ -1143,11 +1295,19 @@ describe('Game Use Cases', () => {
       const roomService = createRoomServiceMock();
       const comPlayerService = {
         createComPlayer: jest.fn(),
-        selectBestCard: jest.fn(() => 'JOKER'),
-        selectBaseSuit: jest.fn(() => '♣'),
         isComPlayer: jest.fn(() => true),
       };
+      const comStrategyService = {
+        chooseBlowAction: jest.fn(() => ({ type: 'pass' })),
+        chooseNegriCard: jest.fn(),
+        choosePlayCard: jest.fn(() => 'JOKER'),
+        chooseBaseSuit: jest.fn(() => '♣'),
+        getLegalPlayCards: jest.fn(),
+      };
       const playCardUseCase = {
+        execute: jest.fn(),
+      };
+      const declareBlowUseCase = {
         execute: jest.fn(),
       };
       const passBlowUseCase = {
@@ -1159,7 +1319,9 @@ describe('Game Use Cases', () => {
       const useCase = new ComAutoPlayUseCase(
         roomService,
         comPlayerService as never,
+        comStrategyService as never,
         playCardUseCase as never,
+        declareBlowUseCase as never,
         passBlowUseCase as never,
         selectNegriUseCase as never,
       );
@@ -1241,9 +1403,13 @@ describe('Game Use Cases', () => {
       const result = await useCase.execute({ roomId: 'room-1' });
 
       expect(result.success).toBe(true);
-      expect(comPlayerService.selectBaseSuit).toHaveBeenCalledWith(
-        ['9♣'],
-        'club',
+      expect(comStrategyService.choosePlayCard).toHaveBeenCalledWith(
+        state,
+        comPlayer,
+      );
+      expect(comStrategyService.chooseBaseSuit).toHaveBeenCalledWith(
+        state,
+        comPlayer,
       );
       expect(state.playState.currentField.baseSuit).toBe('♣');
       expect(
@@ -1261,11 +1427,19 @@ describe('Game Use Cases', () => {
       const roomService = createRoomServiceMock();
       const comPlayerService = {
         createComPlayer: jest.fn(),
-        selectBestCard: jest.fn(),
-        selectBaseSuit: jest.fn(),
         isComPlayer: jest.fn(() => true),
       };
+      const comStrategyService = {
+        chooseBlowAction: jest.fn(() => ({ type: 'pass' })),
+        chooseNegriCard: jest.fn(() => '6♥'),
+        choosePlayCard: jest.fn(),
+        chooseBaseSuit: jest.fn(),
+        getLegalPlayCards: jest.fn(),
+      };
       const playCardUseCase = {
+        execute: jest.fn(),
+      };
+      const declareBlowUseCase = {
         execute: jest.fn(),
       };
       const passBlowUseCase = {
@@ -1277,7 +1451,9 @@ describe('Game Use Cases', () => {
       const useCase = new ComAutoPlayUseCase(
         roomService,
         comPlayerService as never,
+        comStrategyService as never,
         playCardUseCase as never,
+        declareBlowUseCase as never,
         passBlowUseCase as never,
         selectNegriUseCase as never,
       );
@@ -1353,6 +1529,10 @@ describe('Game Use Cases', () => {
       const result = await useCase.execute({ roomId: 'room-1' });
 
       expect(result.success).toBe(true);
+      expect(comStrategyService.chooseNegriCard).toHaveBeenCalledWith(
+        state,
+        comPlayer,
+      );
       expect(selectNegriUseCase.execute).toHaveBeenCalledWith({
         roomId: 'room-1',
         actorId: 'com-timeout-1',
@@ -1371,6 +1551,97 @@ describe('Game Use Cases', () => {
         },
       ]);
       expect(result.shouldContinue).toBe(true);
+    });
+
+    it('declares blow when the COM strategy chooses a declaration', async () => {
+      const roomService = createRoomServiceMock();
+      const comPlayerService = {
+        createComPlayer: jest.fn(),
+        isComPlayer: jest.fn(() => true),
+      };
+      const comStrategyService = {
+        chooseBlowAction: jest.fn(() => ({
+          type: 'declare',
+          declaration: { trumpType: 'herz', numberOfPairs: 6 },
+        })),
+        chooseNegriCard: jest.fn(),
+        choosePlayCard: jest.fn(),
+        chooseBaseSuit: jest.fn(),
+        getLegalPlayCards: jest.fn(),
+      };
+      const playCardUseCase = {
+        execute: jest.fn(),
+      };
+      const declareBlowUseCase = {
+        execute: jest.fn(),
+      };
+      const passBlowUseCase = {
+        execute: jest.fn(),
+      };
+      const selectNegriUseCase = {
+        execute: jest.fn(),
+      };
+      const useCase = new ComAutoPlayUseCase(
+        roomService,
+        comPlayerService as never,
+        comStrategyService as never,
+        playCardUseCase as never,
+        declareBlowUseCase as never,
+        passBlowUseCase as never,
+        selectNegriUseCase as never,
+      );
+
+      const comPlayer: DomainPlayer = {
+        playerId: 'com-0',
+        name: 'COM',
+        hand: ['JOKER', 'J♥', 'A♥'],
+        team: 0,
+        isPasser: false,
+        isCOM: true,
+      };
+      const state = {
+        players: [comPlayer],
+        currentPlayerIndex: 0,
+        gamePhase: 'blow' as GamePhase,
+        blowState: {
+          currentTrump: null,
+          currentHighestDeclaration: null,
+          declarations: [],
+          actionHistory: [],
+          lastPasser: null,
+          isRoundCancelled: false,
+          currentBlowIndex: 0,
+        },
+      };
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        getCurrentPlayer: jest.fn(
+          () => state.players[state.currentPlayerIndex],
+        ),
+      } as unknown as GameStateService;
+
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+      declareBlowUseCase.execute.mockResolvedValue({
+        success: true,
+        events: [
+          {
+            scope: 'room',
+            roomId: 'room-1',
+            event: 'blow-updated',
+            payload: {},
+          },
+        ],
+      });
+
+      const result = await useCase.execute({ roomId: 'room-1' });
+
+      expect(result.success).toBe(true);
+      expect(declareBlowUseCase.execute).toHaveBeenCalledWith({
+        roomId: 'room-1',
+        actorId: 'com-0',
+        declaration: { trumpType: 'herz', numberOfPairs: 6 },
+      });
+      expect(passBlowUseCase.execute).not.toHaveBeenCalled();
     });
   });
 

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -31,6 +31,8 @@ import { ICardService } from '../../services/interfaces/card-service.interface';
 import { IPlayService } from '../../services/interfaces/play-service.interface';
 import { IScoreService } from '../../services/interfaces/score-service.interface';
 import { IGameEventLogService } from '../../services/interfaces/game-event-log.service.interface';
+import { CardService } from '../../services/card.service';
+import { PlayService } from '../../services/play.service';
 describe('Game Use Cases', () => {
   const createRoomServiceMock = () => {
     const mock: Partial<jest.Mocked<IRoomService>> = {
@@ -81,6 +83,8 @@ describe('Game Use Cases', () => {
     };
     return mock as jest.Mocked<ICardService>;
   };
+
+  const createPlayRulesService = () => new PlayService(new CardService());
 
   const createPlayServiceMock = (winnerId: string) => {
     const determineFieldWinnerMock = jest.fn<
@@ -995,7 +999,10 @@ describe('Game Use Cases', () => {
   describe('PlayCardUseCase', () => {
     it('plays a card and advances turn when field not complete', async () => {
       const roomService = createRoomServiceMock();
-      const useCase = new PlayCardUseCase(roomService, createCardServiceMock());
+      const useCase = new PlayCardUseCase(
+        roomService,
+        createPlayRulesService(),
+      );
 
       const currentField: Field = {
         cards: [],
@@ -1086,7 +1093,10 @@ describe('Game Use Cases', () => {
 
     it('returns complete field trigger when field reaches four cards', async () => {
       const roomService = createRoomServiceMock();
-      const useCase = new PlayCardUseCase(roomService, createCardServiceMock());
+      const useCase = new PlayCardUseCase(
+        roomService,
+        createPlayRulesService(),
+      );
 
       const fieldBefore: Field = {
         cards: ['C1', 'C2', 'C3'],
@@ -1148,7 +1158,10 @@ describe('Game Use Cases', () => {
 
     it('rejects off-suit play when the player has the base suit', async () => {
       const roomService = createRoomServiceMock();
-      const useCase = new PlayCardUseCase(roomService, createCardServiceMock());
+      const useCase = new PlayCardUseCase(
+        roomService,
+        createPlayRulesService(),
+      );
       const currentField: Field = {
         cards: ['K♠'],
         playedBy: ['player-2'],
@@ -1193,7 +1206,10 @@ describe('Game Use Cases', () => {
 
     it('allows off-suit play when the player has no base suit', async () => {
       const roomService = createRoomServiceMock();
-      const useCase = new PlayCardUseCase(roomService, createCardServiceMock());
+      const useCase = new PlayCardUseCase(
+        roomService,
+        createPlayRulesService(),
+      );
       const currentField: Field = {
         cards: ['K♠'],
         playedBy: ['player-2'],
@@ -1246,7 +1262,10 @@ describe('Game Use Cases', () => {
 
     it('requires Joker in Tanzen when the player has it', async () => {
       const roomService = createRoomServiceMock();
-      const useCase = new PlayCardUseCase(roomService, createCardServiceMock());
+      const useCase = new PlayCardUseCase(
+        roomService,
+        createPlayRulesService(),
+      );
       const currentField: Field = {
         cards: [],
         playedBy: [],
@@ -1302,7 +1321,6 @@ describe('Game Use Cases', () => {
         chooseNegriCard: jest.fn(),
         choosePlayCard: jest.fn(() => 'JOKER'),
         chooseBaseSuit: jest.fn(() => '♣'),
-        getLegalPlayCards: jest.fn(),
       };
       const playCardUseCase = {
         execute: jest.fn(),
@@ -1434,7 +1452,6 @@ describe('Game Use Cases', () => {
         chooseNegriCard: jest.fn(() => '6♥'),
         choosePlayCard: jest.fn(),
         chooseBaseSuit: jest.fn(),
-        getLegalPlayCards: jest.fn(),
       };
       const playCardUseCase = {
         execute: jest.fn(),
@@ -1567,7 +1584,6 @@ describe('Game Use Cases', () => {
         chooseNegriCard: jest.fn(),
         choosePlayCard: jest.fn(),
         chooseBaseSuit: jest.fn(),
-        getLegalPlayCards: jest.fn(),
       };
       const playCardUseCase = {
         execute: jest.fn(),

--- a/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
+++ b/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
@@ -6,10 +6,15 @@ import {
 } from './interfaces/com-autoplay-use-case.interface';
 import { IRoomService } from '../services/interfaces/room-service.interface';
 import { IComPlayerService } from '../services/interfaces/com-player-service.interface';
+import { IComStrategyService } from '../services/interfaces/com-strategy-service.interface';
 import {
   IPlayCardUseCase,
   PlayCardResponse,
 } from './interfaces/play-card.use-case.interface';
+import {
+  DeclareBlowResponse,
+  IDeclareBlowUseCase,
+} from './interfaces/declare-blow.use-case.interface';
 import {
   IPassBlowUseCase,
   PassBlowResponse,
@@ -35,8 +40,12 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
     private readonly roomService: IRoomService,
     @Inject('IComPlayerService')
     private readonly comPlayerService: IComPlayerService,
+    @Inject('IComStrategyService')
+    private readonly comStrategyService: IComStrategyService,
     @Inject('IPlayCardUseCase')
     private readonly playCardUseCase: IPlayCardUseCase,
+    @Inject('IDeclareBlowUseCase')
+    private readonly declareBlowUseCase: IDeclareBlowUseCase,
     @Inject('IPassBlowUseCase')
     private readonly passBlowUseCase: IPassBlowUseCase,
     @Inject('ISelectNegriUseCase')
@@ -87,7 +96,10 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       state.playState?.negriCard == null &&
       state.blowState.currentHighestDeclaration?.playerId === comPlayer.playerId
     ) {
-      const negriCard = comPlayer.hand[0];
+      const negriCard = this.comStrategyService.chooseNegriCard(
+        state,
+        comPlayer,
+      );
 
       if (!negriCard) {
         return {
@@ -120,14 +132,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       };
     }
 
-    const currentField = state.playState?.currentField ?? null;
-    const currentTrump = state.blowState?.currentTrump ?? null;
-
-    const bestCard = this.comPlayerService.selectBestCard(
-      comPlayer.hand,
-      currentField,
-      currentTrump,
-    );
+    const bestCard = this.comStrategyService.choosePlayCard(state, comPlayer);
 
     const result: PlayCardResponse = await this.playCardUseCase.execute({
       roomId,
@@ -149,9 +154,9 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       !updatedField.baseSuit &&
       updatedField.dealerId === comPlayer.playerId
     ) {
-      updatedField.baseSuit = this.comPlayerService.selectBaseSuit(
-        comPlayer.hand,
-        updatedState.blowState?.currentTrump ?? null,
+      updatedField.baseSuit = this.comStrategyService.chooseBaseSuit(
+        updatedState,
+        comPlayer,
       );
 
       events.push({
@@ -175,12 +180,14 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       await gameState.saveState();
     }
 
-    // Continue if server advanced the turn or completed a field
+    const nextPlayer = updatedState.players[updatedState.currentPlayerIndex];
+    // Continue from the persisted turn owner instead of trusting only emitted
+    // events; this keeps autoplay alive even when a use-case emits no turn event.
     const shouldContinue =
       !completeFieldTrigger &&
-      events.some(
-        (e) => e.event === 'update-turn' || e.event === 'field-complete',
-      );
+      result.success &&
+      !!nextPlayer &&
+      this.comPlayerService.isComPlayer(nextPlayer);
 
     return {
       success: result.success,
@@ -197,11 +204,21 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
     comPlayer: DomainPlayer,
     gameState: GameStateService,
   ): Promise<ComAutoPlayResponse> {
-    // COMは常にパス
-    const result: PassBlowResponse = await this.passBlowUseCase.execute({
-      roomId,
-      actorId: comPlayer.playerId,
-    });
+    const action = this.comStrategyService.chooseBlowAction(
+      gameState.getState(),
+      comPlayer,
+    );
+    const result: PassBlowResponse | DeclareBlowResponse =
+      action.type === 'declare'
+        ? await this.declareBlowUseCase.execute({
+            roomId,
+            actorId: comPlayer.playerId,
+            declaration: action.declaration,
+          })
+        : await this.passBlowUseCase.execute({
+            roomId,
+            actorId: comPlayer.playerId,
+          });
 
     const { events = [], delayedEvents = [] } =
       result as ResponseWithDelayed<PassBlowResponse>;

--- a/mei-tra-backend/src/use-cases/play-card.use-case.ts
+++ b/mei-tra-backend/src/use-cases/play-card.use-case.ts
@@ -12,13 +12,23 @@ import {
   resolvePlayerByActorId,
   resolveTransportPlayers,
 } from './helpers/player-resolution.helper';
+import { ICardService } from '../services/interfaces/card-service.interface';
+import { Field, TrumpType } from '../types/game.types';
 
 @Injectable()
 export class PlayCardUseCase implements IPlayCardUseCase {
   private readonly logger = new Logger(PlayCardUseCase.name);
+  private readonly trumpToSuit: Record<TrumpType, string> = {
+    tra: '',
+    herz: '♥',
+    daiya: '♦',
+    club: '♣',
+    zuppe: '♠',
+  };
 
   constructor(
     @Inject('IRoomService') private readonly roomService: IRoomService,
+    @Inject('ICardService') private readonly cardService: ICardService,
     @Optional()
     @Inject('IGameEventLogService')
     private readonly gameEventLogService?: IGameEventLogService,
@@ -66,6 +76,16 @@ export class PlayCardUseCase implements IPlayCardUseCase {
           success: false,
           error: 'Card already played on the field',
         };
+      }
+
+      const legalPlayError = this.getLegalPlayError(
+        player.hand,
+        state.playState.currentField,
+        state.blowState?.currentTrump ?? null,
+        card,
+      );
+      if (legalPlayError) {
+        return { success: false, error: legalPlayError };
       }
 
       // Remove the card from player's hand
@@ -151,5 +171,63 @@ export class PlayCardUseCase implements IPlayCardUseCase {
       );
       return { success: false, error: 'Internal server error' };
     }
+  }
+
+  private getLegalPlayError(
+    hand: string[],
+    currentField: Field,
+    currentTrump: TrumpType | null,
+    card: string,
+  ): string | null {
+    if (hand.length === 2 && hand.includes('JOKER') && card !== 'JOKER') {
+      return 'In Tanzen round, you must play the Joker if you have it.';
+    }
+
+    if (card === 'JOKER') {
+      return null;
+    }
+
+    if (!currentField.cards.length || !currentField.baseCard) {
+      return null;
+    }
+
+    const baseSuit =
+      currentField.baseCard === 'JOKER'
+        ? currentField.baseSuit
+        : this.cardService.getCardSuit(
+            currentField.baseCard,
+            currentTrump,
+            currentField.baseSuit,
+          );
+
+    if (!baseSuit) {
+      return null;
+    }
+
+    const cardSuit = this.cardService.getCardSuit(card, currentTrump, baseSuit);
+    const hasBaseSuit = hand.some(
+      (handCard) =>
+        handCard !== 'JOKER' &&
+        this.cardService.getCardSuit(handCard, currentTrump, baseSuit) ===
+          baseSuit,
+    );
+
+    if (cardSuit !== baseSuit && hasBaseSuit) {
+      return `You must play a card of suit ${baseSuit}.`;
+    }
+
+    const trumpSuit = currentTrump ? this.trumpToSuit[currentTrump] : '';
+    const hasNonJokerTrump = hand.some(
+      (handCard) =>
+        handCard !== 'JOKER' &&
+        this.cardService.getCardSuit(handCard, currentTrump, baseSuit) ===
+          trumpSuit,
+    );
+
+    if (baseSuit === trumpSuit && hand.includes('JOKER') && !hasNonJokerTrump) {
+      return `You must play the Joker since you have no ${trumpSuit} cards.`;
+    }
+
+    return null;
   }
 }

--- a/mei-tra-backend/src/use-cases/play-card.use-case.ts
+++ b/mei-tra-backend/src/use-cases/play-card.use-case.ts
@@ -12,23 +12,15 @@ import {
   resolvePlayerByActorId,
   resolveTransportPlayers,
 } from './helpers/player-resolution.helper';
-import { ICardService } from '../services/interfaces/card-service.interface';
-import { Field, TrumpType } from '../types/game.types';
+import { IPlayService } from '../services/interfaces/play-service.interface';
 
 @Injectable()
 export class PlayCardUseCase implements IPlayCardUseCase {
   private readonly logger = new Logger(PlayCardUseCase.name);
-  private readonly trumpToSuit: Record<TrumpType, string> = {
-    tra: '',
-    herz: '♥',
-    daiya: '♦',
-    club: '♣',
-    zuppe: '♠',
-  };
 
   constructor(
     @Inject('IRoomService') private readonly roomService: IRoomService,
-    @Inject('ICardService') private readonly cardService: ICardService,
+    @Inject('IPlayService') private readonly playService: IPlayService,
     @Optional()
     @Inject('IGameEventLogService')
     private readonly gameEventLogService?: IGameEventLogService,
@@ -78,7 +70,7 @@ export class PlayCardUseCase implements IPlayCardUseCase {
         };
       }
 
-      const legalPlayError = this.getLegalPlayError(
+      const legalPlayError = this.playService.getCardPlayError(
         player.hand,
         state.playState.currentField,
         state.blowState?.currentTrump ?? null,
@@ -171,63 +163,5 @@ export class PlayCardUseCase implements IPlayCardUseCase {
       );
       return { success: false, error: 'Internal server error' };
     }
-  }
-
-  private getLegalPlayError(
-    hand: string[],
-    currentField: Field,
-    currentTrump: TrumpType | null,
-    card: string,
-  ): string | null {
-    if (hand.length === 2 && hand.includes('JOKER') && card !== 'JOKER') {
-      return 'In Tanzen round, you must play the Joker if you have it.';
-    }
-
-    if (card === 'JOKER') {
-      return null;
-    }
-
-    if (!currentField.cards.length || !currentField.baseCard) {
-      return null;
-    }
-
-    const baseSuit =
-      currentField.baseCard === 'JOKER'
-        ? currentField.baseSuit
-        : this.cardService.getCardSuit(
-            currentField.baseCard,
-            currentTrump,
-            currentField.baseSuit,
-          );
-
-    if (!baseSuit) {
-      return null;
-    }
-
-    const cardSuit = this.cardService.getCardSuit(card, currentTrump, baseSuit);
-    const hasBaseSuit = hand.some(
-      (handCard) =>
-        handCard !== 'JOKER' &&
-        this.cardService.getCardSuit(handCard, currentTrump, baseSuit) ===
-          baseSuit,
-    );
-
-    if (cardSuit !== baseSuit && hasBaseSuit) {
-      return `You must play a card of suit ${baseSuit}.`;
-    }
-
-    const trumpSuit = currentTrump ? this.trumpToSuit[currentTrump] : '';
-    const hasNonJokerTrump = hand.some(
-      (handCard) =>
-        handCard !== 'JOKER' &&
-        this.cardService.getCardSuit(handCard, currentTrump, baseSuit) ===
-          trumpSuit,
-    );
-
-    if (baseSuit === trumpSuit && hand.includes('JOKER') && !hasNonJokerTrump) {
-      return `You must play the Joker since you have no ${trumpSuit} cards.`;
-    }
-
-    return null;
   }
 }

--- a/mei-tra-frontend/components/game/PlayerHand/hooks/useCardValidation.ts
+++ b/mei-tra-frontend/components/game/PlayerHand/hooks/useCardValidation.ts
@@ -20,7 +20,7 @@ const getTrumpSuit = (trumpType: TrumpType): string => {
 
 const isSecondaryJack = (card: string, trumpType: TrumpType): boolean => {
   return card === getSecondaryJack(trumpType);
-}
+};
 
 const getPrimaryJack = (trumpType: TrumpType): string => {
   switch (trumpType) {
@@ -37,7 +37,7 @@ const getPrimaryJack = (trumpType: TrumpType): string => {
     default:
       return 'J♥';
   }
-}
+};
 
 const getSecondaryJack = (trumpType: TrumpType): string => {
   switch (trumpType) {
@@ -54,7 +54,7 @@ const getSecondaryJack = (trumpType: TrumpType): string => {
     default:
       return 'J♦';
   }
-}
+};
 
 const getCardSuit = (
   card: string,
@@ -79,7 +79,7 @@ const getCardSuit = (
   }
 
   return card.slice(-1);
-}
+};
 
 export const useCardValidation = (
   playerHand: string[],
@@ -110,7 +110,10 @@ export const useCardValidation = (
 
       const baseCard = currentField.baseCard;
       // If baseCard is Joker, use the selected baseSuit
-      const baseSuit = baseCard === 'JOKER' ? currentField.baseSuit : getCardSuit(baseCard, currentTrump, currentField.baseSuit);
+      const baseSuit =
+        baseCard === 'JOKER'
+          ? currentField.baseSuit
+          : getCardSuit(baseCard, currentTrump, currentField.baseSuit);
       const cardSuit = getCardSuit(card, currentTrump, baseSuit);
 
       // If no trump is set (Tra) or trump is not Tra, use normal suit matching rules
@@ -119,7 +122,11 @@ export const useCardValidation = (
           return { isValid: true };
         }
 
-        if (playerHand.some((c) => getCardSuit(c) === baseSuit)) {
+        if (
+          playerHand.some(
+            (c) => c !== 'JOKER' && getCardSuit(c) === baseSuit,
+          )
+        ) {
           return {
             isValid: false,
             message: `You must play a card of suit ${baseSuit}`,
@@ -136,7 +143,9 @@ export const useCardValidation = (
         // If player has the base suit, they must play it
         if (baseSuit !== cardSuit) {
           const hasBaseSuit = playerHand.some(
-            (c) => getCardSuit(c, currentTrump) === baseSuit,
+            (c) =>
+              c !== 'JOKER' &&
+              getCardSuit(c, currentTrump, baseSuit) === baseSuit,
           );
           if (hasBaseSuit) {
             return {
@@ -148,10 +157,12 @@ export const useCardValidation = (
 
         // If currentTrump matches baseSuit, player has no cards of that suit, and has Joker, they must play Joker
         if (
-          currentTrump === baseSuit &&
+          trumpSuit === baseSuit &&
           playerHand.includes('JOKER') &&
           !playerHand.some(
-            (c) => getCardSuit(c, currentTrump) === baseSuit,
+            (c) =>
+              c !== 'JOKER' &&
+              getCardSuit(c, currentTrump, baseSuit) === baseSuit,
           )
         ) {
           if (card !== 'JOKER') {
@@ -169,7 +180,9 @@ export const useCardValidation = (
           baseSuit === trumpSuit &&
           playerHand.includes('JOKER') &&
           !playerHand.some(
-            (c) => getCardSuit(c, currentTrump) === trumpSuit,
+            (c) =>
+              c !== 'JOKER' &&
+              getCardSuit(c, currentTrump, baseSuit) === trumpSuit,
           )
         ) {
           if (card !== 'JOKER') {
@@ -189,4 +202,4 @@ export const useCardValidation = (
       isValidCardPlay,
     };
   }, [playerHand, currentField, currentTrump]);
-}; 
+};


### PR DESCRIPTION
## Summary
- Add non-cheating heuristic COM strategy service for blow, negri, card play, and Joker base suit selection
- Keep COM autoplay orchestration in use-case layer and simplify COM player service
- Add backend play legality validation and align frontend card validation
- Fix COM autoplay continuation around delayed events and required broken handling

## Validation
- cd mei-tra-backend && npm test -- --runInBand
- cd mei-tra-backend && npm run lint
- cd mei-tra-backend && npm run build
- cd mei-tra-frontend && npm run lint
- cd mei-tra-frontend && npm run build