### PR TITLE
[codex] Fix spectator field perspective

### DIFF
--- a/mei-tra-backend/src/__tests__/social.gateway.spec.ts
+++ b/mei-tra-backend/src/__tests__/social.gateway.spec.ts
@@ -158,8 +158,13 @@ describe('SocialGateway', () => {
       contentType: 'text',
       replyTo: undefined,
     });
-    expect(serverTo).toHaveBeenCalledWith('room-1');
-    expect(serverEmit).toHaveBeenCalledWith('chat:message', event);
+    expect(socket.emit).toHaveBeenCalledWith('chat:message', event);
+    expect(socket.to).toHaveBeenCalledWith('room-1');
+    const socketToTarget = socket.to.mock.results[0].value as {
+      emit: jest.Mock;
+    };
+    expect(socketToTarget.emit).toHaveBeenCalledWith('chat:message', event);
+    expect(serverTo).not.toHaveBeenCalled();
   });
 
   it('sends typing events as the authenticated user and ignores spoofed userId', async () => {

--- a/mei-tra-backend/src/__tests__/social.gateway.spec.ts
+++ b/mei-tra-backend/src/__tests__/social.gateway.spec.ts
@@ -23,6 +23,7 @@ describe('SocialGateway', () => {
   let authService: jest.Mocked<Pick<AuthService, 'getUserFromSocketToken'>>;
   let serverEmit: jest.Mock;
   let serverTo: jest.Mock;
+  let serverExcept: jest.Mock;
 
   const authenticatedUser: AuthenticatedUser = {
     id: 'user-1',
@@ -74,7 +75,11 @@ describe('SocialGateway', () => {
       getUserFromSocketToken: jest.fn(),
     };
     serverEmit = jest.fn();
-    serverTo = jest.fn().mockReturnValue({ emit: serverEmit });
+    serverExcept = jest.fn().mockReturnValue({ emit: serverEmit });
+    serverTo = jest.fn().mockReturnValue({
+      except: serverExcept,
+      emit: serverEmit,
+    });
 
     gateway = new SocialGateway(
       chatService as unknown as ChatService,
@@ -159,12 +164,9 @@ describe('SocialGateway', () => {
       replyTo: undefined,
     });
     expect(socket.emit).toHaveBeenCalledWith('chat:message', event);
-    expect(socket.to).toHaveBeenCalledWith('room-1');
-    const socketToTarget = socket.to.mock.results[0].value as {
-      emit: jest.Mock;
-    };
-    expect(socketToTarget.emit).toHaveBeenCalledWith('chat:message', event);
-    expect(serverTo).not.toHaveBeenCalled();
+    expect(serverTo).toHaveBeenCalledWith('room-1');
+    expect(serverExcept).toHaveBeenCalledWith('socket-1');
+    expect(serverEmit).toHaveBeenCalledWith('chat:message', event);
   });
 
   it('sends typing events as the authenticated user and ignores spoofed userId', async () => {

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -35,6 +35,7 @@ import { IRevealBrokenHandUseCase } from './use-cases/interfaces/reveal-broken-h
 import { ICompleteFieldUseCase } from './use-cases/interfaces/complete-field.use-case.interface';
 import { IProcessGameOverUseCase } from './use-cases/interfaces/process-game-over.use-case.interface';
 import { IUpdateAuthUseCase } from './use-cases/interfaces/update-auth.use-case.interface';
+import { IWatchRoomUseCase } from './use-cases/interfaces/watch-room.use-case.interface';
 import { IComAutoPlayUseCase } from './use-cases/interfaces/com-autoplay-use-case.interface';
 import { IActivityTrackerService } from './services/interfaces/activity-tracker-service.interface';
 import { createSocketCorsOriginHandler } from './config/frontend-origins';
@@ -108,6 +109,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     private readonly authService: AuthService,
     @Inject('IComAutoPlayUseCase')
     private readonly comAutoPlayUseCase: IComAutoPlayUseCase,
+    @Inject('IWatchRoomUseCase')
+    private readonly watchRoomUseCase: IWatchRoomUseCase,
     @Inject('IActivityTrackerService')
     private readonly activityTracker: IActivityTrackerService,
     private readonly turnMonitorService: TurnMonitorService,
@@ -174,6 +177,12 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     );
   }
 
+  private queueSpectatorSnapshot(roomId: string): void {
+    this.spectatorGatewayEffectsService.queueSnapshot(this.server, roomId, () =>
+      this.watchRoomUseCase.buildSnapshot(roomId),
+    );
+  }
+
   private dispatchEvents(events?: GatewayEvent[]) {
     if (!events) {
       return;
@@ -199,10 +208,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
               ) {
                 void this.startTurnAckMonitor(event.roomId, event.payload);
               }
-              this.spectatorGatewayEffectsService.queueSnapshot(
-                this.server,
-                event.roomId,
-              );
+              this.queueSpectatorSnapshot(event.roomId);
             }
             break;
           case 'socket':
@@ -265,7 +271,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       playerName: targetPlayer?.name ?? playerId,
       message,
     });
-    this.spectatorGatewayEffectsService.queueSnapshot(this.server, roomId);
+    this.queueSpectatorSnapshot(roomId);
     if (updatedRoom) {
       this.dispatchEvents(
         await this.roomUpdateGatewayEffectsService.buildRoomEvents({
@@ -812,20 +818,25 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         return { success: false, error: errorMessage };
       }
 
-      const result = await this.spectatorGatewayEffectsService.watchRoom(
-        client,
-        data.roomId,
-      );
+      const result = await this.watchRoomUseCase.execute({
+        roomId: data.roomId,
+      });
 
-      if (!result.success || !result.room) {
+      if (!result.success || !result.data) {
         const errorMessage = result.error ?? 'Failed to watch room';
         client.emit('error-message', errorMessage);
         return { success: false, error: errorMessage };
       }
 
+      await this.spectatorGatewayEffectsService.watchRoom(
+        client,
+        data.roomId,
+        result.data.gameState,
+      );
+
       return {
         success: true,
-        room: result.room,
+        room: toRoomContract(result.data.room),
       };
     } catch (error) {
       console.error('Error in handleWatchRoom:', error);
@@ -935,10 +946,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         playerId,
         roomId: data.roomId,
       });
-      this.spectatorGatewayEffectsService.queueSnapshot(
-        this.server,
-        data.roomId,
-      );
+      this.queueSpectatorSnapshot(data.roomId);
 
       this.emitRoomsListToAll(roomsList);
       this.server.to(client.id).emit('back-to-lobby');
@@ -957,10 +965,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         this.server
           .to(data.roomId)
           .emit('game-paused', { message: gamePausedMessage });
-        this.spectatorGatewayEffectsService.queueSnapshot(
-          this.server,
-          data.roomId,
-        );
+        this.queueSpectatorSnapshot(data.roomId);
       } else if (!roomDeleted) {
         this.triggerComAutoPlayIfNeeded(data.roomId);
       }
@@ -1042,10 +1047,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
           playerId: result.playerId,
           roomId: data.roomId,
         });
-        this.spectatorGatewayEffectsService.queueSnapshot(
-          this.server,
-          data.roomId,
-        );
+        this.queueSpectatorSnapshot(data.roomId);
         this.emitRoomsListToAll(result.roomsList);
         return { success: true };
       }
@@ -1056,10 +1058,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         playerName: result.playerName,
         message: result.message,
       });
