### PR TITLE
[codex] Improve broken hand replay logging

### DIFF
--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -348,9 +348,23 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       !clientSocket &&
       (targetPlayer?.isCOM || targetPlayer?.playerId.startsWith('com-'))
     ) {
+      const preparation = await this.revealBrokenHandUseCase.prepare({
+        roomId: request.roomId,
+        actorId: request.playerId,
+        playerId: request.playerId,
+      });
+
+      if (!preparation.success || !preparation.followUp) {
+        console.warn(
+          '[GameGateway] Failed to prepare COM broken hand reveal',
+          preparation.error,
+        );
+        return false;
+      }
+
       this.finalizeBrokenHandAfterDelay(
-        { roomId: request.roomId, playerId: request.playerId },
-        3000,
+        preparation.followUp,
+        preparation.delayMs ?? 3000,
       );
       return true;
     }

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -26,10 +26,7 @@ import { ITogglePlayerReadyUseCase } from './use-cases/interfaces/toggle-player-
 import { IChangePlayerTeamUseCase } from './use-cases/interfaces/change-player-team.use-case.interface';
 import { IFillWithComUseCase } from './use-cases/interfaces/fill-with-com.use-case.interface';
 import { GatewayEvent } from './use-cases/interfaces/gateway-event.interface';
-import {
-  IDeclareBlowUseCase,
-  RevealBrokenRequest,
-} from './use-cases/interfaces/declare-blow.use-case.interface';
+import { IDeclareBlowUseCase } from './use-cases/interfaces/declare-blow.use-case.interface';
 import { IPassBlowUseCase } from './use-cases/interfaces/pass-blow.use-case.interface';
 import { ISelectNegriUseCase } from './use-cases/interfaces/select-negri.use-case.interface';
 import { IPlayCardUseCase } from './use-cases/interfaces/play-card.use-case.interface';
@@ -323,72 +320,6 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }, delayMs);
   }
 
-  private async triggerRevealBrokenHand(
-    request?: RevealBrokenRequest,
-  ): Promise<boolean> {
-    if (!request) {
-      return false;
-    }
-
-    const roomGameState = await this.roomService.getRoomGameState(
-      request.roomId,
-    );
-    const state = roomGameState.getState();
-    const targetPlayer = state.players.find(
-      (player) => player.playerId === request.playerId,
-    );
-    const sessionUser =
-      roomGameState.findSessionUserByUserId(request.actorId) ??
-      roomGameState.findSessionUserBySocketId(request.actorId) ??
-      roomGameState.findSessionUserByPlayerId(request.actorId);
-    const clientSocket = sessionUser?.socketId
-      ? this.server.sockets.sockets.get(sessionUser.socketId)
-      : undefined;
-    if (
-      !clientSocket &&
-      (targetPlayer?.isCOM || targetPlayer?.playerId.startsWith('com-'))
-    ) {
-      const preparation = await this.revealBrokenHandUseCase.prepare({
-        roomId: request.roomId,
-        actorId: request.playerId,
-        playerId: request.playerId,
-      });
-
-      if (!preparation.success || !preparation.followUp) {
-        console.warn(
-          '[GameGateway] Failed to prepare COM broken hand reveal',
-          preparation.error,
-        );
-        return false;
-      }
-
-      this.finalizeBrokenHandAfterDelay(
-        preparation.followUp,
-        preparation.delayMs ?? 3000,
-      );
-      return true;
-    }
-
-    if (!clientSocket) {
-      console.warn(
-        '[GameGateway] Socket not found when handling required broken hand',
-        request,
-      );
-      return false;
-    }
-
-    try {
-      await this.handleRevealBrokenHand(clientSocket, {
-        roomId: request.roomId,
-        playerId: request.playerId,
-      });
-      return true;
-    } catch (error) {
-      console.error('Failed to trigger reveal-broken-hand flow:', error);
-      return false;
-    }
-  }
-
   private async processFieldCompletionResult(
     roomId: string,
     response: Awaited<ReturnType<ICompleteFieldUseCase['execute']>>,
@@ -492,9 +423,6 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       // イベント配信（遅延含む）
       this.dispatchEvents(result.events);
       this.dispatchEvents(result.delayedEvents);
-      const revealBrokenScheduled = await this.triggerRevealBrokenHand(
-        result.revealBrokenRequest,
-      );
 
       const delayedEvents = result.delayedEvents ?? [];
       const maxDelay = delayedEvents.reduce(
@@ -520,15 +448,11 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         return; // Wait for completion result before continuing loop
       }
 
-      if (maxDelay > 0 && !revealBrokenScheduled) {
+      if (maxDelay > 0) {
         setTimeout(
           () => this.triggerComAutoPlayIfNeeded(roomId),
           maxDelay + 100,
         );
-        return;
-      }
-
-      if (revealBrokenScheduled) {
         return;
       }
 
@@ -1234,12 +1158,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
       this.dispatchEvents(result.events);
       this.dispatchEvents(result.delayedEvents);
-      const revealBrokenScheduled = await this.triggerRevealBrokenHand(
-        result.revealBrokenRequest,
-      );
-      if (!revealBrokenScheduled) {
-        this.triggerComAutoPlayIfNeeded(data.roomId);
-      }
+      this.triggerComAutoPlayIfNeeded(data.roomId);
     } catch (error) {
       console.error('Error in handleDeclareBlow:', error);
       client.emit('error-message', 'Failed to declare blow');
@@ -1270,12 +1189,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
       this.dispatchEvents(result.events);
       this.dispatchEvents(result.delayedEvents);
-      const revealBrokenScheduled = await this.triggerRevealBrokenHand(
-        result.revealBrokenRequest,
-      );
-      if (!revealBrokenScheduled) {
-        this.triggerComAutoPlayIfNeeded(data.roomId);
-      }
+      this.triggerComAutoPlayIfNeeded(data.roomId);
     } catch (error) {
       console.error('Error in handlePassBlow:', error);
       client.emit('error-message', 'Failed to pass blow');

--- a/mei-tra-backend/src/repositories/implementations/supabase-game-history.repository.spec.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-history.repository.spec.ts
@@ -98,4 +98,50 @@ describe('SupabaseGameHistoryRepository', () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]?.id).toBe('history-2');
   });
