### PR TITLE
[codex] Address profile and team review fixes

### DIFF
--- a/mei-tra-backend/src/use-cases/__tests__/shuffle-teams.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/shuffle-teams.use-case.spec.ts
@@ -81,4 +81,44 @@ describe('ShuffleTeamsUseCase', () => {
     expect(result).toEqual({ success: false, error: 'fill failed' });
     expect(roomService.updatePlayerInRoom).not.toHaveBeenCalled();
   });
+
+  it('returns failure when any player team update fails', async () => {
+    const room = {
+      id: 'room-1',
+      hostId: 'host',
+      status: RoomStatus.WAITING,
+      players: [
+        { playerId: 'host', team: 0 },
+        { playerId: 'player-2', team: 1 },
+        { playerId: 'player-3', team: 0 },
+        { playerId: 'player-4', team: 1 },
+      ],
+      updatedAt: new Date(),
+    };
+    const roomService = {
+      getRoom: jest.fn().mockResolvedValue(room),
+      updatePlayerInRoom: jest
+        .fn()
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true),
+    } as Partial<IRoomService> as IRoomService;
+    const fillWithComUseCase = {
+      execute: jest.fn(),
+    } as unknown as IFillWithComUseCase;
+    const useCase = new ShuffleTeamsUseCase(roomService, fillWithComUseCase);
+
+    const result = await useCase.execute({
+      roomId: 'room-1',
+      playerId: 'host',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Failed to change teams',
+    });
+    expect(roomService.updatePlayerInRoom).toHaveBeenCalledTimes(4);
+    expect(roomService.getRoom).toHaveBeenCalledTimes(1);
+  });
 });

--- a/mei-tra-backend/src/use-cases/shuffle-teams.use-case.ts
+++ b/mei-tra-backend/src/use-cases/shuffle-teams.use-case.ts
@@ -49,13 +49,16 @@ export class ShuffleTeamsUseCase {
       player.team = (idx < half ? 0 : 1) as Team;
     });
 
-    await Promise.all(
+    const updateResults = await Promise.all(
       shuffled.map((player) =>
         this.roomService.updatePlayerInRoom(request.roomId, player.playerId, {
           team: player.team,
         }),
       ),
     );
+    if (updateResults.some((updated) => !updated)) {
+      return { success: false, error: 'Failed to change teams' };
+    }
 
     const updatedRoom = await this.roomService.getRoom(request.roomId);
     if (!updatedRoom) {

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -44,6 +44,11 @@ import {
 import { fromRoomContract, fromRoomSyncPayload } from '../types/room.types';
 import { getTeamDisplayName } from '../lib/utils/teamUtils';
 import { reconnectSocket } from '../app/socket';
+import { clearPlayerProfileCache } from '../lib/utils/profileUtils';
+
+interface ProfileUpdatedPayload {
+  userId: string;
+}
 
 const dedupeCompletedFields = (fields: CompletedField[]): CompletedField[] => {
   const seen = new Set<string>();
@@ -615,6 +620,22 @@ export const useGame = () => {
             isHost: data.isHost,
           }];
         });
+      },
+      'profile-updated': ({ userId }: ProfileUpdatedPayload) => {
+        if (!userId) {
+          return;
+        }
+
+        clearPlayerProfileCache(userId);
+        const profileRevision = Date.now();
+
+        setPlayers((prev) =>
+          prev.map((player) =>
+            player.userId === userId || player.playerId === userId
+              ? { ...player, profileRevision }
+              : player,
+          ),
+        );
       },
       'game-started': ({
         roomId,


### PR DESCRIPTION
## Summary
- Apply `profile-updated` handling in `useGame` so visible table avatars refresh, not only `useRoom` state.
- Fail team shuffling when any per-player `updatePlayerInRoom` persistence call returns `false`.
- Add a regression test for partial shuffle persistence failure.

## Why
Review of #129/#130 found two post-merge gaps:
- Avatar refresh events updated `useRoom` state, but active `PreGameTable`/`GameTable` avatars are driven by `useGame().players`.
- Shuffle persistence ignored boolean failures from `updatePlayerInRoom`, allowing partial DB updates to be reported as success.

## Impact
Players in active rooms now receive avatar refresh triggers on the visible game player list, and failed shuffle persistence is surfaced instead of broadcasting stale or partially updated teams.

## Validation
- `cd mei-tra-backend && npm test -- --runTestsByPath src/use-cases/__tests__/shuffle-teams.use-case.spec.ts`
- `cd mei-tra-backend && npm run lint`
- `cd mei-tra-backend && npm run build`
- `cd mei-tra-frontend && npm run lint`
- `cd mei-tra-frontend && npx tsc --noEmit --pretty false`
