### PR TITLE
[codex] Count COM trump leads for opening theory

### DIFF
--- a/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
@@ -283,6 +283,31 @@ describe('ComStrategyService', () => {
     expect(strategy.choosePlayCard(gameState, com)).toBe('A♥');
   });
 
+  it('ignores empty completed fields when counting trump leads', () => {
+    const com = player(
+      'com-0',
+      0,
+      ['A♥', '5♥', 'K♠', '5♠', '8♣', 'Q♦', '7♣', '9♦', '10♣', '6♦'],
+      { isCOM: true },
+    );
+    const partner = player('partner-0', 0);
+    const gameState = leadState(
+      com,
+      'herz',
+      {
+        currentHighestDeclaration: {
+          playerId: partner.playerId,
+          trumpType: 'herz',
+          numberOfPairs: 6,
+          timestamp: Date.now(),
+        },
+      },
+      [completedField([])],
+    );
+
+    expect(strategy.choosePlayCard(gameState, com)).toBe('A♥');
+  });
+
   it('does not use low-gon on the trump suit', () => {
     const com = player(
       'com-0',

--- a/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
@@ -4,6 +4,7 @@ import { ComStrategyService } from '../com-strategy.service';
 import { PlayService } from '../play.service';
 import {
   BlowState,
+  CompletedField,
   DomainPlayer,
   Field,
   GamePhase,
@@ -254,6 +255,34 @@ describe('ComStrategyService', () => {
     expect(strategy.choosePlayCard(gameState, com)).toBe('A♥');
   });
 
+  it('counts completed trump leads instead of total completed tricks', () => {
+    const com = player(
+      'com-0',
+      0,
+      ['A♥', '5♥', 'K♠', '5♠', '8♣', 'Q♦', '7♣', '9♦', '10♣', '6♦'],
+      { isCOM: true },
+    );
+    const partner = player('partner-0', 0);
+    const gameState = leadState(
+      com,
+      'herz',
+      {
+        currentHighestDeclaration: {
+          playerId: partner.playerId,
+          trumpType: 'herz',
+          numberOfPairs: 6,
+          timestamp: Date.now(),
+        },
+      },
+      [
+        completedField(['5♠', 'A♠', '6♠', '7♠']),
+        completedField(['6♣', 'A♣', '7♣', '8♣']),
+      ],
+    );
+
+    expect(strategy.choosePlayCard(gameState, com)).toBe('A♥');
+  });
+
   it('does not use low-gon on the trump suit', () => {
     const com = player(
       'com-0',
@@ -339,6 +368,7 @@ describe('ComStrategyService', () => {
     com: DomainPlayer,
     trump: TrumpType | null,
     blowState: Partial<BlowState> = {},
+    completedFields: CompletedField[] = [],
   ): GameState {
     const players = [
       com,
@@ -350,7 +380,7 @@ describe('ComStrategyService', () => {
       currentField: null,
       negriCard: null,
       neguri: {},
-      fields: [],
+      fields: completedFields,
       lastWinnerId: null,
       openDeclared: false,
       openDeclarerId: null,
@@ -365,5 +395,14 @@ describe('ComStrategyService', () => {
       } as Partial<BlowState> as BlowState,
       playState: playStateValue,
     });
+  }
+
+  function completedField(cards: string[]): CompletedField {
+    return {
+      cards,
+      winnerId: 'winner',
+      winnerTeam: 0,
+      dealerId: 'leader',
+    };
   }
 });

--- a/mei-tra-backend/src/services/com-strategy.service.ts
+++ b/mei-tra-backend/src/services/com-strategy.service.ts
@@ -215,14 +215,14 @@ export class ComStrategyService implements IComStrategyService {
     const declaringTeam = this.findDeclaringTeam(state);
     const teamTaken = this.countCompletedFieldsByTeam(state, comPlayer.team);
     const declaration = state.blowState.currentHighestDeclaration;
-    const completedTricks = state.playState?.fields.length ?? 0;
+    const completedTrumpLeadCount = this.countCompletedTrumpLeads(state, trump);
     const remainingTricks = comPlayer.hand.length;
     const needsWins =
       declaringTeam === comPlayer.team &&
       declaration != null &&
       declaration.numberOfPairs - teamTaken >= remainingTricks - 1;
 
-    if (declaringTeam === comPlayer.team && completedTricks < 2) {
+    if (declaringTeam === comPlayer.team && completedTrumpLeadCount < 2) {
       const trumpLead = this.chooseTrumpLeadCard(legalCards, trump);
       if (trumpLead) {
         return trumpLead;
@@ -296,6 +296,17 @@ export class ComStrategyService implements IComStrategyService {
     return candidates.length > 0
       ? this.chooseLowestDiscard(candidates, trump)
       : null;
+  }
+
+  private countCompletedTrumpLeads(
+    state: GameState,
+    trump: TrumpType | null,
+  ): number {
+    return (
+      state.playState?.fields.filter((field) =>
+        this.isTrumpCard(field.cards[0], trump),
+      ).length ?? 0
+    );
   }
 
   private findLowestValidDeclaration(

--- a/mei-tra-backend/src/services/com-strategy.service.ts
+++ b/mei-tra-backend/src/services/com-strategy.service.ts
@@ -303,9 +303,10 @@ export class ComStrategyService implements IComStrategyService {
     trump: TrumpType | null,
   ): number {
     return (
-      state.playState?.fields.filter((field) =>
-        this.isTrumpCard(field.cards[0], trump),
-      ).length ?? 0
+      state.playState?.fields.filter((field) => {
+        const leadCard = field.cards[0];
+        return leadCard != null && this.isTrumpCard(leadCard, trump);
+      }).length ?? 0
     );
   }
 


### PR DESCRIPTION
## Summary
- Change COM opening trump theory to count completed fields whose lead card was trump
- Keep the declaring team leading trump until two completed trump leads exist, instead of using total completed trick count
- Add a regression test where two completed tricks exist but neither was led with trump

## Validation
- `cd mei-tra-backend && npm test -- --runInBand src/services/__tests__/com-strategy.service.spec.ts`
- `cd mei-tra-backend && npm run lint`
