### PR TITLE
[codex] Refine COM leads after trump pulls

### DIFF
--- a/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
@@ -308,6 +308,90 @@ describe('ComStrategyService', () => {
     expect(strategy.choosePlayCard(gameState, com)).toBe('A♥');
   });
 
+  it('leads a non-trump ace after two completed trump leads when wins are not urgent', () => {
+    const com = player(
+      'com-0',
+      0,
+      ['A♥', 'K♥', 'Q♥', 'A♠', '8♣', 'Q♦', '7♣', '9♦', '10♣', '6♦'],
+      { isCOM: true },
+    );
+    const partner = player('partner-0', 0);
+    const gameState = leadState(
+      com,
+      'herz',
+      {
+        currentHighestDeclaration: {
+          playerId: partner.playerId,
+          trumpType: 'herz',
+          numberOfPairs: 6,
+          timestamp: Date.now(),
+        },
+      },
+      [
+        completedField(['5♥', 'A♠', '6♠', '7♠'], 0),
+        completedField(['6♥', 'A♣', '7♣', '8♣'], 1),
+      ],
+    );
+
+    expect(strategy.choosePlayCard(gameState, com)).toBe('A♠');
+  });
+
+  it('uses low-gon after two trump leads when there is no non-trump ace', () => {
+    const com = player(
+      'com-0',
+      0,
+      ['A♥', 'K♥', 'Q♥', 'K♠', '5♠', 'Q♦', '7♣', '9♦', '10♣', '6♦'],
+      { isCOM: true },
+    );
+    const partner = player('partner-0', 0);
+    const gameState = leadState(
+      com,
+      'herz',
+      {
+        currentHighestDeclaration: {
+          playerId: partner.playerId,
+          trumpType: 'herz',
+          numberOfPairs: 6,
+          timestamp: Date.now(),
+        },
+      },
+      [
+        completedField(['5♥', 'A♠', '6♠', '7♠'], 0),
+        completedField(['6♥', 'A♣', '7♣', '8♣'], 1),
+      ],
+    );
+
+    expect(strategy.choosePlayCard(gameState, com)).toBe('5♠');
+  });
+
+  it('falls back to the partner declared suit after two trump leads', () => {
+    const com = player(
+      'com-0',
+      0,
+      ['5♥', '8♥', 'Q♠', '8♣', 'Q♦', '7♣', '9♦', '10♣', '6♦', 'Q♣'],
+      { isCOM: true },
+    );
+    const partner = player('partner-0', 0);
+    const gameState = leadState(
+      com,
+      'herz',
+      {
+        currentHighestDeclaration: {
+          playerId: partner.playerId,
+          trumpType: 'herz',
+          numberOfPairs: 6,
+          timestamp: Date.now(),
+        },
+      },
+      [
+        completedField(['K♥', 'A♠', '6♠', '7♠'], 0),
+        completedField(['6♥', 'A♣', '7♣', '8♣'], 1),
+      ],
+    );
+
+    expect(strategy.choosePlayCard(gameState, com)).toBe('5♥');
+  });
+
   it('does not use low-gon on the trump suit', () => {
     const com = player(
       'com-0',
@@ -422,11 +506,14 @@ describe('ComStrategyService', () => {
     });
   }
 
-  function completedField(cards: string[]): CompletedField {
+  function completedField(
+    cards: string[],
+    winnerTeam: Team = 0,
+  ): CompletedField {
     return {
       cards,
       winnerId: 'winner',
-      winnerTeam: 0,
+      winnerTeam,
       dealerId: 'leader',
     };
   }

--- a/mei-tra-backend/src/services/com-strategy.service.ts
+++ b/mei-tra-backend/src/services/com-strategy.service.ts
@@ -233,15 +233,44 @@ export class ComStrategyService implements IComStrategyService {
       return this.chooseStrongestControlCard(legalCards, trump);
     }
 
+    if (declaringTeam === comPlayer.team && completedTrumpLeadCount >= 2) {
+      const nonTrumpAceLead = this.chooseNonTrumpAceLeadCard(legalCards, trump);
+      if (nonTrumpAceLead) {
+        return nonTrumpAceLead;
+      }
+
+      const lowGonLead = this.chooseLowGonLeadCard(legalCards, trump);
+      if (lowGonLead) {
+        return lowGonLead;
+      }
+
+      const partnerDeclaredSuitLead = this.choosePartnerDeclaredSuitLeadCard(
+        legalCards,
+        trump,
+        declaration,
+        comPlayer,
+        state,
+      );
+      if (partnerDeclaredSuitLead) {
+        return partnerDeclaredSuitLead;
+      }
+
+      const nonTrumpCards = this.preferNonTrumpLeadCards(legalCards, trump);
+      return this.chooseMiddleControlCard(
+        nonTrumpCards.length > 0 ? nonTrumpCards : legalCards,
+        trump,
+      );
+    }
+
     const lowGonLead = this.chooseLowGonLeadCard(legalCards, trump);
     if (lowGonLead) {
       return lowGonLead;
     }
 
     if (declaringTeam === comPlayer.team) {
-      const nonJoker = legalCards.filter((card) => card !== 'JOKER');
+      const nonTrumpCards = this.preferNonTrumpLeadCards(legalCards, trump);
       return this.chooseMiddleControlCard(
-        nonJoker.length > 0 ? nonJoker : legalCards,
+        nonTrumpCards.length > 0 ? nonTrumpCards : legalCards,
         trump,
       );
     }
@@ -296,6 +325,48 @@ export class ComStrategyService implements IComStrategyService {
     return candidates.length > 0
       ? this.chooseLowestDiscard(candidates, trump)
       : null;
+  }
+
+  private chooseNonTrumpAceLeadCard(
+    legalCards: string[],
+    trump: TrumpType | null,
+  ): string | null {
+    const aceCards = this.preferNonTrumpLeadCards(legalCards, trump).filter(
+      (card) => this.getRank(card) === 'A',
+    );
+    return aceCards.length > 0 ? aceCards[0] : null;
+  }
+
+  private choosePartnerDeclaredSuitLeadCard(
+    legalCards: string[],
+    trump: TrumpType | null,
+    declaration: BlowDeclaration | null,
+    comPlayer: DomainPlayer,
+    state: GameState,
+  ): string | null {
+    if (
+      declaration == null ||
+      declaration.playerId === comPlayer.playerId ||
+      this.findPlayer(state, declaration.playerId)?.team !== comPlayer.team
+    ) {
+      return null;
+    }
+
+    const trumpCards = legalCards.filter((card) =>
+      this.isTrumpCard(card, trump),
+    );
+    return trumpCards.length > 0
+      ? this.chooseLowestDiscard(trumpCards, trump)
+      : null;
+  }
+
+  private preferNonTrumpLeadCards(
+    legalCards: string[],
+    trump: TrumpType | null,
+  ): string[] {
+    return legalCards.filter(
+      (card) => card !== 'JOKER' && !this.isTrumpCard(card, trump),
+    );
   }
 
   private countCompletedTrumpLeads(


### PR DESCRIPTION
## Summary
- Refine COM lead selection after two completed trump leads
- Prefer non-trump aces, then low-gon, then partner-declared suit, before falling back to a non-trump middle card
- Keep urgent win situations using the existing strongest-card path

## Validation
- `cd mei-tra-backend && npm test -- --runInBand src/services/__tests__/com-strategy.service.spec.ts`
- `cd mei-tra-backend && npm run lint`
