### PR TITLE
[codex] Make COM declaration tuning configurable

### DIFF
--- a/mei-tra-backend/.env.example
+++ b/mei-tra-backend/.env.example
@@ -12,6 +12,10 @@ SUPABASE_SERVICE_ROLE_KEY_PROD=your-production-supabase-service-role-key
 NODE_ENV=development
 PORT=3333
 
+# COM Strategy Configuration
+# Smaller values make COM declare more aggressively; larger values make it more conservative.
+SCORE_PER_ESTIMATED_PAIR=1.35
+
 # Email Configuration (Production only)
 # RESEND_API_KEY=re_xxxxxxxxxxxxx
 

--- a/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from '@nestjs/config';
 import { BlowService } from '../blow.service';
 import { CardService } from '../card.service';
 import { ComStrategyService } from '../com-strategy.service';
@@ -23,6 +24,10 @@ describe('ComStrategyService', () => {
     playService,
     blowService,
   );
+  const strategyWithScorePerEstimatedPair = (value: string) =>
+    new ComStrategyService(cardService, playService, blowService, {
+      get: jest.fn().mockReturnValue(value),
+    } as unknown as ConfigService);
 
   const player = (
     playerId: string,
@@ -118,6 +123,39 @@ describe('ComStrategyService', () => {
     ).toEqual({
       type: 'pass',
     });
+  });
+
+  it('uses configured score per estimated pair when deciding how high to declare', () => {
+    const com = player(
+      'com-0',
+      0,
+      ['A♥', 'K♥', 'Q♥', '10♥', '9♠', '8♠', '7♦', '6♦', '5♣', '5♥'],
+      { isCOM: true },
+    );
+    const enemy = player('enemy-1', 1);
+    const gameState = state({
+      players: [com, enemy, player('partner-0', 0), player('enemy-2', 1)],
+      blowState: {
+        currentHighestDeclaration: {
+          playerId: enemy.playerId,
+          trumpType: 'tra',
+          numberOfPairs: 7,
+          timestamp: Date.now(),
+        },
+      } as Partial<BlowState> as BlowState,
+    });
+
+    expect(strategy.chooseBlowAction(gameState, com)).toEqual({
+      type: 'pass',
+    });
+
+    const aggressiveAction = strategyWithScorePerEstimatedPair(
+      '0.8',
+    ).chooseBlowAction(gameState, com);
+    expect(aggressiveAction.type).toBe('declare');
+    if (aggressiveAction.type === 'declare') {
+      expect(aggressiveAction.declaration.numberOfPairs).toBeGreaterThan(7);
+    }
   });
 
   it('does not overcall a partner declaration without a clear upgrade', () => {

--- a/mei-tra-backend/src/services/com-strategy.service.ts
+++ b/mei-tra-backend/src/services/com-strategy.service.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import {
   BlowDeclaration,
   DomainPlayer,
@@ -41,10 +42,12 @@ const SUITS = ['♠', '♥', '♦', '♣'];
 // COMの宣言判断は、実際の勝ち数を完全シミュレーションせず、
 // 手札の強さをscore化して「何ペアくらい狙えるか」を推定する。
 // scoreが閾値未満なら6ペア宣言できない手として5ペア扱いにし、
-// 閾値以上なら floor(5 + score / 1.35) を6〜10に丸める。
+// 閾値以上なら floor(5 + score / SCORE_PER_ESTIMATED_PAIR) を6〜10に丸める。
+// SCORE_PER_ESTIMATED_PAIRは小さいほど吹きやすく、大きいほど吹きにくい。
 const NON_DECLARABLE_PAIRS = 5;
 const MIN_DECLARATION_SCORE = 3.8;
-const SCORE_PER_ESTIMATED_PAIR = 1.35;
+const SCORE_PER_ESTIMATED_PAIR_ENV = 'SCORE_PER_ESTIMATED_PAIR';
+const DEFAULT_SCORE_PER_ESTIMATED_PAIR = 1.35;
 const ESTIMATED_PAIR_BASELINE = 5;
 const MAX_ESTIMATED_PAIRS = 10;
 const JOKER_SCORE = 2.2;
@@ -54,6 +57,8 @@ const PARTNER_OVERCALL_PAIR_STEP = 1;
 
 @Injectable()
 export class ComStrategyService implements IComStrategyService {
+  private readonly scorePerEstimatedPair: number;
+
   constructor(
     @Inject('ICardService')
     private readonly cardService: ICardService,
@@ -61,7 +66,11 @@ export class ComStrategyService implements IComStrategyService {
     private readonly playService: IPlayService,
     @Inject('IBlowService')
     private readonly blowService: IBlowService,
-  ) {}
+    @Optional()
+    private readonly configService?: ConfigService,
+  ) {
+    this.scorePerEstimatedPair = this.resolveScorePerEstimatedPair();
+  }
 
   chooseBlowAction(state: GameState, comPlayer: DomainPlayer): ComBlowAction {
     if (comPlayer.hasBroken || comPlayer.hasRequiredBroken) {
@@ -476,7 +485,7 @@ export class ComStrategyService implements IComStrategyService {
     }
 
     // score < 3.8 は宣言不可の5ペア扱い。
-    // score >= 3.8 は floor(5 + score / 1.35) で推定し、最低6・最大10に丸める。
+    // score >= 3.8 は floor(5 + score / SCORE_PER_ESTIMATED_PAIR) で推定し、最低6・最大10に丸める。
     const estimatedPairs =
       score < MIN_DECLARATION_SCORE
         ? NON_DECLARABLE_PAIRS
@@ -485,12 +494,23 @@ export class ComStrategyService implements IComStrategyService {
             Math.max(
               6,
               Math.floor(
-                ESTIMATED_PAIR_BASELINE + score / SCORE_PER_ESTIMATED_PAIR,
+                ESTIMATED_PAIR_BASELINE + score / this.scorePerEstimatedPair,
               ),
             ),
           );
 
     return { trumpType, estimatedPairs, score };
+  }
+
+  private resolveScorePerEstimatedPair(): number {
+    const rawValue = this.configService?.get<string>(
+      SCORE_PER_ESTIMATED_PAIR_ENV,
+    );
+    const parsedValue = Number(rawValue);
+
+    return Number.isFinite(parsedValue) && parsedValue > 0
+      ? parsedValue
+      : DEFAULT_SCORE_PER_ESTIMATED_PAIR;
   }
 
   private specialCardScore(card: string, trumpType: TrumpType): number | null {


### PR DESCRIPTION
## Summary
- Make COM declaration aggressiveness configurable via `SCORE_PER_ESTIMATED_PAIR`
- Keep the default behavior at `1.35` when the env var is unset or invalid
- Add test coverage for lower values making COM estimate more pairs

## Runtime config
- Backend reads `SCORE_PER_ESTIMATED_PAIR`; default remains `1.35`
- Smaller values make COM declare more aggressively; larger values make it more conservative
- Fly.io can tune this without code changes, e.g. `flyctl secrets set SCORE_PER_ESTIMATED_PAIR=1.20 --app <backend-app-name>`

## Validation
- `cd mei-tra-backend && npm test -- --runInBand src/services/__tests__/com-strategy.service.spec.ts`
- `cd mei-tra-backend && npm run lint`