-      this.spectatorGatewayEffectsService.queueSnapshot(
-        this.server,
-        data.roomId,
-      );
+      this.queueSpectatorSnapshot(data.roomId);
       this.dispatchEvents(
         await this.roomUpdateGatewayEffectsService.buildRoomEvents({
           room: result.updatedRoom,

--- a/mei-tra-backend/src/services/__tests__/spectator-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/spectator-gateway-effects.service.spec.ts
@@ -1,0 +1,74 @@
+import { Server, Socket } from 'socket.io';
+import { SpectatorGatewayEffectsService } from '../spectator-gateway-effects.service';
+
+describe('SpectatorGatewayEffectsService', () => {
+  const gameState = {
+    players: [],
+    gamePhase: 'play' as const,
+    currentField: null,
+    currentTurn: null,
+    blowState: {
+      currentTrump: null,
+      currentHighestDeclaration: null,
+      declarations: [],
+      actionHistory: [],
+      lastPasser: null,
+      isRoundCancelled: false,
+      currentBlowIndex: 0,
+    },
+    teamScores: {
+      0: { play: 0, total: 0 },
+      1: { play: 0, total: 0 },
+    },
+    you: null,
+    isSpectator: true,
+    negriCard: null,
+    fields: [],
+    roomId: 'room-1',
+    pointsToWin: 5,
+  };
+
+  const createSocket = (id = 'socket-1') =>
+    ({
+      id,
+      join: jest.fn().mockResolvedValue(undefined),
+      leave: jest.fn().mockResolvedValue(undefined),
+      emit: jest.fn(),
+    }) as unknown as Socket;
+
+  it('registers a socket as a spectator and emits the provided snapshot', async () => {
+    const service = new SpectatorGatewayEffectsService();
+    const socket = createSocket();
+
+    await service.watchRoom(socket, 'room-1', gameState);
+
+    expect(service.isSpectatorSocket('socket-1')).toBe(true);
+    expect(socket.join).toHaveBeenCalledWith('spectators:room-1');
+    expect(socket.emit).toHaveBeenCalledWith('game-state', gameState);
+  });
+
+  it('queues a spectator snapshot without knowing how to build it', async () => {
+    jest.useFakeTimers();
+    const service = new SpectatorGatewayEffectsService();
+    const emit = jest.fn();
+    const server = {
+      sockets: {
+        adapter: {
+          rooms: new Map([['spectators:room-1', new Set(['socket-1'])]]),
+        },
+      },
+      to: jest.fn(() => ({ emit })),
+    } as unknown as Server;
+    const buildSnapshot = jest.fn().mockResolvedValue(gameState);
+
+    service.queueSnapshot(server, 'room-1', buildSnapshot);
+    jest.runOnlyPendingTimers();
+    await Promise.resolve();
+
+    expect(buildSnapshot).toHaveBeenCalledTimes(1);
+    expect(server.to).toHaveBeenCalledWith('spectators:room-1');
+    expect(emit).toHaveBeenCalledWith('game-state', gameState);
+
+    jest.useRealTimers();
+  });
+});

--- a/mei-tra-backend/src/services/__tests__/start-game-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/start-game-gateway-effects.service.spec.ts
@@ -7,6 +7,7 @@ describe('StartGameGatewayEffectsService', () => {
     const roomService = {
       getRoom: jest.fn().mockResolvedValue({
         id: 'room-1',
+        name: 'Room 1',
         players: [
           {
             playerId: 'player-1',
@@ -20,6 +21,13 @@ describe('StartGameGatewayEffectsService', () => {
           },
         ],
       }),
+      listRooms: jest.fn().mockResolvedValue([
+        {
+          id: 'room-1',
+          name: 'Room 1',
+          players: [],
+        },
+      ]),
       getRoomGameState: jest.fn().mockResolvedValue({
         getTransportPlayers: jest.fn(() => [
           {
@@ -68,6 +76,11 @@ describe('StartGameGatewayEffectsService', () => {
           ],
         },
       ]),
+      buildRoomsListEvent: jest.fn().mockReturnValue({
+        scope: 'all',
+        event: 'rooms-list',
+        payload: [{ id: 'room-1', name: 'Room 1' }],
+      }),
     } as unknown as RoomUpdateGatewayEffectsService;
 
     const service = new StartGameGatewayEffectsService(
@@ -131,6 +144,11 @@ describe('StartGameGatewayEffectsService', () => {
         ],
       },
       {
+        scope: 'all',
+        event: 'rooms-list',
+        payload: [{ id: 'room-1', name: 'Room 1' }],
+      },
+      {
         scope: 'room',
         roomId: 'room-1',
         event: 'room-playing',
@@ -187,5 +205,18 @@ describe('StartGameGatewayEffectsService', () => {
     expect(roomEventsArgs?.statePlayers?.[0]?.playerId).toBe('player-1');
     expect(roomEventsArgs?.scope).toBe('room');
     expect(roomEventsArgs?.roomId).toBe('room-1');
+    expect(roomService.listRooms).toHaveBeenCalledTimes(1);
+    expect(
+      jest.mocked(roomUpdateGatewayEffectsService.buildRoomsListEvent),
+    ).toHaveBeenCalledWith({
+      rooms: [
+        {
+          id: 'room-1',
+          name: 'Room 1',
+          players: [],
+        },
+      ],
+      scope: 'all',
+    });
   });
 });

--- a/mei-tra-backend/src/services/spectator-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/spectator-gateway-effects.service.ts
@@ -1,24 +1,13 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Server, Socket } from 'socket.io';
-import { RoomContract } from '@contracts/room';
-import { toRoomContract } from '../types/room-adapters';
-import { IWatchRoomUseCase } from '../use-cases/interfaces/watch-room.use-case.interface';
+import type { GameStatePayload } from '@contracts/game';
 
-interface WatchRoomGatewayResponse {
-  success: boolean;
-  error?: string;
-  room?: RoomContract;
-}
+type BuildSpectatorSnapshot = () => Promise<GameStatePayload | null>;
 
 @Injectable()
 export class SpectatorGatewayEffectsService {
   private readonly spectatorRooms = new Map<string, string>();
   private readonly snapshotTimers = new Map<string, NodeJS.Timeout>();
-
-  constructor(
-    @Inject('IWatchRoomUseCase')
-    private readonly watchRoomUseCase: IWatchRoomUseCase,
-  ) {}
 
   isSpectatorSocket(socketId: string): boolean {
     return this.spectatorRooms.has(socketId);
@@ -36,28 +25,16 @@ export class SpectatorGatewayEffectsService {
   async watchRoom(
     client: Socket,
     roomId: string,
-  ): Promise<WatchRoomGatewayResponse> {
+    gameState: GameStatePayload,
+  ): Promise<void> {
     const currentRoomId = this.spectatorRooms.get(client.id);
     if (currentRoomId && currentRoomId !== roomId) {
       await client.leave(this.getRoomName(currentRoomId));
     }
 
-    const result = await this.watchRoomUseCase.execute({ roomId });
-    if (!result.success || !result.data) {
-      return {
-        success: false,
-        error: result.error ?? 'Failed to watch room',
-      };
-    }
-
     this.spectatorRooms.set(client.id, roomId);
     await client.join(this.getRoomName(roomId));
-    client.emit('game-state', result.data.gameState);
-
-    return {
-      success: true,
-      room: toRoomContract(result.data.room),
-    };
+    client.emit('game-state', gameState);
   }
 
   async leaveCurrentRoom(client: Socket): Promise<void> {
@@ -107,14 +84,18 @@ export class SpectatorGatewayEffectsService {
     }
   }
 
-  queueSnapshot(server: Server, roomId: string): void {
+  queueSnapshot(
+    server: Server,
+    roomId: string,
+    buildSnapshot: BuildSpectatorSnapshot,
+  ): void {
     if (this.snapshotTimers.has(roomId)) {
       return;
     }
 
     const timer = setTimeout(() => {
       this.snapshotTimers.delete(roomId);
-      void this.emitSnapshot(server, roomId);
+      void this.emitSnapshot(server, roomId, buildSnapshot);
     }, 0);
     this.snapshotTimers.set(roomId, timer);
   }
@@ -123,14 +104,18 @@ export class SpectatorGatewayEffectsService {
     return `spectators:${roomId}`;
   }
 
-  private async emitSnapshot(server: Server, roomId: string): Promise<void> {
+  private async emitSnapshot(
+    server: Server,
+    roomId: string,
+    buildSnapshot: BuildSpectatorSnapshot,
+  ): Promise<void> {
     const roomName = this.getRoomName(roomId);
     const socketIds = server.sockets.adapter.rooms.get(roomName);
     if (!socketIds || socketIds.size === 0) {
       return;
     }
 
-    const snapshot = await this.watchRoomUseCase.buildSnapshot(roomId);
+    const snapshot = await buildSnapshot();
     if (!snapshot) {
       return;
     }

--- a/mei-tra-backend/src/services/start-game-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/start-game-gateway-effects.service.ts
@@ -54,9 +54,14 @@ export class StartGameGatewayEffectsService {
           roomId,
         })
       : [];
+    const roomsList = await this.roomService.listRooms();
 
     return [
       ...roomEvents,
+      this.roomUpdateGatewayEffectsService.buildRoomsListEvent({
+        rooms: roomsList,
+        scope: 'all',
+      }),
       {
         scope: 'room',
         roomId,

--- a/mei-tra-backend/src/social.gateway.ts
+++ b/mei-tra-backend/src/social.gateway.ts
@@ -165,7 +165,7 @@ export class SocialGateway implements OnGatewayConnection, OnGatewayDisconnect {
       });
 
       client.emit('chat:message', event);
-      client.to(data.roomId).emit('chat:message', event);
+      this.server.to(data.roomId).except(client.id).emit('chat:message', event);
       this.logger.log(
         `Message posted to room ${data.roomId} by user ${authenticatedUser.id}`,
       );

--- a/mei-tra-backend/src/social.gateway.ts
+++ b/mei-tra-backend/src/social.gateway.ts
@@ -164,7 +164,8 @@ export class SocialGateway implements OnGatewayConnection, OnGatewayDisconnect {
         replyTo: data.replyTo,
       });
 
-      this.server.to(data.roomId).emit('chat:message', event);
+      client.emit('chat:message', event);
+      client.to(data.roomId).emit('chat:message', event);
       this.logger.log(
         `Message posted to room ${data.roomId} by user ${authenticatedUser.id}`,
       );

--- a/mei-tra-frontend/components/game/GameTable/index.tsx
+++ b/mei-tra-frontend/components/game/GameTable/index.tsx
@@ -242,7 +242,7 @@ export const GameTable: React.FC<GameTableProps> = ({
             players={players}
             onBaseSuitSelect={gameActions.selectBaseSuit}
             isCurrentPlayer={!isSpectator && currentPlayerId === whoseTurn}
-            currentPlayerId={isSpectator ? '' : currentPlayerId || ''}
+            currentPlayerId={tablePerspectivePlayerId || ''}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- Align `GameField` seat ordering with the selected spectator perspective
- Keep spectators read-only by leaving `isCurrentPlayer` false

## Validation
- `cd mei-tra-frontend && npm test -- --runInBand __tests__/components/PlayerHand.test.tsx`
- `cd mei-tra-frontend && npm run lint`
- `git diff --check`
