### PR TITLE
[codex] Add explicit Supabase Data API grants

### DIFF
--- a/mei-tra-backend/supabase/migrations/20260527120523_add_explicit_data_api_grants.sql
+++ b/mei-tra-backend/supabase/migrations/20260527120523_add_explicit_data_api_grants.sql
@@ -1,0 +1,27 @@
+-- Supabase no longer exposes new public tables to the Data API by default.
+-- Keep these grants explicit so fresh projects and future resets work through
+-- PostgREST / supabase-js without relying on legacy default privileges.
+
+grant select, insert, update, delete on table
+  public.rooms,
+  public.room_players,
+  public.game_states,
+  public.game_history,
+  public.user_profiles,
+  public.chat_rooms,
+  public.chat_members,
+  public.chat_messages
+to service_role;
+
+grant usage, select on all sequences in schema public to service_role;
+
+-- Browser clients read public profiles directly during auth/profile loading.
+grant select on table public.user_profiles to anon, authenticated;
+grant insert, update on table public.user_profiles to authenticated;
+
+-- Chat RLS policies allow public room discovery and authenticated message reads.
+grant select on table public.chat_rooms to anon, authenticated;
+grant select on table public.chat_members to authenticated;
+grant select on table public.chat_messages to authenticated;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- Add an explicit Supabase migration for Data API table grants
- Grant backend `service_role` access to existing public tables used through `supabase-js`
- Grant browser-facing access for `user_profiles` and chat read paths according to existing RLS policies

## Why
Supabase is changing public-schema defaults so new tables are not exposed to the Data API automatically. This keeps fresh projects and future resets from relying on legacy default privileges.

## Validation
- `cd mei-tra-backend && supabase db lint`
- `cd mei-tra-backend && supabase migration up`