+
+  it('deletes game history for finished rooms outside the recent limit', async () => {
+    const roomsOrder = jest.fn().mockResolvedValue({
+      data: [
+        { id: 'room-1' },
+        { id: 'room-2' },
+        { id: 'room-3' },
+        { id: 'room-4' },
+      ],
+      error: null,
+    });
+    const roomsEq = jest.fn().mockReturnValue({ order: roomsOrder });
+    const roomsSelect = jest.fn().mockReturnValue({ eq: roomsEq });
+
+    const historyIn = jest.fn().mockResolvedValue({ count: 2, error: null });
+    const historyDelete = jest.fn().mockReturnValue({ in: historyIn });
+
+    const from = jest.fn((table: string) => {
+      if (table === 'rooms') {
+        return { select: roomsSelect };
+      }
+
+      if (table === 'game_history') {
+        return { delete: historyDelete };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
+    const supabaseService = {
+      client: { from },
+    } as unknown as SupabaseService;
+
+    const repository = new SupabaseGameHistoryRepository(supabaseService);
+
+    await expect(
+      repository.deleteForFinishedRoomsOutsideRecentLimit(2),
+    ).resolves.toBe(2);
+
+    expect(roomsEq).toHaveBeenCalledWith('status', 'finished');
+    expect(roomsOrder).toHaveBeenCalledWith('last_activity_at', {
+      ascending: false,
+    });
+    expect(historyDelete).toHaveBeenCalledWith({ count: 'exact' });
+    expect(historyIn).toHaveBeenCalledWith('room_id', ['room-3', 'room-4']);
+  });
 });

--- a/mei-tra-backend/src/repositories/implementations/supabase-game-history.repository.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-history.repository.ts
@@ -15,6 +15,10 @@ type GameStateIdRow = Pick<
   Database['public']['Tables']['game_states']['Row'],
   'id'
 >;
+type FinishedRoomIdRow = Pick<
+  Database['public']['Tables']['rooms']['Row'],
+  'id'
+>;
 
 @Injectable()
 export class SupabaseGameHistoryRepository implements IGameHistoryRepository {
@@ -103,6 +107,58 @@ export class SupabaseGameHistoryRepository implements IGameHistoryRepository {
     return entries.filter(
       (entry) => this.extractRoundNumber(entry) === query.roundNumber,
     );
+  }
+
+  async deleteForFinishedRoomsOutsideRecentLimit(
+    limit: number,
+  ): Promise<number> {
+    const { data, error } = await this.supabase
+      .from('rooms')
+      .select('id')
+      .eq('status', 'finished')
+      .order('last_activity_at', { ascending: false });
+
+    if (error) {
+      this.logger.error(
+        'Failed to list finished rooms for history pruning',
+        error,
+      );
+      throw new Error(
+        `Failed to list finished rooms for history pruning: ${error.message}`,
+      );
+    }
+
+    const roomIds = ((data as FinishedRoomIdRow[]) ?? []).map(
+      (room) => room.id,
+    );
+    const staleRoomIds = roomIds.slice(Math.max(1, limit));
+    let deletedCount = 0;
+
+    for (let index = 0; index < staleRoomIds.length; index += 100) {
+      const roomIdChunk = staleRoomIds.slice(index, index + 100);
+      if (roomIdChunk.length === 0) {
+        continue;
+      }
+
+      const { count, error: deleteError } = await this.supabase
+        .from('game_history')
+        .delete({ count: 'exact' })
+        .in('room_id', roomIdChunk);
+
+      if (deleteError) {
+        this.logger.error(
+          'Failed to prune old game history entries',
+          deleteError,
+        );
+        throw new Error(
+          `Failed to prune old game history entries: ${deleteError.message}`,
+        );
+      }
+
+      deletedCount += count ?? 0;
+    }
+
+    return deletedCount;
   }
 
   private async findGameStateIdByRoomId(

--- a/mei-tra-backend/src/repositories/interfaces/game-history.repository.interface.ts
+++ b/mei-tra-backend/src/repositories/interfaces/game-history.repository.interface.ts
@@ -10,4 +10,5 @@ export interface IGameHistoryRepository {
     roomId: string,
     query?: GameHistoryQuery,
   ): Promise<GameHistoryEntry[]>;
+  deleteForFinishedRoomsOutsideRecentLimit(limit: number): Promise<number>;
 }

--- a/mei-tra-backend/src/services/__tests__/game-event-log.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/game-event-log.service.spec.ts
@@ -96,6 +96,21 @@ describe('GameEventLogService', () => {
     expect(repository.findByRoomId).toHaveBeenCalledWith('room-1', query);
   });
 
+  it('prunes history for finished rooms outside the retained room limit', async () => {
+    const repository = {
+      create: jest.fn(),
+      findByRoomId: jest.fn(),
+      deleteForFinishedRoomsOutsideRecentLimit: jest.fn().mockResolvedValue(42),
+    } as unknown as IGameHistoryRepository;
+
+    const service = new GameEventLogService(repository);
+
+    await expect(service.pruneFinishedRoomHistory()).resolves.toBe(42);
+    expect(
+      repository.deleteForFinishedRoomsOutsideRecentLimit,
+    ).toHaveBeenCalledWith(10);
+  });
+
   it('summarizes room history by action type and round', async () => {
     const history = [
       {

--- a/mei-tra-backend/src/services/game-event-log.service.ts
+++ b/mei-tra-backend/src/services/game-event-log.service.ts
@@ -27,6 +27,8 @@ import {
   GameHistorySummary,
 } from '../types/game-history.types';
 
+const DEFAULT_FINISHED_ROOM_HISTORY_LIMIT = 10;
+
 @Injectable()
 export class GameEventLogService implements IGameEventLogService {
   private readonly logger = new Logger(GameEventLogService.name);
@@ -65,6 +67,22 @@ export class GameEventLogService implements IGameEventLogService {
 
   listByRoomId(roomId: string, query?: GameHistoryQuery) {
     return this.gameHistoryRepository.findByRoomId(roomId, query);
+  }
+
+  async pruneFinishedRoomHistory(
+    keepRecentRooms: number = DEFAULT_FINISHED_ROOM_HISTORY_LIMIT,
+  ): Promise<number> {
+    try {
+      return await this.gameHistoryRepository.deleteForFinishedRoomsOutsideRecentLimit(
+        Math.max(1, keepRecentRooms),
+      );
+    } catch (error) {
+      this.logger.error(
+        'Failed to prune old game history entries',
+        error instanceof Error ? error.stack : String(error),
+      );
+      return 0;
+    }
   }
 
   async summarizeByRoomId(

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -72,6 +72,7 @@ export class GameStateService implements IGameStateService {
       gamePhase: null,
       blowState: this.getInitialBlowState(),
       playState: this.getInitialPlayState(),
+      pendingBrokenHandReveal: null,
       teamScoreRecords: {
         0: [],
         1: [],
@@ -424,6 +425,7 @@ export class GameStateService implements IGameStateService {
       player.hasBroken = false;
       player.hasRequiredBroken = false;
     });
+    this.state.pendingBrokenHandReveal = null;
 
     // Deal exactly 10 cards to each player
     for (let i = 0; i < 10; i++) {
@@ -624,6 +626,7 @@ export class GameStateService implements IGameStateService {
 
     // Initialize game state
     state.deck = this.cardService.generateDeck();
+    state.pendingBrokenHandReveal = null;
     await this.dealCards();
 
     // Initialize play state

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -626,7 +626,6 @@ export class GameStateService implements IGameStateService {
 
     // Initialize game state
     state.deck = this.cardService.generateDeck();
-    state.pendingBrokenHandReveal = null;
     await this.dealCards();
 
     // Initialize play state

--- a/mei-tra-backend/src/services/interfaces/game-event-log.service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/game-event-log.service.interface.ts
@@ -36,4 +36,5 @@ export interface IGameEventLogService {
     roomId: string,
     query?: GameHistoryQuery,
   ): Promise<GameHistoryReplayView>;
+  pruneFinishedRoomHistory?(keepRecentRooms?: number): Promise<number>;
 }

--- a/mei-tra-backend/src/types/game.types.ts
+++ b/mei-tra-backend/src/types/game.types.ts
@@ -85,6 +85,12 @@ export interface PlayState {
   openDeclarerId: string | null;
 }
 
+export interface PendingBrokenHandReveal {
+  playerId: string;
+  handSnapshot: string[];
+  startedAt: number;
+}
+
 export interface ScoreCard {
   value: number;
   suit: '♥' | '♦' | '♠' | '♣';
@@ -127,6 +133,7 @@ export interface GameState {
   teamScoreRecords: Record<Team, ScoreRecord[]>;
   blowState: BlowState;
   playState?: PlayState;
+  pendingBrokenHandReveal?: PendingBrokenHandReveal | null;
   agari?: string;
   roundNumber: number;
   pointsToWin: number;

--- a/mei-tra-backend/src/use-cases/__tests__/blow-phase-transition.helper.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/blow-phase-transition.helper.spec.ts
@@ -4,7 +4,6 @@ import { GameState } from '../../types/game.types';
 import { Room, RoomStatus } from '../../types/room.types';
 import { IBlowService } from '../../services/interfaces/blow-service.interface';
 import { ICardService } from '../../services/interfaces/card-service.interface';
-import { IChomboService } from '../../services/interfaces/chombo-service.interface';
 
 describe('transitionToPlayPhase', () => {
   it('reveals the Agari card using room player socket when session lookup is empty', async () => {
@@ -119,10 +118,6 @@ describe('transitionToPlayPhase', () => {
     const cardService = {
       compareCards: jest.fn(() => 0),
     } as unknown as ICardService;
-    const chomboService = {
-      checkForRequiredBrokenHand: jest.fn(),
-    } as unknown as IChomboService;
-
     const result = await transitionToPlayPhase({
       roomId: 'room-1',
       roomGameState,
@@ -130,7 +125,6 @@ describe('transitionToPlayPhase', () => {
       state,
       blowService,
       cardService,
-      chomboService,
     });
 
     expect(state.players[0].hand).toContain('H-A');
@@ -157,5 +151,96 @@ describe('transitionToPlayPhase', () => {
     });
     expect(updatePhaseEvent?.payload).not.toHaveProperty('agariCard');
     expect(updatePhaseEvent?.payload).not.toHaveProperty('agariPlayerId');
+  });
+
+  it('does not request broken reveal after the Agari card is added', async () => {
+    const declaration = {
+      playerId: 'player-1',
+      trumpType: 'club' as const,
+      numberOfPairs: 6,
+      timestamp: 1,
+    };
+    const state: GameState = {
+      players: [
+        {
+          playerId: 'player-1',
+          name: 'Player 1',
+          team: 0 as const,
+          hand: ['J♠', 'J♣', 'J♥'],
+          isPasser: false,
+          hasRequiredBroken: false,
+        },
+      ],
+      currentPlayerIndex: 0,
+      gamePhase: 'blow',
+      deck: [],
+      agari: 'J♦',
+      teamScores: {
+        0: { play: 0, total: 0 },
+        1: { play: 0, total: 0 },
+      },
+      teamScoreRecords: {
+        0: [],
+        1: [],
+      },
+      blowState: {
+        currentTrump: null,
+        currentHighestDeclaration: declaration,
+        declarations: [declaration],
+        actionHistory: [],
+        lastPasser: null,
+        isRoundCancelled: false,
+        currentBlowIndex: 0,
+      },
+      playState: {
+        currentField: null,
+        negriCard: null,
+        neguri: {},
+        fields: [],
+        lastWinnerId: null,
+        openDeclared: false,
+        openDeclarerId: null,
+      },
+      roundNumber: 1,
+      pointsToWin: 10,
+      teamAssignments: {},
+    };
+    const roomGameState = {
+      transitionPhase: jest.fn(async (phase: GameState['gamePhase']) => {
+        state.gamePhase = phase;
+      }),
+      getState: jest.fn(() => state),
+      getTransportPlayers: jest.fn(() => state.players),
+      findSessionUserByPlayerId: jest.fn(() => null),
+      saveState: jest.fn(),
+    } as unknown as GameStateService;
+    const blowService = {
+      findHighestDeclaration: jest.fn(() => declaration),
+    } as unknown as IBlowService;
+    const cardService = {
+      compareCards: jest.fn(() => 0),
+    } as unknown as ICardService;
+
+    const result = await transitionToPlayPhase({
+      roomId: 'room-1',
+      roomGameState,
+      state,
+      blowService,
+      cardService,
+    });
+
+    expect(state.players[0].hand).toEqual(['J♠', 'J♣', 'J♥', 'J♦']);
+    expect(state.players[0].hasRequiredBroken).toBe(false);
+    expect(state.gamePhase).toBe('play');
+    expect(
+      result.delayedEvents.some(
+        (event) =>
+          event.event === 'update-phase' &&
+          typeof event.payload === 'object' &&
+          event.payload !== null &&
+          'phase' in event.payload &&
+          event.payload.phase === 'play',
+      ),
+    ).toBe(true);
   });
 });

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -2096,9 +2096,6 @@ describe('Game Use Cases', () => {
       const roomGameState = {
         getState: jest.fn(() => state),
         dealCards: dealCardsMock,
-        transitionPhase: jest.fn().mockImplementation(async (phase) => {
-          state.gamePhase = phase;
-        }),
         findPlayerByActorId: jest.fn((actorId: string) =>
           actorId === 'user-1'
             ? (state.players.find((player) => player.playerId === 'player-1') ??
@@ -2395,9 +2392,6 @@ describe('Game Use Cases', () => {
       const roomGameState = {
         getState: jest.fn(() => state),
         dealCards: dealCardsMock,
-        transitionPhase: jest.fn().mockImplementation(async (phase) => {
-          state.gamePhase = phase;
-        }),
         findPlayerByActorId: jest.fn(
           (actorId: string) =>
             state.players.find((player) => player.playerId === actorId) ?? null,
@@ -2561,7 +2555,6 @@ describe('Game Use Cases', () => {
       const roomGameState = {
         getState: jest.fn(() => state),
         dealCards: jest.fn(),
-        transitionPhase: jest.fn(),
         saveState: jest.fn(),
       } as unknown as GameStateService;
 
@@ -2577,7 +2570,6 @@ describe('Game Use Cases', () => {
         success: false,
         error: 'Broken hand request is stale',
       });
-      expect(roomGameState.transitionPhase).not.toHaveBeenCalled();
       expect(roomGameState.dealCards).not.toHaveBeenCalled();
       expect(roomGameState.saveState).toHaveBeenCalled();
       expect(state.pendingBrokenHandReveal).toBeNull();
@@ -2631,9 +2623,6 @@ describe('Game Use Cases', () => {
         dealCards: jest.fn(() => {
           state.players[0].hand = ['X1', 'X2'];
         }),
-        transitionPhase: jest.fn().mockImplementation(async (phase) => {
-          state.gamePhase = phase;
-        }),
         findPlayerByActorId: jest.fn(
           (actorId: string) =>
             state.players.find((player) => player.playerId === actorId) ?? null,
@@ -2664,7 +2653,6 @@ describe('Game Use Cases', () => {
 
       expect(completion.success).toBe(true);
       expect(state.pendingBrokenHandReveal).toBeNull();
-      expect(roomGameState.transitionPhase).toHaveBeenCalledWith('blow');
       expect(roomGameState.dealCards).toHaveBeenCalled();
       expect(roomGameState.saveState).toHaveBeenCalled();
     });

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -1761,6 +1761,7 @@ describe('Game Use Cases', () => {
             hand: ['C1'],
             team: 0,
             isPasser: false,
+            hasRequiredBroken: false,
           },
           {
             playerId: 'player-2',
@@ -1826,7 +1827,14 @@ describe('Game Use Cases', () => {
     it('prepares and finalizes broken hand flow', async () => {
       const roomService = createRoomServiceMock();
       const cardService = createCardServiceMock();
-      const useCase = new RevealBrokenHandUseCase(roomService, cardService);
+      const gameEventLogService = {
+        log: jest.fn().mockResolvedValue(undefined),
+      } as unknown as jest.Mocked<IGameEventLogService>;
+      const useCase = new RevealBrokenHandUseCase(
+        roomService,
+        cardService,
+        gameEventLogService,
+      );
 
       const state: {
         players: DomainPlayer[];
@@ -1842,6 +1850,7 @@ describe('Game Use Cases', () => {
             hand: ['C1'],
             team: 0,
             isPasser: false,
+            hasRequiredBroken: true,
           },
           {
             playerId: 'player-2',
@@ -1849,6 +1858,7 @@ describe('Game Use Cases', () => {
             hand: ['D1'],
             team: 1,
             isPasser: false,
+            hasRequiredBroken: false,
           },
         ],
         blowState: {
@@ -1907,6 +1917,20 @@ describe('Game Use Cases', () => {
         const completion = await useCase.finalize(preparation.followUp);
         expect(completion.success).toBe(true);
         expect(dealCardsMock).toHaveBeenCalled();
+        expect(gameEventLogService.log).toHaveBeenCalledWith(
+          expect.objectContaining({
+            actionType: 'broken_hand_revealed',
+            playerId: 'player-1',
+            actionData: expect.objectContaining({
+              nextPlayerId: 'player-1',
+              nextBlowIndex: 0,
+              startingHandsByPlayerId: {
+                'player-1': ['X1', 'X2'],
+                'player-2': ['X1', 'X2'],
+              },
+            }),
+          }),
+        );
         const brokenEvent = completion.events?.find(
           (evt) => evt.event === 'broken',
         );
@@ -1940,6 +1964,7 @@ describe('Game Use Cases', () => {
             hand: ['D1'],
             team: 1,
             isPasser: true,
+            hasRequiredBroken: false,
           },
           {
             playerId: 'player-3',
@@ -1947,6 +1972,7 @@ describe('Game Use Cases', () => {
             hand: ['H1'],
             team: 0,
             isPasser: false,
+            hasRequiredBroken: true,
           },
           {
             playerId: 'player-4',
@@ -1954,6 +1980,7 @@ describe('Game Use Cases', () => {
             hand: ['S1'],
             team: 1,
             isPasser: false,
+            hasRequiredBroken: false,
           },
         ],
         blowState: {
@@ -2054,6 +2081,74 @@ describe('Game Use Cases', () => {
         (evt) => evt.event === 'update-turn',
       );
       expect(updateTurnEvent?.payload).toBe('player-3');
+    });
+
+    it('does not finalize a stale delayed broken hand request after the hand changes', async () => {
+      const roomService = createRoomServiceMock();
+      const cardService = createCardServiceMock();
+      const gameEventLogService = {
+        log: jest.fn().mockResolvedValue(undefined),
+      } as unknown as jest.Mocked<IGameEventLogService>;
+      const useCase = new RevealBrokenHandUseCase(
+        roomService,
+        cardService,
+        gameEventLogService,
+      );
+
+      const state: {
+        players: DomainPlayer[];
+        blowState: BlowState;
+        currentPlayerIndex: number;
+        gamePhase: 'play' | 'blow';
+        deck: string[];
+      } = {
+        players: [
+          {
+            playerId: 'player-1',
+            name: 'Player 1',
+            hand: ['new-card'],
+            team: 0,
+            isPasser: false,
+            hasRequiredBroken: true,
+          },
+        ],
+        blowState: {
+          currentTrump: null,
+          declarations: [],
+          actionHistory: [],
+          currentHighestDeclaration: null,
+          lastPasser: null,
+          isRoundCancelled: false,
+          currentBlowIndex: 0,
+        },
+        currentPlayerIndex: 0,
+        gamePhase: 'play',
+        deck: [],
+      };
+
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        dealCards: jest.fn(),
+        transitionPhase: jest.fn(),
+        saveState: jest.fn(),
+      } as unknown as GameStateService;
+
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const completion = await useCase.finalize({
+        roomId: 'room-1',
+        playerId: 'player-1',
+        handSnapshot: ['old-card'],
+      });
+
+      expect(completion).toEqual({
+        success: false,
+        error: 'Broken hand request is stale',
+      });
+      expect(roomGameState.transitionPhase).not.toHaveBeenCalled();
+      expect(roomGameState.dealCards).not.toHaveBeenCalled();
+      expect(roomGameState.saveState).not.toHaveBeenCalled();
+      expect(gameEventLogService.log).not.toHaveBeenCalled();
     });
   });
 

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -2341,6 +2341,7 @@ describe('Game Use Cases', () => {
       const roomService = createRoomServiceMock();
       const gameEventLogService = {
         log: jest.fn().mockResolvedValue(undefined),
+        pruneFinishedRoomHistory: jest.fn().mockResolvedValue(0),
       } as unknown as jest.Mocked<IGameEventLogService>;
       const useCase = new ProcessGameOverUseCase(
         roomService,
@@ -2391,6 +2392,7 @@ describe('Game Use Cases', () => {
           }),
         }),
       );
+      expect(gameEventLogService.pruneFinishedRoomHistory).toHaveBeenCalled();
     });
   });
 

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -5,6 +5,8 @@ import { LeaveRoomUseCase } from '../leave-room.use-case';
 import { StartGameUseCase } from '../start-game.use-case';
 import { TogglePlayerReadyUseCase } from '../toggle-player-ready.use-case';
 import { ChangePlayerTeamUseCase } from '../change-player-team.use-case';
+import { DeclareBlowUseCase } from '../declare-blow.use-case';
+import { PassBlowUseCase } from '../pass-blow.use-case';
 import { PlayCardUseCase } from '../play-card.use-case';
 import { SelectBaseSuitUseCase } from '../select-base-suit.use-case';
 import { SelectNegriUseCase } from '../select-negri.use-case';
@@ -33,6 +35,10 @@ import { IScoreService } from '../../services/interfaces/score-service.interface
 import { IGameEventLogService } from '../../services/interfaces/game-event-log.service.interface';
 import { CardService } from '../../services/card.service';
 import { PlayService } from '../../services/play.service';
+import {
+  BROKEN_HAND_REVEAL_PENDING_TTL_MS,
+  REQUIRED_BROKEN_HAND_REVEAL_ERROR,
+} from '../helpers/broken-hand.helper';
 describe('Game Use Cases', () => {
   const createRoomServiceMock = () => {
     const mock: Partial<jest.Mocked<IRoomService>> = {
@@ -996,6 +1002,95 @@ describe('Game Use Cases', () => {
     });
   });
 
+  describe('Blow action required broken guard', () => {
+    const buildRequiredBrokenState = () => ({
+      players: [
+        {
+          playerId: 'player-1',
+          name: 'Player 1',
+          hand: ['J♠', 'J♣', 'J♥', 'J♦'],
+          team: 0 as Team,
+          isPasser: false,
+          hasRequiredBroken: true,
+        },
+      ],
+      currentPlayerIndex: 0,
+      gamePhase: 'blow' as GamePhase,
+      blowState: {
+        currentTrump: null,
+        declarations: [],
+        actionHistory: [],
+        currentHighestDeclaration: null,
+        lastPasser: null,
+        isRoundCancelled: false,
+        currentBlowIndex: 0,
+      },
+    });
+
+    it('rejects declare when required broken hand must be revealed', async () => {
+      const roomService = createRoomServiceMock();
+      const blowService = {
+        isValidDeclaration: jest.fn(),
+        createDeclaration: jest.fn(),
+      };
+      const useCase = new DeclareBlowUseCase(
+        roomService,
+        blowService as never,
+        createCardServiceMock(),
+      );
+      const state = buildRequiredBrokenState();
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        findPlayerByActorId: jest.fn(() => state.players[0]),
+        isPlayerTurn: jest.fn(() => true),
+        saveState: jest.fn(),
+      } as unknown as GameStateService;
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const result = await useCase.execute({
+        roomId: 'room-1',
+        actorId: 'player-1',
+        declaration: { trumpType: 'club', numberOfPairs: 6 },
+      });
+
+      expect(result).toEqual({
+        success: false,
+        error: REQUIRED_BROKEN_HAND_REVEAL_ERROR,
+      });
+      expect(blowService.isValidDeclaration).not.toHaveBeenCalled();
+      expect(roomGameState.saveState).not.toHaveBeenCalled();
+    });
+
+    it('rejects pass when required broken hand must be revealed', async () => {
+      const roomService = createRoomServiceMock();
+      const useCase = new PassBlowUseCase(
+        roomService,
+        {} as never,
+        createCardServiceMock(),
+      );
+      const state = buildRequiredBrokenState();
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        findPlayerByActorId: jest.fn(() => state.players[0]),
+        isPlayerTurn: jest.fn(() => true),
+        saveState: jest.fn(),
+      } as unknown as GameStateService;
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const result = await useCase.execute({
+        roomId: 'room-1',
+        actorId: 'player-1',
+      });
+
+      expect(result).toEqual({
+        success: false,
+        error: REQUIRED_BROKEN_HAND_REVEAL_ERROR,
+      });
+      expect(state.players[0].isPasser).toBe(false);
+      expect(roomGameState.saveState).not.toHaveBeenCalled();
+    });
+  });
+
   describe('PlayCardUseCase', () => {
     it('plays a card and advances turn when field not complete', async () => {
       const roomService = createRoomServiceMock();
@@ -1334,6 +1429,10 @@ describe('Game Use Cases', () => {
       const selectNegriUseCase = {
         execute: jest.fn(),
       };
+      const revealBrokenHandUseCase = {
+        prepare: jest.fn(),
+        finalize: jest.fn(),
+      };
       const useCase = new ComAutoPlayUseCase(
         roomService,
         comPlayerService as never,
@@ -1342,6 +1441,7 @@ describe('Game Use Cases', () => {
         declareBlowUseCase as never,
         passBlowUseCase as never,
         selectNegriUseCase as never,
+        revealBrokenHandUseCase as never,
       );
 
       const comPlayer: DomainPlayer = {
@@ -1465,6 +1565,10 @@ describe('Game Use Cases', () => {
       const selectNegriUseCase = {
         execute: jest.fn(),
       };
+      const revealBrokenHandUseCase = {
+        prepare: jest.fn(),
+        finalize: jest.fn(),
+      };
       const useCase = new ComAutoPlayUseCase(
         roomService,
         comPlayerService as never,
@@ -1473,6 +1577,7 @@ describe('Game Use Cases', () => {
         declareBlowUseCase as never,
         passBlowUseCase as never,
         selectNegriUseCase as never,
+        revealBrokenHandUseCase as never,
       );
 
       const comPlayer: DomainPlayer = {
@@ -1597,6 +1702,10 @@ describe('Game Use Cases', () => {
       const selectNegriUseCase = {
         execute: jest.fn(),
       };
+      const revealBrokenHandUseCase = {
+        prepare: jest.fn(),
+        finalize: jest.fn(),
+      };
       const useCase = new ComAutoPlayUseCase(
         roomService,
         comPlayerService as never,
@@ -1605,6 +1714,7 @@ describe('Game Use Cases', () => {
         declareBlowUseCase as never,
         passBlowUseCase as never,
         selectNegriUseCase as never,
+        revealBrokenHandUseCase as never,
       );
 
       const comPlayer: DomainPlayer = {
@@ -1658,6 +1768,103 @@ describe('Game Use Cases', () => {
         declaration: { trumpType: 'herz', numberOfPairs: 6 },
       });
       expect(passBlowUseCase.execute).not.toHaveBeenCalled();
+    });
+
+    it('reveals required broken hand for COM before choosing blow action', async () => {
+      const roomService = createRoomServiceMock();
+      const comPlayerService = {
+        createComPlayer: jest.fn(),
+        isComPlayer: jest.fn(() => true),
+      };
+      const comStrategyService = {
+        chooseBlowAction: jest.fn(),
+        chooseNegriCard: jest.fn(),
+        choosePlayCard: jest.fn(),
+        chooseBaseSuit: jest.fn(),
+      };
+      const playCardUseCase = { execute: jest.fn() };
+      const declareBlowUseCase = { execute: jest.fn() };
+      const passBlowUseCase = { execute: jest.fn() };
+      const selectNegriUseCase = { execute: jest.fn() };
+      const revealBrokenHandUseCase = {
+        prepare: jest.fn().mockResolvedValue({
+          success: true,
+          followUp: {
+            roomId: 'room-1',
+            playerId: 'com-0',
+            handSnapshot: ['J♠', 'J♣', 'J♥', 'J♦'],
+          },
+        }),
+        finalize: jest.fn().mockResolvedValue({
+          success: true,
+          events: [
+            {
+              scope: 'room',
+              roomId: 'room-1',
+              event: 'broken',
+              payload: { nextPlayerId: 'com-0' },
+            },
+          ],
+        }),
+      };
+      const useCase = new ComAutoPlayUseCase(
+        roomService,
+        comPlayerService as never,
+        comStrategyService as never,
+        playCardUseCase as never,
+        declareBlowUseCase as never,
+        passBlowUseCase as never,
+        selectNegriUseCase as never,
+        revealBrokenHandUseCase as never,
+      );
+
+      const comPlayer: DomainPlayer = {
+        playerId: 'com-0',
+        name: 'COM',
+        hand: ['J♠', 'J♣', 'J♥', 'J♦'],
+        team: 0,
+        isPasser: false,
+        isCOM: true,
+        hasRequiredBroken: true,
+      };
+      const state = {
+        players: [comPlayer],
+        currentPlayerIndex: 0,
+        gamePhase: 'blow' as GamePhase,
+      };
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        getCurrentPlayer: jest.fn(
+          () => state.players[state.currentPlayerIndex],
+        ),
+      } as unknown as GameStateService;
+
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const result = await useCase.execute({ roomId: 'room-1' });
+
+      expect(result.success).toBe(true);
+      expect(revealBrokenHandUseCase.prepare).toHaveBeenCalledWith({
+        roomId: 'room-1',
+        actorId: 'com-0',
+        playerId: 'com-0',
+      });
+      expect(revealBrokenHandUseCase.finalize).toHaveBeenCalledWith({
+        roomId: 'room-1',
+        playerId: 'com-0',
+        handSnapshot: ['J♠', 'J♣', 'J♥', 'J♦'],
+      });
+      expect(comStrategyService.chooseBlowAction).not.toHaveBeenCalled();
+      expect(declareBlowUseCase.execute).not.toHaveBeenCalled();
+      expect(passBlowUseCase.execute).not.toHaveBeenCalled();
+      expect(result.events).toEqual([
+        {
+          scope: 'room',
+          roomId: 'room-1',
+          event: 'broken',
+          payload: { nextPlayerId: 'com-0' },
+        },
+      ]);
     });
   });
 
@@ -1842,6 +2049,11 @@ describe('Game Use Cases', () => {
         currentPlayerIndex: number;
         gamePhase: 'play' | 'blow';
         deck: string[];
+        pendingBrokenHandReveal?: {
+          playerId: string;
+          handSnapshot: string[];
+          startedAt: number;
+        } | null;
       } = {
         players: [
           {
@@ -1871,7 +2083,7 @@ describe('Game Use Cases', () => {
           currentBlowIndex: 0,
         },
         currentPlayerIndex: 0,
-        gamePhase: 'play' as const,
+        gamePhase: 'blow' as const,
         deck: [],
       };
 
@@ -1912,10 +2124,16 @@ describe('Game Use Cases', () => {
       expect(preparation.success).toBe(true);
       expect(preparation.delayMs).toBe(3000);
       expect(preparation.followUp).toBeDefined();
+      expect(state.pendingBrokenHandReveal).toEqual({
+        playerId: 'player-1',
+        handSnapshot: ['C1'],
+        startedAt: expect.any(Number),
+      });
 
       if (preparation.followUp) {
         const completion = await useCase.finalize(preparation.followUp);
         expect(completion.success).toBe(true);
+        expect(state.pendingBrokenHandReveal).toBeNull();
         expect(dealCardsMock).toHaveBeenCalled();
         expect(gameEventLogService.log).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -1938,6 +2156,142 @@ describe('Game Use Cases', () => {
       }
     });
 
+    it('rejects broken hand reveal outside the blow phase', async () => {
+      const roomService = createRoomServiceMock();
+      const cardService = createCardServiceMock();
+      const useCase = new RevealBrokenHandUseCase(roomService, cardService);
+
+      const state = {
+        players: [
+          {
+            playerId: 'player-1',
+            name: 'Player 1',
+            hand: ['C1'],
+            team: 0,
+            isPasser: false,
+            hasRequiredBroken: true,
+          },
+        ],
+        blowState: {
+          declarations: [],
+        },
+        gamePhase: 'play' as GamePhase,
+      };
+
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        findPlayerByActorId: jest.fn(() => state.players[0]),
+        saveState: jest.fn(),
+      } as unknown as GameStateService;
+
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const preparation = await useCase.prepare({
+        roomId: 'room-1',
+        actorId: 'player-1',
+        playerId: 'player-1',
+      });
+
+      expect(preparation).toEqual({
+        success: false,
+        error: 'Cannot reveal broken hand now',
+      });
+      expect(roomGameState.saveState).not.toHaveBeenCalled();
+    });
+
+    it('rejects broken hand reveal after the player already acted in blow', async () => {
+      const roomService = createRoomServiceMock();
+      const cardService = createCardServiceMock();
+      const useCase = new RevealBrokenHandUseCase(roomService, cardService);
+
+      const state = {
+        players: [
+          {
+            playerId: 'player-1',
+            name: 'Player 1',
+            hand: ['C1'],
+            team: 0,
+            isPasser: false,
+            hasRequiredBroken: true,
+          },
+        ],
+        blowState: {
+          declarations: [
+            {
+              playerId: 'player-1',
+              trumpType: 'club' as const,
+              numberOfPairs: 6,
+              timestamp: 1,
+            },
+          ],
+        },
+        gamePhase: 'blow' as GamePhase,
+      };
+
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        findPlayerByActorId: jest.fn(() => state.players[0]),
+        saveState: jest.fn(),
+      } as unknown as GameStateService;
+
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const preparation = await useCase.prepare({
+        roomId: 'room-1',
+        actorId: 'player-1',
+        playerId: 'player-1',
+      });
+
+      expect(preparation).toEqual({
+        success: false,
+        error: 'Cannot reveal broken hand now',
+      });
+      expect(roomGameState.saveState).not.toHaveBeenCalled();
+    });
+
+    it('rejects broken hand reveal after the player already passed in blow', async () => {
+      const roomService = createRoomServiceMock();
+      const cardService = createCardServiceMock();
+      const useCase = new RevealBrokenHandUseCase(roomService, cardService);
+
+      const state = {
+        players: [
+          {
+            playerId: 'player-1',
+            name: 'Player 1',
+            hand: ['C1'],
+            team: 0,
+            isPasser: true,
+            hasRequiredBroken: true,
+          },
+        ],
+        blowState: {
+          declarations: [],
+        },
+        gamePhase: 'blow' as GamePhase,
+      };
+
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        findPlayerByActorId: jest.fn(() => state.players[0]),
+        saveState: jest.fn(),
+      } as unknown as GameStateService;
+
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const preparation = await useCase.prepare({
+        roomId: 'room-1',
+        actorId: 'player-1',
+        playerId: 'player-1',
+      });
+
+      expect(preparation).toEqual({
+        success: false,
+        error: 'Cannot reveal broken hand now',
+      });
+      expect(roomGameState.saveState).not.toHaveBeenCalled();
+    });
+
     it('resets blow declarations after broken hand without changing starting order', async () => {
       const roomService = createRoomServiceMock();
       const cardService = createCardServiceMock();
@@ -1949,6 +2303,11 @@ describe('Game Use Cases', () => {
         currentPlayerIndex: number;
         gamePhase: 'play' | 'blow';
         deck: string[];
+        pendingBrokenHandReveal?: {
+          playerId: string;
+          handSnapshot: string[];
+          startedAt: number;
+        } | null;
       } = {
         players: [
           {
@@ -2020,6 +2379,11 @@ describe('Game Use Cases', () => {
         currentPlayerIndex: 1,
         gamePhase: 'blow',
         deck: [],
+        pendingBrokenHandReveal: {
+          playerId: 'player-3',
+          handSnapshot: ['H1'],
+          startedAt: 1,
+        },
       };
 
       const dealCardsMock = jest.fn(() => {
@@ -2049,6 +2413,7 @@ describe('Game Use Cases', () => {
       });
 
       expect(completion.success).toBe(true);
+      expect(state.pendingBrokenHandReveal).toBeNull();
       expect(state.blowState.currentBlowIndex).toBe(2);
       expect(state.currentPlayerIndex).toBe(2);
       expect(state.blowState.declarations).toEqual([]);
@@ -2083,6 +2448,63 @@ describe('Game Use Cases', () => {
       expect(updateTurnEvent?.payload).toBe('player-3');
     });
 
+    it('allows a new broken hand reveal when a previous pending marker expired', async () => {
+      const roomService = createRoomServiceMock();
+      const cardService = createCardServiceMock();
+      const useCase = new RevealBrokenHandUseCase(roomService, cardService);
+
+      const state: {
+        players: DomainPlayer[];
+        blowState: Pick<BlowState, 'declarations'>;
+        gamePhase: GamePhase;
+        pendingBrokenHandReveal?: {
+          playerId: string;
+          handSnapshot: string[];
+          startedAt: number;
+        } | null;
+      } = {
+        players: [
+          {
+            playerId: 'player-1',
+            name: 'Player 1',
+            hand: ['C1'],
+            team: 0,
+            isPasser: false,
+            hasRequiredBroken: true,
+          },
+        ],
+        blowState: { declarations: [] },
+        gamePhase: 'blow',
+        pendingBrokenHandReveal: {
+          playerId: 'player-1',
+          handSnapshot: ['old-card'],
+          startedAt: Date.now() - BROKEN_HAND_REVEAL_PENDING_TTL_MS - 1,
+        },
+      };
+
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        findPlayerByActorId: jest.fn(() => state.players[0]),
+        saveState: jest.fn(),
+      } as unknown as GameStateService;
+
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const preparation = await useCase.prepare({
+        roomId: 'room-1',
+        actorId: 'user-1',
+        playerId: 'player-1',
+      });
+
+      expect(preparation.success).toBe(true);
+      expect(state.pendingBrokenHandReveal).toEqual({
+        playerId: 'player-1',
+        handSnapshot: ['C1'],
+        startedAt: expect.any(Number),
+      });
+      expect(roomGameState.saveState).toHaveBeenCalledTimes(2);
+    });
+
     it('does not finalize a stale delayed broken hand request after the hand changes', async () => {
       const roomService = createRoomServiceMock();
       const cardService = createCardServiceMock();
@@ -2101,6 +2523,11 @@ describe('Game Use Cases', () => {
         currentPlayerIndex: number;
         gamePhase: 'play' | 'blow';
         deck: string[];
+        pendingBrokenHandReveal?: {
+          playerId: string;
+          handSnapshot: string[];
+          startedAt: number;
+        } | null;
       } = {
         players: [
           {
@@ -2124,6 +2551,11 @@ describe('Game Use Cases', () => {
         currentPlayerIndex: 0,
         gamePhase: 'play',
         deck: [],
+        pendingBrokenHandReveal: {
+          playerId: 'player-1',
+          handSnapshot: ['old-card'],
+          startedAt: 1,
+        },
       };
 
       const roomGameState = {
@@ -2147,7 +2579,8 @@ describe('Game Use Cases', () => {
       });
       expect(roomGameState.transitionPhase).not.toHaveBeenCalled();
       expect(roomGameState.dealCards).not.toHaveBeenCalled();
-      expect(roomGameState.saveState).not.toHaveBeenCalled();
+      expect(roomGameState.saveState).toHaveBeenCalled();
+      expect(state.pendingBrokenHandReveal).toBeNull();
       expect(gameEventLogService.log).not.toHaveBeenCalled();
     });
 
@@ -2162,6 +2595,11 @@ describe('Game Use Cases', () => {
         currentPlayerIndex: number;
         gamePhase: 'play' | 'blow';
         deck: string[];
+        pendingBrokenHandReveal?: {
+          playerId: string;
+          handSnapshot: string[];
+          startedAt: number;
+        } | null;
       } = {
         players: [
           {
@@ -2225,6 +2663,7 @@ describe('Game Use Cases', () => {
       const completion = await useCase.finalize(preparation.followUp);
 
       expect(completion.success).toBe(true);
+      expect(state.pendingBrokenHandReveal).toBeNull();
       expect(roomGameState.transitionPhase).toHaveBeenCalledWith('blow');
       expect(roomGameState.dealCards).toHaveBeenCalled();
       expect(roomGameState.saveState).toHaveBeenCalled();

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -2150,6 +2150,85 @@ describe('Game Use Cases', () => {
       expect(roomGameState.saveState).not.toHaveBeenCalled();
       expect(gameEventLogService.log).not.toHaveBeenCalled();
     });
+
+    it('allows optional broken hand reveal when the player has normal broken', async () => {
+      const roomService = createRoomServiceMock();
+      const cardService = createCardServiceMock();
+      const useCase = new RevealBrokenHandUseCase(roomService, cardService);
+
+      const state: {
+        players: DomainPlayer[];
+        blowState: BlowState;
+        currentPlayerIndex: number;
+        gamePhase: 'play' | 'blow';
+        deck: string[];
+      } = {
+        players: [
+          {
+            playerId: 'player-1',
+            name: 'Player 1',
+            hand: ['2♣', '3♦'],
+            team: 0,
+            isPasser: false,
+            hasBroken: true,
+            hasRequiredBroken: false,
+          },
+        ],
+        blowState: {
+          currentTrump: null,
+          declarations: [],
+          actionHistory: [],
+          currentHighestDeclaration: null,
+          lastPasser: null,
+          isRoundCancelled: false,
+          currentBlowIndex: 0,
+        },
+        currentPlayerIndex: 0,
+        gamePhase: 'blow',
+        deck: [],
+      };
+
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        dealCards: jest.fn(() => {
+          state.players[0].hand = ['X1', 'X2'];
+        }),
+        transitionPhase: jest.fn().mockImplementation(async (phase) => {
+          state.gamePhase = phase;
+        }),
+        findPlayerByActorId: jest.fn(
+          (actorId: string) =>
+            state.players.find((player) => player.playerId === actorId) ?? null,
+        ),
+        saveState: jest.fn(),
+      } as unknown as GameStateService;
+
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const preparation = await useCase.prepare({
+        roomId: 'room-1',
+        actorId: 'player-1',
+        playerId: 'player-1',
+      });
+
+      expect(preparation.success).toBe(true);
+      expect(preparation.followUp).toEqual({
+        roomId: 'room-1',
+        playerId: 'player-1',
+        handSnapshot: ['2♣', '3♦'],
+      });
+
+      if (!preparation.followUp) {
+        throw new Error('Expected broken hand followUp');
+      }
+
+      const completion = await useCase.finalize(preparation.followUp);
+
+      expect(completion.success).toBe(true);
+      expect(roomGameState.transitionPhase).toHaveBeenCalledWith('blow');
+      expect(roomGameState.dealCards).toHaveBeenCalled();
+      expect(roomGameState.saveState).toHaveBeenCalled();
+    });
   });
 
   describe('CompleteFieldUseCase', () => {

--- a/mei-tra-backend/src/use-cases/__tests__/get-user-recent-game-history.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/get-user-recent-game-history.use-case.spec.ts
@@ -118,4 +118,94 @@ describe('GetUserRecentGameHistoryUseCase', () => {
       'room-2',
     );
   });
+
+  it('omits finished rooms whose retained history has been pruned', async () => {
+    const roomRepository: Pick<IRoomRepository, 'findRecentFinishedByUserId'> =
+      {
+        findRecentFinishedByUserId: jest.fn().mockResolvedValue([
+          {
+            id: 'room-with-history',
+            name: 'Retained room',
+            hostId: 'host-1',
+            status: RoomStatus.FINISHED,
+            players: [],
+            settings: {
+              maxPlayers: 4,
+              isPrivate: false,
+              password: null,
+              teamAssignmentMethod: 'random',
+              pointsToWin: 7,
+              allowSpectators: true,
+            },
+            createdAt: new Date('2026-04-16T00:00:00.000Z'),
+            updatedAt: new Date('2026-04-16T00:05:00.000Z'),
+            lastActivityAt: new Date('2026-04-16T00:05:00.000Z'),
+          },
+          {
+            id: 'pruned-room',
+            name: 'Pruned room',
+            hostId: 'host-2',
+            status: RoomStatus.FINISHED,
+            players: [],
+            settings: {
+              maxPlayers: 4,
+              isPrivate: false,
+              password: null,
+              teamAssignmentMethod: 'random',
+              pointsToWin: 7,
+              allowSpectators: true,
+            },
+            createdAt: new Date('2026-04-15T00:00:00.000Z'),
+            updatedAt: new Date('2026-04-15T00:05:00.000Z'),
+            lastActivityAt: new Date('2026-04-15T00:05:00.000Z'),
+          },
+        ]),
+      };
+
+    const gameEventLogService: IGameEventLogService = {
+      log: jest.fn(),
+      listByRoomId: jest.fn(),
+      replayByRoomId: jest.fn(),
+      summarizeByRoomId: jest
+        .fn()
+        .mockResolvedValueOnce({
+          roomId: 'room-with-history',
+          totalEntries: 2,
+          byActionType: { game_over: 1 },
+          playerIds: ['player-1'],
+          playerNames: { 'player-1': 'Player 1' },
+          status: 'completed' as const,
+          winningTeam: 0,
+          lastActionType: 'game_over' as const,
+          roundNumbers: [1],
+          firstTimestamp: new Date('2026-04-16T00:00:00.000Z'),
+          lastTimestamp: new Date('2026-04-16T00:05:00.000Z'),
+        })
+        .mockResolvedValueOnce({
+          roomId: 'pruned-room',
+          totalEntries: 0,
+          byActionType: {},
+          playerIds: [],
+          playerNames: {},
+          status: 'in_progress' as const,
+          winningTeam: null,
+          lastActionType: null,
+          roundNumbers: [],
+          firstTimestamp: null,
+          lastTimestamp: null,
+        }),
+    };
+
+    const useCase = new GetUserRecentGameHistoryUseCase(
+      roomRepository as IRoomRepository,
+      gameEventLogService,
+    );
+
+    await expect(useCase.execute('user-1')).resolves.toEqual([
+      expect.objectContaining({
+        roomId: 'room-with-history',
+        totalEntries: 2,
+      }),
+    ]);
+  });
 });

--- a/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
+++ b/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
@@ -4,7 +4,6 @@ import { Room } from '../types/room.types';
 import { GameStateService } from '../services/game-state.service';
 import { IBlowService } from '../services/interfaces/blow-service.interface';
 import { ICardService } from '../services/interfaces/card-service.interface';
-import { IChomboService } from '../services/interfaces/chombo-service.interface';
 import { IGameEventLogService } from '../services/interfaces/game-event-log.service.interface';
 import { buildPlayerSyncEvents } from './helpers/player-resolution.helper';
 import { GatewayEvent } from './interfaces/gateway-event.interface';
@@ -12,11 +11,6 @@ import { GatewayEvent } from './interfaces/gateway-event.interface';
 export interface TransitionResult {
   events: GatewayEvent[];
   delayedEvents: GatewayEvent[];
-  revealBrokenRequest?: {
-    roomId: string;
-    playerId: string;
-    actorId: string;
-  };
 }
 
 interface TransitionParams {
@@ -26,7 +20,6 @@ interface TransitionParams {
   state: GameState;
   blowService: IBlowService;
   cardService: ICardService;
-  chomboService: IChomboService;
   gameEventLogService?: IGameEventLogService;
 }
 
@@ -37,7 +30,6 @@ export async function transitionToPlayPhase({
   state,
   blowService,
   cardService,
-  chomboService,
   gameEventLogService,
 }: TransitionParams): Promise<TransitionResult> {
   const highestDeclaration = blowService.findHighestDeclaration(
@@ -55,7 +47,6 @@ export async function transitionToPlayPhase({
     winningPlayer.hand.push(state.agari);
   }
   winningPlayer.hand.sort((a, b) => cardService.compareCards(a, b));
-  chomboService.checkForRequiredBrokenHand(winningPlayer);
 
   await roomGameState.transitionPhase('play');
   const nextState = roomGameState.getState();
@@ -122,17 +113,6 @@ export async function transitionToPlayPhase({
     });
   }
 
-  const revealBrokenRequest = winningPlayer.hasRequiredBroken
-    ? {
-        roomId,
-        playerId: winningPlayer.playerId,
-        actorId:
-          winningPlayerSession?.userId ??
-          winningPlayerSocketId ??
-          winningPlayer.playerId,
-      }
-    : undefined;
-
   await gameEventLogService?.log({
     roomId,
     actionType: 'play_phase_started',
@@ -142,7 +122,7 @@ export async function transitionToPlayPhase({
       currentHighestDeclaration: nextState.blowState.currentHighestDeclaration,
       currentTrump: nextState.blowState.currentTrump,
       winnerPlayerId: winningPlayer.playerId,
-      revealBrokenRequired: Boolean(revealBrokenRequest),
+      revealBrokenRequired: false,
     },
   });
 
@@ -151,6 +131,5 @@ export async function transitionToPlayPhase({
   return {
     events,
     delayedEvents,
-    revealBrokenRequest,
   };
 }

--- a/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
+++ b/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
@@ -122,7 +122,6 @@ export async function transitionToPlayPhase({
       currentHighestDeclaration: nextState.blowState.currentHighestDeclaration,
       currentTrump: nextState.blowState.currentTrump,
       winnerPlayerId: winningPlayer.playerId,
-      revealBrokenRequired: false,
     },
   });
 

--- a/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
+++ b/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
@@ -23,10 +23,12 @@ import {
   ISelectNegriUseCase,
   SelectNegriResponse,
 } from './interfaces/select-negri.use-case.interface';
+import { IRevealBrokenHandUseCase } from './interfaces/reveal-broken-hand.use-case.interface';
 import { DomainPlayer } from '../types/game.types';
 import { GameStateService } from '../services/game-state.service';
 import { GatewayEvent } from './interfaces/gateway-event.interface';
 import { CompleteFieldTrigger } from './interfaces/play-card.use-case.interface';
+import { getBrokenHandRevealPendingError } from './helpers/broken-hand.helper';
 
 type ResponseWithDelayed<T> = T & {
   delayedEvents?: GatewayEvent[];
@@ -50,6 +52,8 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
     private readonly passBlowUseCase: IPassBlowUseCase,
     @Inject('ISelectNegriUseCase')
     private readonly selectNegriUseCase: ISelectNegriUseCase,
+    @Inject('IRevealBrokenHandUseCase')
+    private readonly revealBrokenHandUseCase: IRevealBrokenHandUseCase,
   ) {}
 
   async execute(request: ComAutoPlayRequest): Promise<ComAutoPlayResponse> {
@@ -58,6 +62,10 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
     try {
       // 1. ゲーム状態取得
       const gameState = await this.roomService.getRoomGameState(roomId);
+      if (await getBrokenHandRevealPendingError(gameState)) {
+        return { success: true, events: [], shouldContinue: false };
+      }
+
       const currentPlayer = gameState.getCurrentPlayer();
 
       // 2. COMプレイヤーでなければスキップ
@@ -71,6 +79,14 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       if (phase === 'play') {
         return await this.handleComPlayPhase(roomId, currentPlayer, gameState);
       } else if (phase === 'blow') {
+        if (currentPlayer.hasRequiredBroken) {
+          return await this.handleComRequiredBrokenHand(
+            roomId,
+            currentPlayer,
+            gameState,
+          );
+        }
+
         return await this.handleComBlowPhase(roomId, currentPlayer, gameState);
       }
 
@@ -234,9 +250,50 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       success: result.success,
       events,
       delayedEvents,
-      revealBrokenRequest: result.revealBrokenRequest,
       shouldContinue,
       error: result.error,
+    };
+  }
+
+  private async handleComRequiredBrokenHand(
+    roomId: string,
+    comPlayer: DomainPlayer,
+    gameState: GameStateService,
+  ): Promise<ComAutoPlayResponse> {
+    const preparation = await this.revealBrokenHandUseCase.prepare({
+      roomId,
+      actorId: comPlayer.playerId,
+      playerId: comPlayer.playerId,
+    });
+
+    if (!preparation.success || !preparation.followUp) {
+      return {
+        success: false,
+        events: [],
+        shouldContinue: false,
+        error: preparation.error ?? 'Failed to prepare COM broken hand reveal',
+      };
+    }
+
+    const completion = await this.revealBrokenHandUseCase.finalize(
+      preparation.followUp,
+    );
+
+    if (!completion.success) {
+      return {
+        success: false,
+        events: [],
+        shouldContinue: false,
+        error: completion.error ?? 'Failed to finalize COM broken hand reveal',
+      };
+    }
+
+    const nextPlayer = gameState.getCurrentPlayer();
+    return {
+      success: true,
+      events: completion.events ?? [],
+      shouldContinue:
+        !!nextPlayer && this.comPlayerService.isComPlayer(nextPlayer),
     };
   }
 }

--- a/mei-tra-backend/src/use-cases/declare-blow.use-case.ts
+++ b/mei-tra-backend/src/use-cases/declare-blow.use-case.ts
@@ -7,7 +7,6 @@ import {
 import { IRoomService } from '../services/interfaces/room-service.interface';
 import { IBlowService } from '../services/interfaces/blow-service.interface';
 import { ICardService } from '../services/interfaces/card-service.interface';
-import { IChomboService } from '../services/interfaces/chombo-service.interface';
 import { GatewayEvent } from './interfaces/gateway-event.interface';
 import {
   buildPlayerSyncEvents,
@@ -18,6 +17,10 @@ import {
   transitionToPlayPhase,
   TransitionResult,
 } from './blow-phase-transition.helper';
+import {
+  getBrokenHandRevealPendingError,
+  getRequiredBrokenHandRevealError,
+} from './helpers/broken-hand.helper';
 
 @Injectable()
 export class DeclareBlowUseCase implements IDeclareBlowUseCase {
@@ -27,7 +30,6 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
     @Inject('IRoomService') private readonly roomService: IRoomService,
     @Inject('IBlowService') private readonly blowService: IBlowService,
     @Inject('ICardService') private readonly cardService: ICardService,
-    @Inject('IChomboService') private readonly chomboService: IChomboService,
     @Optional()
     @Inject('IGameEventLogService')
     private readonly gameEventLogService?: IGameEventLogService,
@@ -44,8 +46,18 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
         return { success: false, error: 'Player not found in game state' };
       }
 
+      const pendingError = await getBrokenHandRevealPendingError(roomGameState);
+      if (pendingError) {
+        return { success: false, error: pendingError };
+      }
+
       if (!roomGameState.isPlayerTurn(player.playerId)) {
         return { success: false, error: "It's not your turn to declare" };
+      }
+
+      const requiredBrokenError = getRequiredBrokenHandRevealError(player);
+      if (requiredBrokenError) {
+        return { success: false, error: requiredBrokenError };
       }
 
       // Check if player has already declared in this blow phase
@@ -145,7 +157,6 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
           state,
           blowService: this.blowService,
           cardService: this.cardService,
-          chomboService: this.chomboService,
           gameEventLogService: this.gameEventLogService,
         });
 
@@ -153,7 +164,6 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
           success: true,
           events: [...events, ...transition.events],
           delayedEvents: transition.delayedEvents,
-          revealBrokenRequest: transition.revealBrokenRequest,
         };
       }
 

--- a/mei-tra-backend/src/use-cases/get-user-recent-game-history.use-case.ts
+++ b/mei-tra-backend/src/use-cases/get-user-recent-game-history.use-case.ts
@@ -46,8 +46,11 @@ export class GetUserRecentGameHistoryUseCase
       }),
     );
 
-    return items.sort(
-      (left, right) => right.completedAt.getTime() - left.completedAt.getTime(),
-    );
+    return items
+      .filter((item) => item.totalEntries > 0)
+      .sort(
+        (left, right) =>
+          right.completedAt.getTime() - left.completedAt.getTime(),
+      );
   }
 }

--- a/mei-tra-backend/src/use-cases/helpers/broken-hand.helper.ts
+++ b/mei-tra-backend/src/use-cases/helpers/broken-hand.helper.ts
@@ -1,0 +1,45 @@
+import { DomainPlayer, GameState } from '../../types/game.types';
+
+export const BROKEN_HAND_REVEAL_PENDING_ERROR = 'Broken hand reveal is pending';
+export const BROKEN_HAND_REVEAL_PENDING_TTL_MS = 10_000;
+export const REQUIRED_BROKEN_HAND_REVEAL_ERROR =
+  'Required broken hand must be revealed';
+
+type BrokenHandRevealPendingState = Pick<
+  GameState,
+  'gamePhase' | 'pendingBrokenHandReveal'
+>;
+
+export interface BrokenHandRevealPendingStateStore {
+  getState(): BrokenHandRevealPendingState;
+  saveState(): Promise<void>;
+}
+
+export async function getBrokenHandRevealPendingError(
+  stateStore: BrokenHandRevealPendingStateStore,
+  now: number = Date.now(),
+): Promise<string | null> {
+  const state = stateStore.getState();
+  if (state.gamePhase !== 'blow') {
+    return null;
+  }
+
+  const pendingReveal = state.pendingBrokenHandReveal;
+  if (!pendingReveal) {
+    return null;
+  }
+
+  if (now - pendingReveal.startedAt > BROKEN_HAND_REVEAL_PENDING_TTL_MS) {
+    state.pendingBrokenHandReveal = null;
+    await stateStore.saveState();
+    return null;
+  }
+
+  return BROKEN_HAND_REVEAL_PENDING_ERROR;
+}
+
+export function getRequiredBrokenHandRevealError(
+  player: Pick<DomainPlayer, 'hasRequiredBroken'>,
+): string | null {
+  return player.hasRequiredBroken ? REQUIRED_BROKEN_HAND_REVEAL_ERROR : null;
+}

--- a/mei-tra-backend/src/use-cases/interfaces/com-autoplay-use-case.interface.ts
+++ b/mei-tra-backend/src/use-cases/interfaces/com-autoplay-use-case.interface.ts
@@ -9,11 +9,6 @@ export interface ComAutoPlayResponse {
   success: boolean;
   events: GatewayEvent[];
   delayedEvents?: GatewayEvent[];
-  revealBrokenRequest?: {
-    roomId: string;
-    playerId: string;
-    actorId: string;
-  };
   completeFieldTrigger?: CompleteFieldTrigger;
   shouldContinue: boolean;
   error?: string;

--- a/mei-tra-backend/src/use-cases/interfaces/declare-blow.use-case.interface.ts
+++ b/mei-tra-backend/src/use-cases/interfaces/declare-blow.use-case.interface.ts
@@ -10,18 +10,11 @@ export interface DeclareBlowRequest {
   };
 }
 
-export interface RevealBrokenRequest {
-  roomId: string;
-  playerId: string;
-  actorId: string;
-}
-
 export interface DeclareBlowResponse {
   success: boolean;
   error?: string;
   events?: GatewayEvent[];
   delayedEvents?: GatewayEvent[];
-  revealBrokenRequest?: RevealBrokenRequest;
 }
 
 export interface IDeclareBlowUseCase {

--- a/mei-tra-backend/src/use-cases/interfaces/pass-blow.use-case.interface.ts
+++ b/mei-tra-backend/src/use-cases/interfaces/pass-blow.use-case.interface.ts
@@ -10,11 +10,6 @@ export interface PassBlowResponse {
   error?: string;
   events?: GatewayEvent[];
   delayedEvents?: GatewayEvent[];
-  revealBrokenRequest?: {
-    roomId: string;
-    playerId: string;
-    actorId: string;
-  };
 }
 
 export interface IPassBlowUseCase {

--- a/mei-tra-backend/src/use-cases/interfaces/reveal-broken-hand.use-case.interface.ts
+++ b/mei-tra-backend/src/use-cases/interfaces/reveal-broken-hand.use-case.interface.ts
@@ -12,6 +12,7 @@ export interface RevealBrokenHandPreparation {
   followUp?: {
     roomId: string;
     playerId: string;
+    handSnapshot?: string[];
   };
   delayMs?: number;
 }
@@ -29,5 +30,6 @@ export interface IRevealBrokenHandUseCase {
   finalize(followUp: {
     roomId: string;
     playerId: string;
+    handSnapshot?: string[];
   }): Promise<RevealBrokenHandCompletion>;
 }

--- a/mei-tra-backend/src/use-cases/pass-blow.use-case.ts
+++ b/mei-tra-backend/src/use-cases/pass-blow.use-case.ts
@@ -8,7 +8,6 @@ import {
 import { IRoomService } from '../services/interfaces/room-service.interface';
 import { IBlowService } from '../services/interfaces/blow-service.interface';
 import { ICardService } from '../services/interfaces/card-service.interface';
-import { IChomboService } from '../services/interfaces/chombo-service.interface';
 import { GatewayEvent } from './interfaces/gateway-event.interface';
 import { GameState } from '../types/game.types';
 import { GameStateService } from '../services/game-state.service';
@@ -22,6 +21,10 @@ import {
   transitionToPlayPhase,
   TransitionResult,
 } from './blow-phase-transition.helper';
+import {
+  getBrokenHandRevealPendingError,
+  getRequiredBrokenHandRevealError,
+} from './helpers/broken-hand.helper';
 
 @Injectable()
 export class PassBlowUseCase implements IPassBlowUseCase {
@@ -31,7 +34,6 @@ export class PassBlowUseCase implements IPassBlowUseCase {
     @Inject('IRoomService') private readonly roomService: IRoomService,
     @Inject('IBlowService') private readonly blowService: IBlowService,
     @Inject('ICardService') private readonly cardService: ICardService,
-    @Inject('IChomboService') private readonly chomboService: IChomboService,
     @Optional()
     @Inject('IGameEventLogService')
     private readonly gameEventLogService?: IGameEventLogService,
@@ -48,8 +50,18 @@ export class PassBlowUseCase implements IPassBlowUseCase {
         return { success: false, error: 'Player not found in game state' };
       }
 
+      const pendingError = await getBrokenHandRevealPendingError(roomGameState);
+      if (pendingError) {
+        return { success: false, error: pendingError };
+      }
+
       if (!roomGameState.isPlayerTurn(player.playerId)) {
         return { success: false, error: "It's not your turn to pass" };
+      }
+
+      const requiredBrokenError = getRequiredBrokenHandRevealError(player);
+      if (requiredBrokenError) {
+        return { success: false, error: requiredBrokenError };
       }
 
       // Check if player has already passed in this blow phase
@@ -148,7 +160,6 @@ export class PassBlowUseCase implements IPassBlowUseCase {
           state,
           blowService: this.blowService,
           cardService: this.cardService,
-          chomboService: this.chomboService,
           gameEventLogService: this.gameEventLogService,
         });
 
@@ -156,7 +167,6 @@ export class PassBlowUseCase implements IPassBlowUseCase {
           success: true,
           events: [...events, ...transition.events],
           delayedEvents: transition.delayedEvents,
-          revealBrokenRequest: transition.revealBrokenRequest,
         };
       }
 

--- a/mei-tra-backend/src/use-cases/process-game-over.use-case.ts
+++ b/mei-tra-backend/src/use-cases/process-game-over.use-case.ts
@@ -103,6 +103,8 @@ export class ProcessGameOverUseCase implements IProcessGameOverUseCase {
         finalScores: teamScores,
       },
     });
+
+    await this.gameEventLogService?.pruneFinishedRoomHistory?.();
   }
 
   private resolveAuthenticatedUserId(

--- a/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
@@ -43,7 +43,7 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
         return { success: false, error: 'Player mismatch for broken hand' };
       }
 
-      if (!player.hasRequiredBroken) {
+      if (!this.hasRevealableBrokenHand(player)) {
         return { success: false, error: 'Player does not have broken hand' };
       }
 
@@ -76,7 +76,7 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
         return { success: false, error: 'Player not found in game state' };
       }
 
-      if (!player.hasRequiredBroken) {
+      if (!this.hasRevealableBrokenHand(player)) {
         return { success: false, error: 'Player does not have broken hand' };
       }
 
@@ -186,5 +186,12 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
     }
 
     return currentHand.every((card, index) => card === snapshot[index]);
+  }
+
+  private hasRevealableBrokenHand(player: {
+    hasBroken?: boolean;
+    hasRequiredBroken?: boolean;
+  }): boolean {
+    return Boolean(player.hasBroken || player.hasRequiredBroken);
   }
 }

--- a/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
@@ -43,10 +43,14 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
         return { success: false, error: 'Player mismatch for broken hand' };
       }
 
+      if (!player.hasRequiredBroken) {
+        return { success: false, error: 'Player does not have broken hand' };
+      }
+
       return {
         success: true,
         delayMs: 3000,
-        followUp: { roomId, playerId },
+        followUp: { roomId, playerId, handSnapshot: [...player.hand] },
       };
     } catch (error) {
       this.logger.error(
@@ -60,6 +64,7 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
   async finalize(followUp: {
     roomId: string;
     playerId: string;
+    handSnapshot?: string[];
   }): Promise<RevealBrokenHandCompletion> {
     try {
       const { roomId, playerId } = followUp;
@@ -69,6 +74,17 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
 
       if (!player) {
         return { success: false, error: 'Player not found in game state' };
+      }
+
+      if (!player.hasRequiredBroken) {
+        return { success: false, error: 'Player does not have broken hand' };
+      }
+
+      if (
+        followUp.handSnapshot &&
+        !this.isSameHand(player.hand, followUp.handSnapshot)
+      ) {
+        return { success: false, error: 'Broken hand request is stale' };
       }
 
       await roomGameState.transitionPhase('blow');
@@ -162,5 +178,13 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
       );
       return { success: false, error: 'Internal server error' };
     }
+  }
+
+  private isSameHand(currentHand: string[], snapshot: string[]): boolean {
+    if (currentHand.length !== snapshot.length) {
+      return false;
+    }
+
+    return currentHand.every((card, index) => card === snapshot[index]);
   }
 }

--- a/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
@@ -14,6 +14,7 @@ import {
   resolvePlayerByActorId,
   resolveTransportPlayers,
 } from './helpers/player-resolution.helper';
+import { getBrokenHandRevealPendingError } from './helpers/broken-hand.helper';
 
 @Injectable()
 export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
@@ -33,6 +34,7 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
     try {
       const { roomId, actorId, playerId } = request;
       const roomGameState = await this.roomService.getRoomGameState(roomId);
+      const state = roomGameState.getState();
       const player = resolvePlayerByActorId(roomGameState, actorId);
 
       if (!player) {
@@ -43,14 +45,38 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
         return { success: false, error: 'Player mismatch for broken hand' };
       }
 
+      if (state.gamePhase !== 'blow') {
+        return { success: false, error: 'Cannot reveal broken hand now' };
+      }
+
+      const hasDeclared = state.blowState.declarations.some(
+        (declaration) => declaration.playerId === playerId,
+      );
+      if (player.isPasser || hasDeclared) {
+        return { success: false, error: 'Cannot reveal broken hand now' };
+      }
+
       if (!this.hasRevealableBrokenHand(player)) {
         return { success: false, error: 'Player does not have broken hand' };
       }
 
+      const pendingError = await getBrokenHandRevealPendingError(roomGameState);
+      if (pendingError) {
+        return { success: false, error: pendingError };
+      }
+
+      const handSnapshot = [...player.hand];
+      state.pendingBrokenHandReveal = {
+        playerId,
+        handSnapshot,
+        startedAt: Date.now(),
+      };
+      await roomGameState.saveState();
+
       return {
         success: true,
         delayMs: 3000,
-        followUp: { roomId, playerId, handSnapshot: [...player.hand] },
+        followUp: { roomId, playerId, handSnapshot },
       };
     } catch (error) {
       this.logger.error(
@@ -80,15 +106,27 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
         return { success: false, error: 'Player does not have broken hand' };
       }
 
+      const pendingReveal = state.pendingBrokenHandReveal;
+      if (!pendingReveal || pendingReveal.playerId !== playerId) {
+        return { success: false, error: 'Broken hand reveal is not pending' };
+      }
+
       if (
         followUp.handSnapshot &&
-        !this.isSameHand(player.hand, followUp.handSnapshot)
+        !this.isSameHand(pendingReveal.handSnapshot, followUp.handSnapshot)
       ) {
+        return { success: false, error: 'Broken hand request is stale' };
+      }
+
+      if (!this.isSameHand(player.hand, pendingReveal.handSnapshot)) {
+        state.pendingBrokenHandReveal = null;
+        await roomGameState.saveState();
         return { success: false, error: 'Broken hand request is stale' };
       }
 
       await roomGameState.transitionPhase('blow');
       const nextState = roomGameState.getState();
+      nextState.pendingBrokenHandReveal = null;
 
       nextState.playState = {
         currentField: null,

--- a/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
@@ -124,7 +124,6 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
         return { success: false, error: 'Broken hand request is stale' };
       }
 
-      await roomGameState.transitionPhase('blow');
       const nextState = roomGameState.getState();
       nextState.pendingBrokenHandReveal = null;
 

--- a/mei-tra-frontend/components/game/GameHistoryDock.module.scss
+++ b/mei-tra-frontend/components/game/GameHistoryDock.module.scss
@@ -330,6 +330,10 @@
   }
 }
 
+.handSnapshotItem {
+  list-style: none;
+}
+
 .eventMetaRow {
   display: flex;
   align-items: flex-start;

--- a/mei-tra-frontend/components/game/GameHistoryDock.tsx
+++ b/mei-tra-frontend/components/game/GameHistoryDock.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import { useTranslations } from 'next-intl';
 import { useGameHistory } from '@/hooks/useGameHistory';
 import { Link } from '@/i18n/routing';
@@ -530,76 +531,151 @@ export function GameHistoryDock({
     return [...highlights].slice(0, 4);
   };
 
+  const renderEventItem = (
+    event: GameHistoryReplayEvent,
+    roundNumber: number | null,
+  ) => {
+    const eventDetails = getEventDetails(event);
+
+    return (
+      <li key={event.id} className={styles.eventItem}>
+        <div className={styles.eventMetaRow}>
+          <div className={styles.eventTimestamp}>
+            {event.timestamp.toLocaleTimeString()}
+          </div>
+          <div className={styles.eventBadges}>
+            <span className={styles.eventBadge}>
+              {roundNumber === null
+                ? t('preGame')
+                : t('round', { round: roundNumber })}
+            </span>
+            <span className={styles.eventBadge}>
+              {getActionLabel(event.actionType)}
+            </span>
+            {formatPlayer(event.playerId) ? (
+              <span className={styles.eventBadgeMuted}>
+                {formatPlayer(event.playerId)}
+              </span>
+            ) : null}
+          </div>
+        </div>
+        <div className={styles.eventSummary}>
+          {formatEventSummary(event)}
+        </div>
+        {eventDetails.length > 0 ? (
+          <div className={styles.eventDetails}>
+            {eventDetails.map((detail) => (
+              <span key={`${event.id}-${detail}`} className={styles.detailChip}>
+                {detail}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </li>
+    );
+  };
+
   const renderEventList = (
     items: Array<{ event: GameHistoryReplayEvent; roundNumber: number | null }>,
   ) => (
     <ul className={styles.eventList}>
-      {items.map(({ event, roundNumber }) => {
-        const eventDetails = getEventDetails(event);
-
-        return (
-          <li key={event.id} className={styles.eventItem}>
-            <div className={styles.eventMetaRow}>
-              <div className={styles.eventTimestamp}>
-                {event.timestamp.toLocaleTimeString()}
-              </div>
-              <div className={styles.eventBadges}>
-                <span className={styles.eventBadge}>
-                  {roundNumber === null
-                    ? t('preGame')
-                    : t('round', { round: roundNumber })}
-                </span>
-                <span className={styles.eventBadge}>
-                  {getActionLabel(event.actionType)}
-                </span>
-                {formatPlayer(event.playerId) ? (
-                  <span className={styles.eventBadgeMuted}>
-                    {formatPlayer(event.playerId)}
-                  </span>
-                ) : null}
-              </div>
-            </div>
-            <div className={styles.eventSummary}>
-              {formatEventSummary(event)}
-            </div>
-            {eventDetails.length > 0 ? (
-              <div className={styles.eventDetails}>
-                {eventDetails.map((detail) => (
-                  <span key={`${event.id}-${detail}`} className={styles.detailChip}>
-                    {detail}
-                  </span>
-                ))}
-              </div>
-            ) : null}
-          </li>
-        );
-      })}
+      {items.map(({ event, roundNumber }) => renderEventItem(event, roundNumber))}
     </ul>
   );
 
-  const renderStartingHand = (round: GameHistoryReplayRound) => {
-    const hand = round.viewerStartingHand ?? [];
+  const extractViewerHand = (event: GameHistoryReplayEvent): string[] => {
+    const hand = event.actionData.viewerStartingHand;
 
-    return (
-      <div className={styles.startingHandPanel}>
-        <span className={styles.startingHandLabel}>{t('startingHand')}</span>
-        {hand.length > 0 ? (
-          <div className={styles.startingHandCards}>
-            {hand.map((card, index) => (
-              <CardFace
-                key={`${round.roundNumber}-${card}-${index}`}
-                card={card}
-                className={styles.startingHandCard}
-              />
-            ))}
-          </div>
-        ) : (
-          <span className={styles.startingHandEmpty}>{t('noStartingHand')}</span>
-        )}
-      </div>
-    );
+    return Array.isArray(hand)
+      ? hand.filter((card): card is string => typeof card === 'string')
+      : [];
   };
 
+  const renderHandSnapshot = (
+    label: string,
+    hand: string[],
+    keyPrefix: string,
+  ) => (
+    <div className={styles.startingHandPanel}>
+      <span className={styles.startingHandLabel}>{label}</span>
+      {hand.length > 0 ? (
+        <div className={styles.startingHandCards}>
+          {hand.map((card, index) => (
+            <CardFace
+              key={`${keyPrefix}-${card}-${index}`}
+              card={card}
+              className={styles.startingHandCard}
+            />
+          ))}
+        </div>
+      ) : (
+        <span className={styles.startingHandEmpty}>{t('noStartingHand')}</span>
+      )}
+    </div>
+  );
+
+  const renderRoundTimeline = (
+    round: GameHistoryReplayRound,
+    events: GameHistoryReplayEvent[],
+  ) => {
+    const items: ReactNode[] = [];
+    let renderedInitialHand = false;
+
+    events.forEach((event) => {
+      const hand = extractViewerHand(event);
+      const isBrokenHand = event.actionType === 'broken_hand_revealed';
+
+      if (hand.length > 0 && !isBrokenHand && !renderedInitialHand) {
+        items.push(
+          <li
+            key={`${event.id}-starting-hand`}
+            className={styles.handSnapshotItem}
+          >
+            {renderHandSnapshot(
+              t('startingHand'),
+              hand,
+              `${event.id}-starting-hand`,
+            )}
+          </li>,
+        );
+        renderedInitialHand = true;
+      }
+
+      items.push(renderEventItem(event, round.roundNumber));
+
+      if (hand.length > 0 && isBrokenHand) {
+        items.push(
+          <li
+            key={`${event.id}-redealt-hand`}
+            className={styles.handSnapshotItem}
+          >
+            {renderHandSnapshot(
+              t('redealtHand'),
+              hand,
+              `${event.id}-redealt-hand`,
+            )}
+          </li>,
+        );
+      }
+    });
+
+    if (!renderedInitialHand && items.length > 0) {
+      items.unshift(
+        <li
+          key={`${round.roundNumber ?? 'pre-game'}-starting-hand-fallback`}
+          className={styles.handSnapshotItem}
+        >
+          {renderHandSnapshot(
+            t('startingHand'),
+            round.viewerStartingHand ?? [],
+            `${round.roundNumber ?? 'pre-game'}-starting-hand-fallback`,
+          )}
+        </li>,
+      );
+    }
+
+    return <ul className={styles.eventList}>{items}</ul>;
+  };
   if (variant === 'dock' && isMinimized) {
     return (
       <div className={styles.minimized}>
@@ -830,7 +906,6 @@ export function GameHistoryDock({
                         </div>
                       </summary>
                       <div className={styles.roundSectionBody}>
-                        {renderStartingHand(round)}
                         {roundHighlights.length > 0 ? (
                           <div className={styles.breakdown}>
                             {roundHighlights.map((highlight) => (
@@ -840,12 +915,7 @@ export function GameHistoryDock({
                             ))}
                           </div>
                         ) : null}
-                        {renderEventList(
-                          chronologicalEvents.map((event) => ({
-                            event,
-                            roundNumber: round.roundNumber,
-                          })),
-                        )}
+                        {renderRoundTimeline(round, chronologicalEvents)}
                       </div>
                     </details>
                   );

--- a/mei-tra-frontend/components/game/GameHistoryDock.tsx
+++ b/mei-tra-frontend/components/game/GameHistoryDock.tsx
@@ -105,7 +105,7 @@ export function GameHistoryDock({
     'all' | GameHistoryActionType
   >('all');
   const [selectedPlayerId, setSelectedPlayerId] = useState<'all' | string>('all');
-  const entryLimit = variant === 'page' ? 250 : 25;
+  const entryLimit = variant === 'page' ? undefined : 25;
   const historyEnabled = variant === 'page' || !isMinimized;
   const replayQuery = useMemo(
     () => ({

--- a/mei-tra-frontend/messages/en.json
+++ b/mei-tra-frontend/messages/en.json
@@ -420,6 +420,7 @@
     "noLastAction": "None",
     "entriesMetric": "{count} entries",
     "startingHand": "Your starting hand this round",
+    "redealtHand": "Your hand after redeal",
     "noStartingHand": "No hand log",
     "unknownPlayer": "Unknown player",
     "unknownValue": "Unknown",

--- a/mei-tra-frontend/messages/ja.json
+++ b/mei-tra-frontend/messages/ja.json
@@ -420,6 +420,7 @@
     "noLastAction": "なし",
     "entriesMetric": "{count}件",
     "startingHand": "このラウンドの自分の手札",
+    "redealtHand": "繰り直し後の自分の手札",
     "noStartingHand": "手札ログなし",
     "unknownPlayer": "不明なプレイヤー",
     "unknownValue": "不明",


### PR DESCRIPTION
## Summary
- Show replay rounds as a chronological timeline so broken-hand rounds keep the pre-broken hand, broken-hand reveal, redealt hand, then subsequent blow/play events in order.
- Log `broken_hand_revealed` with redealt starting hands and guard delayed broken-hand finalization with the prepared hand snapshot.
- Limit retained game history for finished rooms and keep recent-history queries bounded.

## Impact
- Replay viewers can distinguish the original broken hand from the redealt hand instead of seeing only a final-state snapshot.
- Stale delayed broken-hand callbacks are rejected before mutating state or writing misleading replay history.
- Finished-room history pruning reduces retained replay data volume.

## Validation
- Previously validated on this commit set: backend `npm test -- --runInBand`, `npm run lint`, `npm run build`; frontend `npm run lint`, `npm run build`.
- No additional validation run during branch recreation; this PR only moves the already-pushed commits to a new branch.
