### PR TITLE
[codex] Sync profile avatar updates

### DIFF
--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -613,6 +613,25 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     });
   }
 
+  @SubscribeMessage('profile-updated')
+  handleProfileUpdated(@ConnectedSocket() client: Socket): void {
+    const authenticatedUser = this.getAuthenticatedUser(client);
+    if (!authenticatedUser) {
+      client.emit('profile-update-error', 'Authentication required');
+      return;
+    }
+
+    const payload = { userId: authenticatedUser.id };
+    const roomId = this.playerRooms.get(client.id);
+
+    if (roomId) {
+      this.server.to(roomId).emit('profile-updated', payload);
+      return;
+    }
+
+    this.server.emit('profile-updated', payload);
+  }
+
   async handleDisconnect(client: Socket) {
     this.activityTracker.decrementConnections();
 

--- a/mei-tra-frontend/components/game/PlayerAvatar/index.tsx
+++ b/mei-tra-frontend/components/game/PlayerAvatar/index.tsx
@@ -20,7 +20,14 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
 }) => {
   const [profile, setProfile] = useState<PlayerProfile | null>(null);
   const [imageError, setImageError] = useState(false);
-  const { playerId, userId, isAuthenticated, isCOM, name } = player;
+  const {
+    playerId,
+    userId,
+    isAuthenticated,
+    isCOM,
+    name,
+    profileRevision,
+  } = player;
 
   useEffect(() => {
     let cancelled = false;
@@ -53,6 +60,7 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
     isAuthenticated,
     isCOM,
     name,
+    profileRevision,
   ]);
 
   useEffect(() => {

--- a/mei-tra-frontend/components/profile/ProfileEditForm.tsx
+++ b/mei-tra-frontend/components/profile/ProfileEditForm.tsx
@@ -199,6 +199,7 @@ export function ProfileEditForm({ profile, onSave, onCancel }: ProfileEditFormPr
 
       if (socket?.connected && token) {
         socket.emit('update-auth', { token });
+        socket.emit('profile-updated');
       }
     } catch (error) {
       setError(error instanceof Error ? error.message : t('saveFailed'));

--- a/mei-tra-frontend/hooks/useRoom.ts
+++ b/mei-tra-frontend/hooks/useRoom.ts
@@ -16,10 +16,15 @@ import {
 import { useAuth } from '../contexts/AuthContext';
 import { ConnectionUser, Team } from '../types/game.types';
 import { RoomStatus } from '../types/room.types';
+import { clearPlayerProfileCache } from '../lib/utils/profileUtils';
 
 interface UseRoomOptions {
   users?: ConnectionUser[];
   currentPlayerId?: string | null;
+}
+
+interface ProfileUpdatedPayload {
+  userId: string;
 }
 
 export const useRoom = (options: UseRoomOptions = {}) => {
@@ -378,6 +383,43 @@ export const useRoom = (options: UseRoomOptions = {}) => {
       }
     };
 
+    const applyProfileRevision = (
+      room: Room,
+      userId: string,
+      profileRevision: number,
+    ): Room => ({
+      ...room,
+      players: room.players.map((player) =>
+        player.userId === userId || player.playerId === userId
+          ? { ...player, profileRevision }
+          : player,
+      ),
+    });
+
+    const handleProfileUpdated = ({ userId }: ProfileUpdatedPayload) => {
+      if (!userId) {
+        return;
+      }
+
+      clearPlayerProfileCache(userId);
+      const profileRevision = Date.now();
+
+      setCurrentRoom((prevRoom) =>
+        prevRoom
+          ? applyProfileRevision(prevRoom, userId, profileRevision)
+          : prevRoom,
+      );
+      setAvailableRooms((prevRooms) =>
+        prevRooms.map((room) =>
+          room.players.some(
+            (player) => player.userId === userId || player.playerId === userId,
+          )
+            ? applyProfileRevision(room, userId, profileRevision)
+            : room,
+        ),
+      );
+    };
+
     // エラーメッセージ
     const handleErrorMessage = (message: string) => {
       console.warn('[useRoom] error-message received:', {
@@ -426,6 +468,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
     socket.on('player-left', handlePlayerLeft);
     socket.on('room-playing', handleRoomPlaying);
     socket.on('update-players', handleUpdatePlayers);
+    socket.on('profile-updated', handleProfileUpdated);
     socket.on('error-message', handleErrorMessage);
     socket.on('set-room-id', handleSetRoomId);
     socket.on('back-to-lobby', handleBackToLobby);
@@ -438,6 +481,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
       socket.off('player-left', handlePlayerLeft);
       socket.off('room-playing', handleRoomPlaying);
       socket.off('update-players', handleUpdatePlayers);
+      socket.off('profile-updated', handleProfileUpdated);
       socket.off('error-message', handleErrorMessage);
       socket.off('set-room-id', handleSetRoomId);
       socket.off('back-to-lobby', handleBackToLobby);

--- a/mei-tra-frontend/types/game.types.ts
+++ b/mei-tra-frontend/types/game.types.ts
@@ -12,6 +12,7 @@ export interface ConnectionUser {
   name: string;
   userId?: string; // Canonical authenticated account ID
   isAuthenticated?: boolean;
+  profileRevision?: number;
 }
 
 export interface CompletedField {


### PR DESCRIPTION
## Summary
- Add a `profile-updated` socket notification after profile saves.
- Relay authenticated profile update notifications from the gateway to the active room.
- Clear the affected player profile cache on other clients and trigger `PlayerAvatar` to refetch.

## Why
Profile avatar uploads updated the current user's local profile immediately, but other players kept rendering their cached profile for up to five minutes. The update path did not notify other room clients that a profile cache entry had become stale.

## Impact
Players in the same room now see avatar changes shortly after the profile save completes, without removing the existing profile cache or sending image data through Socket.IO.

## Validation
- `cd mei-tra-frontend && npm run lint`
- `cd mei-tra-frontend && npx tsc --noEmit --pretty false`
- `cd mei-tra-backend && npm run lint`
- `cd mei-tra-backend && npm run build`

## Notes
- `cd mei-tra-frontend && npm run build` previously hit repeated external fetch `ECONNRESET/ETIMEDOUT` errors, so type/lint validation was used for the frontend build boundary.
