### PR TITLE
[codex] Fix unbalanced team starts

### DIFF
--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts
@@ -349,11 +349,19 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
 
   private mapDatabaseToGameState(dbGameState: GameStateRow): GameState {
     const stateData = dbGameState.state_data || {};
+    const teamAssignments = dbGameState.team_assignments as {
+      [playerId: string]: 0 | 1;
+    };
     const players = Array.isArray(stateData.players)
       ? stateData.players
-          .map((player) =>
-            toRuntimePlayer(player as Partial<PersistedGamePlayer>),
-          )
+          .map((player) => {
+            const persistedPlayer = player as Partial<PersistedGamePlayer>;
+            const fallbackTeam =
+              typeof persistedPlayer.playerId === 'string'
+                ? teamAssignments[persistedPlayer.playerId]
+                : undefined;
+            return toRuntimePlayer(persistedPlayer, fallbackTeam);
+          })
           .filter((player): player is DomainPlayer => Boolean(player))
       : [];
 
@@ -374,9 +382,7 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
       agari: stateData.agari,
       roundNumber: dbGameState.round_number,
       pointsToWin: dbGameState.points_to_win,
-      teamAssignments: dbGameState.team_assignments as {
-        [playerId: string]: 0 | 1;
-      },
+      teamAssignments,
     };
   }
 

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -1615,6 +1615,85 @@ describe('Reconnection Token Management', () => {
     });
 
     describe('leaveRoom token preservation', () => {
+      it('should preserve team when replacing a leaving waiting-room player with a COM placeholder', async () => {
+        const roomId = 'room-123';
+        const playerId = 'player-2';
+
+        const hostPlayer: RoomPlayer = {
+          socketId: 'socket-1',
+          playerId: 'player-1',
+          name: 'Host Player',
+          team: 0,
+          hand: [],
+          isPasser: false,
+          hasBroken: false,
+          isReady: true,
+          isHost: true,
+          joinedAt: new Date(),
+        };
+        const leavingPlayer: RoomPlayer = {
+          socketId: 'socket-2',
+          playerId,
+          name: 'Leaving Player',
+          team: 1,
+          hand: [],
+          isPasser: false,
+          hasBroken: false,
+          isReady: true,
+          isHost: false,
+          joinedAt: new Date(),
+        };
+
+        const room: Room = {
+          ...baseRoom,
+          status: RoomStatus.WAITING,
+          players: [hostPlayer, leavingPlayer],
+        };
+
+        const roomState = bindRoomRepositoryToState(room);
+        const gameState = await roomService.getRoomGameState(roomId);
+        gameState.getState().players = [
+          {
+            playerId: hostPlayer.playerId,
+            name: hostPlayer.name,
+            team: hostPlayer.team,
+            hand: [],
+            isPasser: false,
+            hasBroken: false,
+            hasRequiredBroken: false,
+          },
+          {
+            playerId: leavingPlayer.playerId,
+            name: leavingPlayer.name,
+            team: leavingPlayer.team,
+            hand: [],
+            isPasser: false,
+            hasBroken: false,
+            hasRequiredBroken: false,
+          },
+        ];
+        gameState.getState().teamAssignments = {
+          [hostPlayer.playerId]: hostPlayer.team,
+          [leavingPlayer.playerId]: leavingPlayer.team,
+        };
+
+        await roomService.leaveRoom(roomId, playerId);
+
+        const updatedRoom = roomState.getPersistedRoom();
+        const replacementCom = updatedRoom?.players.find(
+          (player) => player.isCOM,
+        );
+        expect(replacementCom?.team).toBe(1);
+        expect(gameState.getState().players[1].playerId).toBe(
+          replacementCom?.playerId,
+        );
+        expect(gameState.getState().players[1].team).toBe(1);
+        expect(
+          gameState.getState().teamAssignments[replacementCom?.playerId ?? ''],
+        ).toBe(1);
+        expect(gameState.getState().teamAssignments[playerId]).toBeUndefined();
+      });
+
       it('should not remove reconnectToken when leaving during play', async () => {
         const roomId = 'room-123';
         const playerId = 'player-1';

--- a/mei-tra-backend/src/services/com-session.service.ts
+++ b/mei-tra-backend/src/services/com-session.service.ts
@@ -33,6 +33,7 @@ export class ComSessionService {
 
   private createCOMPlaceholder(
     index: number | string,
+    team: Team,
     hand: string[] = [],
   ): RoomPlayer {
     const idStr = String(index);
@@ -47,7 +48,7 @@ export class ComSessionService {
         name: 'COM',
         isCOM: true,
         hand,
-        team: 0 as Team,
+        team,
         isPasser: true,
         hasBroken: false,
         hasRequiredBroken: false,
@@ -66,8 +67,7 @@ export class ComSessionService {
     >,
     hand: string[] = [],
   ): RoomPlayer {
-    const comPlayer = this.createCOMPlaceholder(index, hand);
-    comPlayer.team = sourcePlayer.team;
+    const comPlayer = this.createCOMPlaceholder(index, sourcePlayer.team, hand);
     comPlayer.isPasser = sourcePlayer.isPasser;
     comPlayer.hasBroken = sourcePlayer.hasBroken ?? false;
     comPlayer.hasRequiredBroken = sourcePlayer.hasRequiredBroken ?? false;
@@ -109,8 +109,7 @@ export class ComSessionService {
         (player) => player.team === 1,
       ).length;
       const team = (team0Count <= team1Count ? 0 : 1) as Team;
-      const placeholder = this.createCOMPlaceholder(idx);
-      placeholder.team = team;
+      const placeholder = this.createCOMPlaceholder(idx, team);
       await this.roomRepository.addPlayer(roomId, placeholder);
       room.players.push(placeholder);
       state.players.push(toDomainPlayer(placeholder));

--- a/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
@@ -86,7 +86,7 @@ export class JoinRoomGatewayEffectsService {
     const joiningPlayer = room.players.find(
       (player) => player.playerId === normalizedUser.playerId,
     );
-    const joiningTeam = joiningPlayer?.team ?? 0;
+    const joiningTeam = joiningPlayer?.team;
 
     const roomPlayerJoinedPayload: RoomPlayerJoinedPayload = {
       playerId: normalizedUser.playerId,

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -476,7 +476,9 @@ export class RoomService implements IRoomService, OnModuleDestroy {
         (p) => p.playerId === playerId,
       );
       if (playerIndex !== -1) {
+        const leavingPlayer = room.players[playerIndex];
         const comPlaceholder = this.createCOMPlaceholder(playerIndex);
+        comPlaceholder.team = leavingPlayer.team;
         room.players[playerIndex] = comPlaceholder;
         await this.roomRepository.removePlayer(roomId, playerId);
         await this.roomRepository.addPlayer(roomId, comPlaceholder);
@@ -484,9 +486,11 @@ export class RoomService implements IRoomService, OnModuleDestroy {
         const state = gameState.getState();
         const gsIndex = state.players.findIndex((p) => p.playerId === playerId);
         if (gsIndex !== -1) {
-          state.players[gsIndex] = toDomainPlayer(
-            this.createCOMPlaceholder(gsIndex),
-          );
+          state.players[gsIndex] = toDomainPlayer(comPlaceholder);
+          if (state.teamAssignments[playerId] != null) {
+            delete state.teamAssignments[playerId];
+          }
+          state.teamAssignments[comPlaceholder.playerId] = comPlaceholder.team;
         }
       }
       // 再接続トークンを削除

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -219,6 +219,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
 
   private createCOMPlaceholder(
     index: number | string,
+    team: Team,
     hand: string[] = [],
   ): RoomPlayer {
     const idStr = String(index);
@@ -228,7 +229,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       name: 'COM',
       isCOM: true,
       hand,
-      team: 0 as Team,
+      team,
       isReady: false,
       isHost: false,
       joinedAt: new Date(),
@@ -245,8 +246,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     >,
     hand: string[] = [],
   ): RoomPlayer {
-    const comPlayer = this.createCOMPlaceholder(index, hand);
-    comPlayer.team = sourcePlayer.team;
+    const comPlayer = this.createCOMPlaceholder(index, sourcePlayer.team, hand);
     comPlayer.isPasser = sourcePlayer.isPasser;
     comPlayer.hasBroken = sourcePlayer.hasBroken ?? false;
     comPlayer.hasRequiredBroken = sourcePlayer.hasRequiredBroken ?? false;
@@ -477,8 +477,10 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       );
       if (playerIndex !== -1) {
         const leavingPlayer = room.players[playerIndex];
-        const comPlaceholder = this.createCOMPlaceholder(playerIndex);
-        comPlaceholder.team = leavingPlayer.team;
+        const comPlaceholder = this.createCOMPlaceholder(
+          playerIndex,
+          leavingPlayer.team,
+        );
         room.players[playerIndex] = comPlaceholder;
         await this.roomRepository.removePlayer(roomId, playerId);
         await this.roomRepository.addPlayer(roomId, comPlaceholder);

--- a/mei-tra-backend/src/types/player-adapters.spec.ts
+++ b/mei-tra-backend/src/types/player-adapters.spec.ts
@@ -1,0 +1,30 @@
+import { toRuntimePlayer } from './player-adapters';
+
+describe('player-adapters', () => {
+  describe('toRuntimePlayer', () => {
+    it('uses an explicit fallback team when persisted player team is missing', () => {
+      const player = toRuntimePlayer(
+        {
+          playerId: 'player-1',
+          name: 'Player 1',
+          hand: [],
+          isPasser: false,
+        },
+        1,
+      );
+
+      expect(player?.team).toBe(1);
+    });
+
+    it('rejects players without a persisted or fallback team', () => {
+      const player = toRuntimePlayer({
+        playerId: 'player-1',
+        name: 'Player 1',
+        hand: [],
+        isPasser: false,
+      });
+
+      expect(player).toBeNull();
+    });
+  });
+});

--- a/mei-tra-backend/src/types/player-adapters.ts
+++ b/mei-tra-backend/src/types/player-adapters.ts
@@ -94,6 +94,7 @@ export function toPersistedGamePlayer(
 
 export function toRuntimePlayer(
   player: Partial<PersistedGamePlayer> | null | undefined,
+  fallbackTeam?: 0 | 1,
 ): DomainPlayer | null {
   if (
     !player ||
@@ -103,11 +104,16 @@ export function toRuntimePlayer(
     return null;
   }
 
+  const team = player.team ?? fallbackTeam;
+  if (team !== 0 && team !== 1) {
+    return null;
+  }
+
   return {
     playerId: player.playerId,
     name: player.name,
     hand: Array.isArray(player.hand) ? [...player.hand] : [],
-    team: player.team ?? 0,
+    team,
     isPasser: player.isPasser ?? false,
     isCOM: player.isCOM,
     hasBroken: player.hasBroken ?? false,

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -863,6 +863,73 @@ describe('Game Use Cases', () => {
       expect(result.success).toBe(false);
       expect(result.errorMessage).toBe('Need more players');
     });
+
+    it('rejects starting a full room with unbalanced teams', async () => {
+      const roomService = createRoomServiceMock();
+      const useCase = new StartGameUseCase(roomService);
+
+      const room: Room = {
+        ...baseRoom,
+        status: RoomStatus.READY,
+        players: [
+          {
+            ...basePlayers[0],
+            team: 0 as const,
+            isReady: true,
+          },
+          {
+            ...basePlayers[1],
+            team: 0 as const,
+            isReady: true,
+          },
+          {
+            socketId: 'socket-3',
+            playerId: 'player-3',
+            name: 'Player 3',
+            team: 0 as const,
+            hand: [],
+            isPasser: false,
+            isReady: true,
+            isHost: false,
+            hasBroken: false,
+            joinedAt: new Date(),
+          } as RoomPlayer,
+          {
+            socketId: 'socket-4',
+            playerId: 'player-4',
+            name: 'Player 4',
+            team: 1 as const,
+            hand: [],
+            isPasser: false,
+            isReady: true,
+            isHost: false,
+            hasBroken: false,
+            joinedAt: new Date(),
+          } as RoomPlayer,
+        ],
+      };
+
+      roomService.getRoom.mockResolvedValue(room);
+      roomService.getRoomGameState.mockResolvedValue({
+        getState: jest.fn(() => ({
+          players: [],
+          teamAssignments: {},
+        })),
+      } as unknown as GameStateService);
+      roomService.canStartGame.mockResolvedValue({ canStart: true });
+      roomService.fillVacantSeatsWithCOM.mockResolvedValue(undefined);
+
+      const result = await useCase.execute({
+        playerId: 'player-1',
+        roomId: room.id,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errorMessage).toBe(
+        'Teams must be balanced before starting the game',
+      );
+      expect(roomService.updateRoomStatus).not.toHaveBeenCalled();
+    });
   });
 
   describe('TogglePlayerReadyUseCase', () => {
@@ -958,6 +1025,65 @@ describe('Game Use Cases', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Each team must have at most 2 players');
+    });
+
+    it('counts COM players when validating team changes', async () => {
+      const roomService = createRoomServiceMock();
+      const useCase = new ChangePlayerTeamUseCase(roomService);
+
+      const room: Room = {
+        ...baseRoom,
+        players: [
+          {
+            ...basePlayers[0],
+            team: 0 as const,
+          },
+          {
+            ...basePlayers[1],
+            team: 0 as const,
+          },
+          {
+            socketId: 'com-1',
+            playerId: 'com-1',
+            name: 'COM 1',
+            team: 1 as const,
+            hand: [],
+            isPasser: false,
+            isReady: true,
+            isHost: false,
+            hasBroken: false,
+            isCOM: true,
+            joinedAt: new Date(),
+          } as RoomPlayer,
+          {
+            socketId: 'com-2',
+            playerId: 'com-2',
+            name: 'COM 2',
+            team: 1 as const,
+            hand: [],
+            isPasser: false,
+            isReady: true,
+            isHost: false,
+            hasBroken: false,
+            isCOM: true,
+            joinedAt: new Date(),
+          } as RoomPlayer,
+        ],
+      };
+
+      roomService.getRoom.mockResolvedValue(room);
+
+      const result = await useCase.execute({
+        roomId: room.id,
+        playerId: 'player-1',
+        teamChanges: {
+          'player-2': 1,
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Each team must have at most 2 players');
+      expect(roomService.updatePlayerInRoom).not.toHaveBeenCalled();
     });
 
     it('applies valid team changes', async () => {

--- a/mei-tra-backend/src/use-cases/__tests__/shuffle-teams.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/shuffle-teams.use-case.spec.ts
@@ -1,7 +1,7 @@
 import { ShuffleTeamsUseCase } from '../shuffle-teams.use-case';
 import { IRoomService } from '../../services/interfaces/room-service.interface';
 import { IFillWithComUseCase } from '../interfaces/fill-with-com.use-case.interface';
-import { RoomStatus } from '../../types/room.types';
+import { RoomPlayer, RoomStatus } from '../../types/room.types';
 
 describe('ShuffleTeamsUseCase', () => {
   it('fills empty seats before shuffling and persists the updated room', async () => {
@@ -29,7 +29,7 @@ describe('ShuffleTeamsUseCase', () => {
         .fn()
         .mockResolvedValueOnce(room)
         .mockResolvedValueOnce(updatedRoom),
-      updateRoom: jest.fn().mockResolvedValue(updatedRoom),
+      updatePlayerInRoom: jest.fn().mockResolvedValue(true),
     } as Partial<IRoomService> as IRoomService;
     const fillWithComUseCase = {
       execute: jest.fn().mockResolvedValue({ success: true, updatedRoom }),
@@ -43,6 +43,42 @@ describe('ShuffleTeamsUseCase', () => {
 
     expect(result.success).toBe(true);
     expect(fillWithComUseCase.execute).toHaveBeenCalled();
-    expect(roomService.updateRoom).toHaveBeenCalled();
+    expect(roomService.updatePlayerInRoom).toHaveBeenCalledTimes(4);
+    const updateCalls = jest.mocked(roomService.updatePlayerInRoom).mock.calls;
+    expect(updateCalls.every(([roomId]) => roomId === 'room-1')).toBe(true);
+    expect(
+      updateCalls.every(
+        ([, , updates]: [string, string, Partial<RoomPlayer>]) =>
+          updates.team === 0 || updates.team === 1,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns failure when empty seats cannot be filled', async () => {
+    const room = {
+      id: 'room-1',
+      hostId: 'host',
+      status: RoomStatus.WAITING,
+      players: [{ playerId: 'host', team: 0 }],
+      updatedAt: new Date(),
+    };
+    const roomService = {
+      getRoom: jest.fn().mockResolvedValue(room),
+      updatePlayerInRoom: jest.fn(),
+    } as Partial<IRoomService> as IRoomService;
+    const fillWithComUseCase = {
+      execute: jest
+        .fn()
+        .mockResolvedValue({ success: false, error: 'fill failed' }),
+    } as unknown as IFillWithComUseCase;
+    const useCase = new ShuffleTeamsUseCase(roomService, fillWithComUseCase);
+
+    const result = await useCase.execute({
+      roomId: 'room-1',
+      playerId: 'host',
+    });
+
+    expect(result).toEqual({ success: false, error: 'fill failed' });
+    expect(roomService.updatePlayerInRoom).not.toHaveBeenCalled();
   });
 });

--- a/mei-tra-backend/src/use-cases/change-player-team.use-case.ts
+++ b/mei-tra-backend/src/use-cases/change-player-team.use-case.ts
@@ -39,12 +39,19 @@ export class ChangePlayerTeamUseCase implements IChangePlayerTeamUseCase {
       }
 
       const currentTeamCounts = {
-        0: room.players.filter((p) => !p.isCOM && p.team === 0).length,
-        1: room.players.filter((p) => !p.isCOM && p.team === 1).length,
+        0: room.players.filter((p) => p.team === 0).length,
+        1: room.players.filter((p) => p.team === 1).length,
       } as Record<Team, number>;
 
       const newTeamCounts = { ...currentTeamCounts };
       for (const [playerId, newTeam] of Object.entries(teamChanges)) {
+        if (newTeam !== 0 && newTeam !== 1) {
+          return {
+            success: false,
+            error: `Invalid team for player ${playerId}`,
+          };
+        }
+
         const player = room.players.find((p) => p.playerId === playerId);
         if (!player) {
           return {

--- a/mei-tra-backend/src/use-cases/shuffle-teams.use-case.ts
+++ b/mei-tra-backend/src/use-cases/shuffle-teams.use-case.ts
@@ -30,9 +30,13 @@ export class ShuffleTeamsUseCase {
         roomId: request.roomId,
         playerId: request.playerId,
       });
-      if (fillResult.success && fillResult.updatedRoom) {
-        room = fillResult.updatedRoom;
+      if (!fillResult.success || !fillResult.updatedRoom) {
+        return {
+          success: false,
+          error: fillResult.error || 'Failed to fill empty seats',
+        };
       }
+      room = fillResult.updatedRoom;
     }
 
     const shuffled = [...room.players];
@@ -45,9 +49,15 @@ export class ShuffleTeamsUseCase {
       player.team = (idx < half ? 0 : 1) as Team;
     });
 
-    room.updatedAt = new Date();
-    room.players = shuffled;
-    const updatedRoom = await this.roomService.updateRoom(request.roomId, room);
+    await Promise.all(
+      shuffled.map((player) =>
+        this.roomService.updatePlayerInRoom(request.roomId, player.playerId, {
+          team: player.team,
+        }),
+      ),
+    );
+
+    const updatedRoom = await this.roomService.getRoom(request.roomId);
     if (!updatedRoom) {
       return { success: false, error: 'Failed to change teams' };
     }

--- a/mei-tra-backend/src/use-cases/start-game.use-case.ts
+++ b/mei-tra-backend/src/use-cases/start-game.use-case.ts
@@ -5,9 +5,11 @@ import {
   StartGameRequest,
   StartGameResponse,
 } from './interfaces/start-game.use-case.interface';
-import { RoomStatus } from '../types/room.types';
+import { Room, RoomStatus } from '../types/room.types';
 import { IGameEventLogService } from '../services/interfaces/game-event-log.service.interface';
 import { toDomainPlayer } from '../types/player-adapters';
+import { GameStateService } from '../services/game-state.service';
+import { GameState } from '../types/game.types';
 
 @Injectable()
 export class StartGameUseCase implements IStartGameUseCase {
@@ -33,48 +35,7 @@ export class StartGameUseCase implements IStartGameUseCase {
       }
 
       const roomGameState = await this.roomService.getRoomGameState(roomId);
-      const state = roomGameState.getState();
-
-      // Waiting-room seat order is driven by room.players, so rebuild the in-memory
-      // players array from that source before starting. This keeps the play order
-      // aligned with the shuffled seat arrangement instead of any stale game-state order.
-      const existingPlayers = new Map(
-        state.players.map((statePlayer) => [statePlayer.playerId, statePlayer]),
-      );
-      state.players = room.players.map((roomPlayer) => {
-        const existingPlayer = existingPlayers.get(roomPlayer.playerId);
-
-        if (!existingPlayer) {
-          if (typeof roomGameState.registerPlayerToken === 'function') {
-            roomGameState.registerPlayerToken(
-              roomPlayer.playerId,
-              roomPlayer.playerId,
-            );
-          }
-          return {
-            ...toDomainPlayer(roomPlayer),
-            hand: [...roomPlayer.hand],
-            isPasser: roomPlayer.isPasser ?? false,
-            hasBroken: roomPlayer.hasBroken ?? false,
-            hasRequiredBroken: roomPlayer.hasRequiredBroken ?? false,
-          };
-        }
-
-        return {
-          ...toDomainPlayer(existingPlayer),
-          ...toDomainPlayer(roomPlayer),
-          hand: [...existingPlayer.hand],
-          isPasser: existingPlayer.isPasser,
-          hasBroken: existingPlayer.hasBroken,
-          hasRequiredBroken: existingPlayer.hasRequiredBroken,
-        };
-      });
-
-      state.teamAssignments = Object.fromEntries(
-        state.players.map((player) => [player.playerId, player.team]),
-      );
-
-      const player = state.players.find((p) => p.playerId === playerId);
+      const player = room.players.find((p) => p.playerId === playerId);
       if (!player) {
         this.logger.error('Player not found in game state for game start', {
           playerId,
@@ -105,6 +66,24 @@ export class StartGameUseCase implements IStartGameUseCase {
 
       // 空席をCOMで埋めてからゲーム開始
       await this.roomService.fillVacantSeatsWithCOM(roomId);
+      const roomWithFilledSeats = await this.roomService.getRoom(roomId);
+      if (!roomWithFilledSeats) {
+        return {
+          success: false,
+          errorMessage: 'Room not found after filling vacant seats',
+        };
+      }
+
+      const teamValidationError =
+        this.validateFullRoomTeamBalance(roomWithFilledSeats);
+      if (teamValidationError) {
+        return {
+          success: false,
+          errorMessage: teamValidationError,
+        };
+      }
+
+      this.syncStatePlayersFromRoom(roomGameState, roomWithFilledSeats);
 
       await this.roomService.updateRoomStatus(roomId, RoomStatus.PLAYING);
       await roomGameState.startGame();
@@ -113,7 +92,7 @@ export class StartGameUseCase implements IStartGameUseCase {
       updatedState.pointsToWin = room.settings.pointsToWin;
 
       // Synchronize hands with room representation
-      room.players.forEach((roomPlayer) => {
+      roomWithFilledSeats.players.forEach((roomPlayer) => {
         const statePlayer = updatedState.players.find(
           (p) => p.playerId === roomPlayer.playerId,
         );
@@ -173,5 +152,74 @@ export class StartGameUseCase implements IStartGameUseCase {
         errorMessage: 'Failed to start game',
       };
     }
+  }
+
+  private syncStatePlayersFromRoom(
+    roomGameState: GameStateService,
+    room: Room,
+  ): GameState {
+    const state = roomGameState.getState();
+
+    // Waiting-room seat order is driven by room.players, so rebuild the in-memory
+    // players array from that source before starting. This keeps the play order
+    // aligned with the shuffled seat arrangement instead of any stale game-state order.
+    const existingPlayers = new Map(
+      state.players.map((statePlayer) => [statePlayer.playerId, statePlayer]),
+    );
+    state.players = room.players.map((roomPlayer) => {
+      const existingPlayer = existingPlayers.get(roomPlayer.playerId);
+
+      if (!existingPlayer) {
+        if (typeof roomGameState.registerPlayerToken === 'function') {
+          roomGameState.registerPlayerToken(
+            roomPlayer.playerId,
+            roomPlayer.playerId,
+          );
+        }
+        return {
+          ...toDomainPlayer(roomPlayer),
+          hand: [...roomPlayer.hand],
+          isPasser: roomPlayer.isPasser ?? false,
+          hasBroken: roomPlayer.hasBroken ?? false,
+          hasRequiredBroken: roomPlayer.hasRequiredBroken ?? false,
+        };
+      }
+
+      return {
+        ...toDomainPlayer(existingPlayer),
+        ...toDomainPlayer(roomPlayer),
+        hand: [...existingPlayer.hand],
+        isPasser: existingPlayer.isPasser,
+        hasBroken: existingPlayer.hasBroken,
+        hasRequiredBroken: existingPlayer.hasRequiredBroken,
+      };
+    });
+
+    state.teamAssignments = Object.fromEntries(
+      state.players.map((player) => [player.playerId, player.team]),
+    );
+
+    return state;
+  }
+
+  private validateFullRoomTeamBalance(room: Room): string | null {
+    const maxPlayers = room.settings.maxPlayers;
+    if (room.players.length !== maxPlayers) {
+      return null;
+    }
+
+    const team0Count = room.players.filter(
+      (player) => player.team === 0,
+    ).length;
+    const team1Count = room.players.filter(
+      (player) => player.team === 1,
+    ).length;
+    const expectedTeamSize = maxPlayers / 2;
+
+    if (team0Count !== expectedTeamSize || team1Count !== expectedTeamSize) {
+      return 'Teams must be balanced before starting the game';
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
- Preserve a leaving waiting-room player's team when replacing their seat with a COM placeholder.
- Count COM players in host team-change validation.
- Re-check full-room team balance after COM seats are filled and before starting a game.
- Add regression coverage for waiting-room COM replacement, team-change validation, and unbalanced game start rejection.

## Root Cause
A waiting-room player leaving was replaced with a COM placeholder created with the default `team: 0`. If a team 1 player left, their seat could become team 0; the next human taking that seat inherited the wrong team, allowing a human 4-player room to start as 3 vs 1.

## Validation
- `cd mei-tra-backend && npm test -- --runInBand src/services/__tests__/reconnection.spec.ts src/use-cases/__tests__/game.use-cases.spec.ts`
- `cd mei-tra-backend && npm run lint`
- `cd mei-tra-backend && npm run build`
