### PR TITLE
[codex] Add COM play theory leads

### DIFF
--- a/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
@@ -142,6 +142,34 @@ describe('ComStrategyService', () => {
     expect(strategy.chooseBlowAction(gameState, com)).toEqual({ type: 'pass' });
   });
 
+  it('overcalls a partner declaration from one pair higher', () => {
+    const com = player(
+      'com-0',
+      0,
+      ['JOKER', 'J♥', 'J♦', 'A♥', 'K♥', 'Q♥', '10♥', 'A♠', '5♣', '6♦'],
+      { isCOM: true },
+    );
+    const partner = player('partner-0', 0);
+    const gameState = state({
+      players: [com, player('e1', 1), partner, player('e2', 1)],
+      blowState: {
+        currentHighestDeclaration: {
+          playerId: partner.playerId,
+          trumpType: 'club',
+          numberOfPairs: 6,
+          timestamp: Date.now(),
+        },
+      } as Partial<BlowState> as BlowState,
+    });
+
+    const action = strategy.chooseBlowAction(gameState, com);
+
+    expect(action.type).toBe('declare');
+    if (action.type === 'declare') {
+      expect(action.declaration.numberOfPairs).toBe(7);
+    }
+  });
+
   it('selects low off-trump negri and avoids Joker, jacks, and high trump', () => {
     const com = player(
       'com-0',

--- a/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
@@ -206,6 +206,66 @@ describe('ComStrategyService', () => {
     expect(strategy.choosePlayCard(gameState, com)).toBe('5♣');
   });
 
+  it('leads trump during the first two tricks when the COM team declares', () => {
+    const com = player(
+      'com-0',
+      0,
+      ['A♥', '5♥', 'K♠', '5♠', '8♣', 'Q♦', '7♣', '9♦', '10♣', '6♦'],
+      { isCOM: true },
+    );
+    const partner = player('partner-0', 0);
+    const gameState = leadState(com, 'herz', {
+      currentHighestDeclaration: {
+        playerId: partner.playerId,
+        trumpType: 'herz',
+        numberOfPairs: 6,
+        timestamp: Date.now(),
+      },
+    });
+
+    expect(strategy.choosePlayCard(gameState, com)).toBe('A♥');
+  });
+
+  it('does not use low-gon on the trump suit', () => {
+    const com = player(
+      'com-0',
+      0,
+      ['K♥', '5♥', '8♣', 'Q♦', '7♣', '9♦', '10♣', '6♦', '5♠', '8♠'],
+      { isCOM: true },
+    );
+    const enemy = player('enemy-1', 1);
+    const gameState = leadState(com, 'herz', {
+      currentHighestDeclaration: {
+        playerId: enemy.playerId,
+        trumpType: 'herz',
+        numberOfPairs: 6,
+        timestamp: Date.now(),
+      },
+    });
+
+    expect(strategy.choosePlayCard(gameState, com)).not.toBe('5♥');
+  });
+
+  it('leads the low card first when holding low-gon without the ace', () => {
+    const com = player(
+      'com-0',
+      0,
+      ['K♠', '5♠', '8♣', 'Q♦', '7♣', '9♦', '10♣', '6♦', '5♥', '8♥'],
+      { isCOM: true },
+    );
+    const enemy = player('enemy-1', 1);
+    const gameState = leadState(com, 'herz', {
+      currentHighestDeclaration: {
+        playerId: enemy.playerId,
+        trumpType: 'herz',
+        numberOfPairs: 6,
+        timestamp: Date.now(),
+      },
+    });
+
+    expect(strategy.choosePlayCard(gameState, com)).toBe('5♠');
+  });
+
   it('selects the strongest supported suit after leading Joker', () => {
     const com = player('com-0', 0, ['A♣', 'K♣', '5♣', 'A♠', '6♥'], {
       isCOM: true,
@@ -243,6 +303,38 @@ describe('ComStrategyService', () => {
       players,
       gamePhase: 'play',
       blowState: { currentTrump: trump } as Partial<BlowState> as BlowState,
+      playState: playStateValue,
+    });
+  }
+
+  function leadState(
+    com: DomainPlayer,
+    trump: TrumpType | null,
+    blowState: Partial<BlowState> = {},
+  ): GameState {
+    const players = [
+      com,
+      player('enemy-1', 1),
+      player('partner-0', 0),
+      player('enemy-2', 1),
+    ];
+    const playStateValue: PlayState = {
+      currentField: null,
+      negriCard: null,
+      neguri: {},
+      fields: [],
+      lastWinnerId: null,
+      openDeclared: false,
+      openDeclarerId: null,
+    };
+
+    return state({
+      players,
+      gamePhase: 'play',
+      blowState: {
+        currentTrump: trump,
+        ...blowState,
+      } as Partial<BlowState> as BlowState,
       playState: playStateValue,
     });
   }

--- a/mei-tra-backend/src/services/com-strategy.service.ts
+++ b/mei-tra-backend/src/services/com-strategy.service.ts
@@ -213,14 +213,27 @@ export class ComStrategyService implements IComStrategyService {
     const declaringTeam = this.findDeclaringTeam(state);
     const teamTaken = this.countCompletedFieldsByTeam(state, comPlayer.team);
     const declaration = state.blowState.currentHighestDeclaration;
+    const completedTricks = state.playState?.fields.length ?? 0;
     const remainingTricks = comPlayer.hand.length;
     const needsWins =
       declaringTeam === comPlayer.team &&
       declaration != null &&
       declaration.numberOfPairs - teamTaken >= remainingTricks - 1;
 
+    if (declaringTeam === comPlayer.team && completedTricks < 2) {
+      const trumpLead = this.chooseTrumpLeadCard(legalCards, trump);
+      if (trumpLead) {
+        return trumpLead;
+      }
+    }
+
     if (needsWins || remainingTricks <= 3) {
       return this.chooseStrongestControlCard(legalCards, trump);
+    }
+
+    const lowGonLead = this.chooseLowGonLeadCard(legalCards, trump);
+    if (lowGonLead) {
+      return lowGonLead;
     }
 
     if (declaringTeam === comPlayer.team) {
@@ -238,6 +251,49 @@ export class ComStrategyService implements IComStrategyService {
       nonControlCards.length > 0 ? nonControlCards : legalCards,
       trump,
     );
+  }
+
+  private chooseTrumpLeadCard(
+    legalCards: string[],
+    trump: TrumpType | null,
+  ): string | null {
+    const trumpCards = legalCards.filter((card) =>
+      this.isTrumpCard(card, trump),
+    );
+    return trumpCards.length > 0
+      ? this.chooseStrongestControlCard(trumpCards, trump)
+      : null;
+  }
+
+  private chooseLowGonLeadCard(
+    legalCards: string[],
+    trump: TrumpType | null,
+  ): string | null {
+    const trumpSuit = trump && trump !== 'tra' ? TRUMP_TO_SUIT[trump] : '';
+    const candidates: string[] = [];
+
+    for (const suit of SUITS) {
+      if (suit === trumpSuit) {
+        continue;
+      }
+
+      const suitCards = legalCards.filter(
+        (card) =>
+          card !== 'JOKER' &&
+          this.cardService.getCardSuit(card, trump) === suit,
+      );
+      const hasKing = suitCards.some((card) => this.getRank(card) === 'K');
+      const hasAce = suitCards.some((card) => this.getRank(card) === 'A');
+      if (!hasKing || hasAce) {
+        continue;
+      }
+
+      candidates.push(...suitCards.filter((card) => this.isLowCard(card)));
+    }
+
+    return candidates.length > 0
+      ? this.chooseLowestDiscard(candidates, trump)
+      : null;
   }
 
   private findLowestValidDeclaration(
@@ -533,6 +589,24 @@ export class ComStrategyService implements IComStrategyService {
       this.isSecondaryJack(card, trump) ||
       (trumpSuit !== '' && suit === trumpSuit)
     );
+  }
+
+  private isTrumpCard(card: string, trump: TrumpType | null): boolean {
+    if (!trump || trump === 'tra' || card === 'JOKER') {
+      return false;
+    }
+
+    const trumpSuit = TRUMP_TO_SUIT[trump];
+    const suit = this.cardService.getCardSuit(card, trump);
+    return (
+      this.isPrimaryJack(card, trump) ||
+      this.isSecondaryJack(card, trump) ||
+      suit === trumpSuit
+    );
+  }
+
+  private isLowCard(card: string): boolean {
+    return ['5', '6', '7', '8', '9'].includes(this.getRank(card));
   }
 
   private baseSuitControlScore(

--- a/mei-tra-backend/src/services/com-strategy.service.ts
+++ b/mei-tra-backend/src/services/com-strategy.service.ts
@@ -50,6 +50,7 @@ const MAX_ESTIMATED_PAIRS = 10;
 const JOKER_SCORE = 2.2;
 const PRIMARY_JACK_SCORE = 1.5;
 const SECONDARY_JACK_SCORE = 1.2;
+const PARTNER_OVERCALL_PAIR_STEP = 1;
 
 @Injectable()
 export class ComStrategyService implements IComStrategyService {
@@ -89,10 +90,11 @@ export class ComStrategyService implements IComStrategyService {
     if (currentHighestIsPartner) {
       const best = evaluations[0];
       // 味方が最高宣言中なら基本は邪魔しない。
-      // 例外として、味方宣言より2ペア以上高く見積もれる場合だけovercallする。
+      // 例外として、味方宣言より1ペア以上高く見積もれる場合だけovercallする。
       const shouldOvercallPartner =
         currentHighest != null &&
-        best.estimatedPairs >= currentHighest.numberOfPairs + 2;
+        best.estimatedPairs >=
+          currentHighest.numberOfPairs + PARTNER_OVERCALL_PAIR_STEP;
 
       if (!shouldOvercallPartner) {
         return { type: 'pass' };
@@ -321,7 +323,7 @@ export class ComStrategyService implements IComStrategyService {
         if (
           currentHighestIsPartner &&
           currentHighest != null &&
-          pairs < currentHighest.numberOfPairs + 2
+          pairs < currentHighest.numberOfPairs + PARTNER_OVERCALL_PAIR_STEP
         ) {
           continue;
         }


### PR DESCRIPTION
## Summary
- Add an early-trick trump lead theory for the declaring team COM play
- Add low-gon lead selection for non-trump suits with K + low card and no A
- Cover declaring-team trump leads, trump-suit low-gon exclusion, and low-gon lead selection with unit tests

## Validation
- `cd mei-tra-backend && npm test -- --runInBand src/services/__tests__/com-strategy.service.spec.ts`
- `cd mei-tra-backend && npm run lint`
