### PR TITLE
ゲーム画面をコンパクト化してプレイUIを整理

### DIFF
--- a/mei-tra-frontend/__tests__/components/GameDock.test.tsx
+++ b/mei-tra-frontend/__tests__/components/GameDock.test.tsx
@@ -87,4 +87,30 @@ describe('GameDock', () => {
     expect(screen.getByText('strength dock topbar')).toBeInTheDocument();
     expect(screen.getByText('chat dock menu')).toBeInTheDocument();
   });
+
+  it('includes the leave action in the mobile menu', async () => {
+    mockMatchMedia(true);
+    const onLeaveRequest = jest.fn();
+
+    render(
+      <GameDock
+        roomId="room-1"
+        gameStarted
+        currentTrump={null}
+        gamePhase="play"
+        onLeaveRequest={onLeaveRequest}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'menu' })).toBeInTheDocument();
+    });
+
+    const menuButton = screen.getByRole('button', { name: 'menu' });
+    fireEvent.click(menuButton);
+    fireEvent.click(screen.getByRole('button', { name: 'leave' }));
+
+    expect(onLeaveRequest).toHaveBeenCalledTimes(1);
+    expect(menuButton).toHaveAttribute('aria-expanded', 'false');
+  });
 });

--- a/mei-tra-frontend/__tests__/components/GameInfo.test.tsx
+++ b/mei-tra-frontend/__tests__/components/GameInfo.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import { GameInfo } from '@/components/game/GameInfo';
+import type { Player, TeamScores } from '@/types/game.types';
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => {
+    const labels: Record<string, string> = {
+      'common.leave': 'Leave',
+      'gameInfo.reach': 'Reach',
+      'gameInfo.win': 'WIN',
+      'room.leaveConfirm.title': 'Leave room',
+      'room.leaveConfirm.message': 'Are you sure?',
+      'common.cancel': 'Cancel',
+    };
+
+    return (key: string) => labels[key] ?? key;
+  },
+}));
+
+jest.mock('@/components/shared/ConfirmModal', () => ({
+  ConfirmModal: () => null,
+}));
+
+const players: Player[] = [
+  {
+    socketId: 'player-1',
+    playerId: 'player-1',
+    name: 'Player 1',
+    team: 0,
+    hand: [],
+  },
+  {
+    socketId: 'player-2',
+    playerId: 'player-2',
+    name: 'Player 2',
+    team: 1,
+    hand: [],
+  },
+];
+
+const renderGameInfo = (teamScores: TeamScores) =>
+  render(
+    <GameInfo
+      players={players}
+      pointsToWin={5}
+      teamScores={teamScores}
+    />,
+  );
+
+describe('GameInfo', () => {
+  it('marks a team within one point of the target as reaching', () => {
+    renderGameInfo({
+      0: { deal: 0, blow: 0, play: 0, total: 4 },
+      1: { deal: 0, blow: 0, play: 0, total: 2 },
+    });
+
+    const teamMeter = screen.getByRole('meter', { name: 'Player 1' });
+
+    expect(teamMeter).toHaveAttribute('aria-valuetext', '4/5 Reach');
+    expect(screen.getByText('Reach')).toBeInTheDocument();
+  });
+
+  it('marks a team at the target as a winner', () => {
+    renderGameInfo({
+      0: { deal: 0, blow: 0, play: 0, total: 2 },
+      1: { deal: 0, blow: 0, play: 0, total: 5 },
+    });
+
+    const teamMeter = screen.getByRole('meter', { name: 'Player 2' });
+
+    expect(teamMeter).toHaveAttribute('aria-valuetext', '5/5 WIN');
+    expect(screen.getByText('WIN')).toBeInTheDocument();
+  });
+});

--- a/mei-tra-frontend/__tests__/components/PlayerHand.test.tsx
+++ b/mei-tra-frontend/__tests__/components/PlayerHand.test.tsx
@@ -8,6 +8,7 @@ jest.mock('next-intl', () => ({
     const labels: Record<string, Record<string, string>> = {
       playerHand: {
         agari: 'Agari',
+        bid: 'Bid:',
         cards: 'cards',
         negri: 'Negri',
         selectNegri: 'Please select your Negri',
@@ -150,6 +151,46 @@ describe('PlayerHand', () => {
     expect(screen.getAllByText('Agari').length).toBeGreaterThan(0);
     expect(screen.getByText('Please select your Negri')).toBeInTheDocument();
     expect(screen.getAllByText('H-A').length).toBeGreaterThan(0);
+  });
+
+  it('keeps bottom-player status displays in a dedicated zone above the hand', () => {
+    renderPlayerHand({
+      position: 'bottom',
+      agariCard: 'H-A',
+      currentHighestDeclaration: { playerId: 'player-2' },
+      currentPlayerId: 'player-2',
+      whoseTurn: 'player-2',
+      player: {
+        ...otherPlayer,
+        hand: ['H-A', 'S-2'],
+      },
+    });
+
+    expect(screen.getByText('Agari').closest('.bottomStatusZone')).toBeInTheDocument();
+    expect(screen.getByText('Agari').closest('.declarationContext')).toBeInTheDocument();
+    expect(
+      screen.getByText('Please select your Negri').closest('.bottomStatusZone'),
+    ).toBeInTheDocument();
+  });
+
+  it('places the bottom player Negri card beside the declaration', () => {
+    renderPlayerHand({
+      position: 'bottom',
+      currentPlayerId: 'player-2',
+      negriCard: 'H-A',
+      negriPlayerId: 'player-2',
+    });
+
+    expect(screen.getByText('negri card').closest('.declarationContext')).toBeInTheDocument();
+  });
+
+  it('hides the Negri card for another player', () => {
+    renderPlayerHand({
+      negriCard: 'H-A',
+      negriPlayerId: 'player-2',
+    });
+
+    expect(screen.queryByText('negri card')).not.toBeInTheDocument();
   });
 
   it('shows the selected spectator perspective hand face up', () => {

--- a/mei-tra-frontend/app/[locale]/index.module.css
+++ b/mei-tra-frontend/app/[locale]/index.module.css
@@ -47,6 +47,14 @@
   flex-direction: column;
 }
 
+@media (min-width: 769px) {
+  .activeGameWrapper {
+    height: calc(100dvh - 4.5rem);
+    min-height: 0;
+    overflow: hidden;
+  }
+}
+
 @media (max-width: 768px) {
   .main {
     min-height: calc(100dvh - 4rem);
@@ -55,5 +63,12 @@
   .gameWrapper {
     min-height: calc(100dvh - 4rem);
     padding-bottom: 4.5rem;
+  }
+
+  .activeGameWrapper {
+    height: calc(100dvh - 4rem);
+    min-height: 0;
+    padding-bottom: 0;
+    overflow: hidden;
   }
 }

--- a/mei-tra-frontend/app/[locale]/page.tsx
+++ b/mei-tra-frontend/app/[locale]/page.tsx
@@ -189,7 +189,7 @@ export default function Home() {
 
             {/* ② PreGameTable: 待機中 / GameTable: ゲーム中 */}
             {currentRoomId && (
-              <div className={styles.gameWrapper}>
+              <div className={`${styles.gameWrapper} ${gameStarted ? styles.activeGameWrapper : ''}`}>
                 {!gameStarted ? (
                   <PreGameTable
                     players={players}

--- a/mei-tra-frontend/components/game/CompletedFields/index.module.scss
+++ b/mei-tra-frontend/components/game/CompletedFields/index.module.scss
@@ -1,64 +1,86 @@
 .completedFieldsContainer {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0 12px;
-  background: var(--mt-surface-raised);
-  border-radius: var(--mt-radius);
-  margin-top: 16px;
-  padding: 8px 16px;
-  width: 526px;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  gap: 0.8rem;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  max-width: 100%;
+  min-height: 4.5rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x proximity;
+  scrollbar-width: thin;
 }
 
 .completedField {
-  /* 5個ごとに折り返すために20%の幅を指定 */
-  flex: 0 0 calc(20% - 9.6px); /* (gap * 4) / 5 = 9.6px */
+  flex: 0 0 clamp(6.35rem, 9.5vw, 6.8rem);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
-  gap: 6px;
-  border-radius: var(--mt-radius);
-  padding: 8px;
+  gap: 0.2rem;
+  padding: 0;
+  scroll-snap-align: start;
 }
 
 .winnerName {
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   color: var(--mt-text-primary);
   text-align: center;
-  padding: 4px;
-  background: var(--mt-surface-raised);
+  padding: 0;
+  background: transparent;
   border-radius: var(--mt-radius);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  width: 70px;
+  width: 100%;
+  line-height: 1.2;
+  font-weight: 700;
 }
 
 .cards {
   display: flex;
-  gap: 4px;
+  align-items: center;
+  height: 3rem;
+  gap: 0;
   justify-content: center;
+  width: 100%;
+}
+
+.cards > * {
+  flex: 0 0 2rem;
+  width: 2rem;
+  margin: 0 -0.32rem;
 }
 
 @media (max-width: 768px) {
   .completedFieldsContainer {
-    gap: 8px;
-    padding: 8px;
-    width: 300px;
+    gap: 0.6rem;
+    min-height: 4rem;
+    padding: 0;
+    width: 100%;
   }
 
   .completedField {
-    /* 3個ごとに折り返すために33.333%の幅を指定 */
-    flex: 0 0 calc(33.333% - 5.33px); /* (gap * 2) / 3 = 5.33px */
+    flex-basis: 5.85rem;
+    min-height: 3.5rem;
   }
 
   .winnerName {
-    font-size: 0.7rem;
-    padding: 2px;
+    font-size: 0.66rem;
+    padding: 0;
   }
 
   .cards {
-    gap: 2px;
+    height: 2.625rem;
+  }
+
+  .cards > * {
+    flex-basis: 1.75rem;
+    width: 1.75rem;
+    margin: 0 -0.24rem;
   }
 }

--- a/mei-tra-frontend/components/game/GameDock.module.scss
+++ b/mei-tra-frontend/components/game/GameDock.module.scss
@@ -15,21 +15,29 @@
 }
 
 .menuButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: var(--mt-btn-primary-text);
   background: var(--mt-btn-primary-bg);
   border: none;
-  padding: 0.5rem 0.75rem;
+  padding: 0;
   border-radius: var(--mt-radius);
   min-height: 2.25rem;
-  min-width: 4.75rem;
-  font-size: 0.875rem;
+  min-width: 2.25rem;
   cursor: pointer;
   transition: all 0.2s ease;
-  line-height: 1.3;
 
   &:hover {
     box-shadow: 0 0 15px var(--mt-accent-subtle);
   }
+}
+
+.menuSymbol {
+  display: block;
+  font-size: 1.35rem;
+  font-weight: 800;
+  line-height: 1;
 }
 
 .mobileMenu {
@@ -56,4 +64,21 @@
   opacity: 1;
   pointer-events: auto;
   visibility: visible;
+}
+
+.leaveMenuButton {
+  width: 100%;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid var(--mt-border-hairline);
+  border-radius: var(--mt-radius);
+  background: var(--mt-surface-raised-2);
+  color: var(--mt-text-primary);
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--mt-accent);
+  }
 }

--- a/mei-tra-frontend/components/game/GameDock.tsx
+++ b/mei-tra-frontend/components/game/GameDock.tsx
@@ -12,6 +12,7 @@ interface GameDockProps {
   gameStarted: boolean;
   currentTrump: TrumpType | null;
   gamePhase?: string | null;
+  onLeaveRequest?: () => void;
 }
 
 export function GameDock({
@@ -19,6 +20,7 @@ export function GameDock({
   gameStarted,
   currentTrump,
   gamePhase,
+  onLeaveRequest,
 }: GameDockProps) {
   const tCommon = useTranslations('common');
   const [isMobile, setIsMobile] = useState(false);
@@ -71,6 +73,20 @@ export function GameDock({
           placement={isMobile ? 'menu' : 'topbar'}
         />
       </div>
+      {isMobile && onLeaveRequest && (
+        <div className={styles.dockItem}>
+          <button
+            type="button"
+            className={styles.leaveMenuButton}
+            onClick={() => {
+              setIsMenuOpen(false);
+              onLeaveRequest();
+            }}
+          >
+            {tCommon('leave')}
+          </button>
+        </div>
+      )}
     </>
   );
 
@@ -82,8 +98,12 @@ export function GameDock({
           className={styles.menuButton}
           onClick={() => setIsMenuOpen((prev) => !prev)}
           aria-expanded={isMenuOpen}
+          aria-label={tCommon('menu')}
+          title={tCommon('menu')}
         >
-          {tCommon('menu')}
+          <span className={styles.menuSymbol} aria-hidden="true">
+            {isMenuOpen ? '×' : '⋯'}
+          </span>
         </button>
         <div
           className={`${styles.mobileMenu} ${isMenuOpen ? styles.mobileMenuOpen : ''}`}

--- a/mei-tra-frontend/components/game/GameField/index.module.scss
+++ b/mei-tra-frontend/components/game/GameField/index.module.scss
@@ -3,8 +3,8 @@
   position: relative;
   justify-self: center;
   width: 100%;
-  height: auto;
-  margin: -28px 0 auto;
+  height: 100%;
+  margin: 0;
   background: transparent;
   border-radius: 1rem;
   display: flex;
@@ -19,9 +19,9 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  width: min(100%, 320px);
+  width: min(100%, clamp(12rem, 34vh, 20rem));
   aspect-ratio: 1 / 1;
-  padding: 0.4rem;
+  padding: 0.25rem;
   border-radius: 999px;
 }
 
@@ -43,11 +43,23 @@
   z-index: 0;
 }
 
+:global(html[data-theme='light']) .fieldContainerOuter::before {
+  inset: -16px;
+  background: radial-gradient(
+    circle at center,
+    rgba(255, 245, 208, 0.55) 0%,
+    rgba(217, 176, 84, 0.32) 28%,
+    rgba(173, 128, 42, 0.16) 53%,
+    rgba(173, 128, 42, 0) 76%
+  );
+  filter: blur(14px);
+}
+
 .fieldContainerInner {
   position: relative;
   z-index: 1;
-  width: 200px;
-  height: 200px;
+  width: clamp(9rem, 22vh, 12rem);
+  height: clamp(9rem, 22vh, 12rem);
 }
 
 /* Each played card is absolutely positioned from center */
@@ -77,7 +89,7 @@
 
 .card {
   position: relative;
-  width: var(--card-width);
+  width: min(var(--card-width), 4.5rem);
   aspect-ratio: 2 / 3;
   border-radius: var(--radius-md);
   display: flex;
@@ -225,7 +237,7 @@
   }
 
   .fieldContainerOuter {
-    width: min(100%, 248px);
+    width: min(100%, 208px);
     aspect-ratio: 1 / 1;
     min-height: 0;
     justify-content: center;
@@ -248,12 +260,12 @@
   }
 
   .fieldContainerInner {
-    width: 160px;
-    height: 160px;
+    width: 140px;
+    height: 140px;
   }
 
   .card {
-    width: 68px;
+    width: 60px;
     aspect-ratio: 2 / 3;
     box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
   }

--- a/mei-tra-frontend/components/game/GameInfo/index.module.scss
+++ b/mei-tra-frontend/components/game/GameInfo/index.module.scss
@@ -1,56 +1,155 @@
 .gameInfoContainer {
-  position: relative;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  flex-wrap: wrap;
-  gap: 0.75rem 1rem;
-  padding: 16px 32px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  padding: 0.3rem clamp(0.75rem, 2vw, 2rem);
+  flex-shrink: 0;
 }
 
 .gameInfoContent {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-md);
   min-width: 0;
-  flex: 1 1 18rem;
-}
-
-.gameInfoTrump {
-  
-}
-
-.gameInfoTrumpText {
-  color: var(--mt-text-primary);
-  font-weight: bold;
-  font-size: 1.1rem;
-  line-height: 1.4;
-  word-break: break-word;
 }
 
 .gameInfoScores {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.gameInfoScore {
+  position: relative;
+  min-width: 0;
+}
+
+.gameInfoScoreContent {
   display: flex;
-  gap: var(--spacing-md);
-  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.3rem;
 }
 
-.gameInfoScoreText0 {
-  font-weight: bold;
-  font-size: 1.1rem;
-  line-height: 1.4;
+.gameInfoMeter {
+  position: relative;
+  flex: 0 0 clamp(5rem, 10vw, 7rem);
+  width: clamp(5rem, 10vw, 7rem);
+  height: 1.35rem;
+  border-radius: 999px;
+  background: var(--mt-border-hairline);
+  overflow: hidden;
 }
 
-.gameInfoScoreText1 {
-  font-weight: bold;
-  font-size: 1.1rem;
-  line-height: 1.4;
+.gameInfoScoreFill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--team-score-progress, 0%);
+  border-radius: inherit;
+  background: color-mix(in srgb, var(--mt-accent) 62%, transparent);
+  transition: width 0.3s ease;
+}
+
+.gameInfoScoreMeta {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.3rem;
+  height: 100%;
+  padding: 0 0.42rem;
+}
+
+.leadingTeam {
+  .gameInfoScoreValue {
+    color: var(--mt-accent);
+  }
+}
+
+.gameInfoScore.reachingTeam {
+  .gameInfoMeter {
+    box-shadow: 0 0 8px var(--mt-accent-subtle);
+  }
+}
+
+.gameInfoScore.winningTeam {
+  .gameInfoMeter {
+    box-shadow: 0 0 10px var(--mt-accent-subtle);
+  }
+}
+
+.team0 {
+  .gameInfoScoreFill {
+    background: color-mix(in srgb, var(--mt-accent) 62%, transparent);
+  }
+}
+
+.team1 {
+  .gameInfoScoreFill {
+    background: color-mix(in srgb, var(--mt-text-secondary) 52%, transparent);
+  }
+}
+
+.reachingTeam .gameInfoScoreFill,
+.winningTeam .gameInfoScoreFill {
+  background: color-mix(in srgb, var(--mt-accent) 52%, transparent);
+}
+
+.gameInfoScoreTeam {
+  flex: 0 1 auto;
+  max-width: clamp(4rem, 12vw, 9rem);
+  min-width: 0;
+  overflow: hidden;
+  color: var(--mt-text-secondary);
+  font-size: clamp(0.68rem, 0.85vw, 0.82rem);
+  font-weight: 700;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gameInfoScoreValue {
+  color: var(--mt-text-primary);
+  font-size: clamp(0.96rem, 1.3vw, 1.1rem);
+  font-weight: 800;
+  line-height: 1;
+  white-space: nowrap;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.gameInfoScoreValue span {
+  color: var(--mt-text-muted);
+  font-size: 0.7em;
+}
+
+.gameInfoScoreStatus {
+  padding: 0.1rem 0.36rem;
+  border-radius: 999px;
+  background: var(--mt-accent);
+  color: var(--mt-btn-primary-text);
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  box-shadow: 0 1px 4px var(--mt-accent-subtle);
+}
+
+.scoreAnnouncement {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .gameInfoActions {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.5rem;
-  margin-left: auto;
+  min-width: max-content;
 }
 
 .leaveButton {
@@ -74,9 +173,12 @@
 
 @media (max-width: 768px) {
   .gameInfoContainer {
-    padding: 8px 12px;
+    position: relative;
+    display: flex;
+    justify-content: space-between;
+    padding: 6px 12px;
     align-items: flex-start;
-    gap: 0.75rem;
+    gap: 0.5rem;
   }
 
   .gameInfoContent {
@@ -85,22 +187,47 @@
   }
 
   .gameInfoScores {
-    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .gameInfoScore {
+    width: 100%;
+  }
+
+  .gameInfoScoreContent {
     gap: 0.25rem;
+  }
+
+  .gameInfoMeter {
+    flex-basis: clamp(3.6rem, 18vw, 4.6rem);
+    width: clamp(3.6rem, 18vw, 4.6rem);
+    height: 1.2rem;
+  }
+
+  .gameInfoScoreMeta {
+    gap: 0.15rem;
+    padding: 0 0.28rem;
+  }
+
+  .gameInfoScoreStatus {
+    padding: 0.06rem 0.18rem;
+    font-size: 0.54rem;
+  }
+
+  .gameInfoScoreValue {
+    font-size: 0.86rem;
   }
 
   .gameInfoActions {
     position: absolute;
-    top: 8px;
+    top: 6px;
     right: 12px;
     align-items: flex-start;
     margin-left: 0;
   }
 
   .leaveButton {
-    margin-left: auto;
-    min-width: 4.25rem;
-    padding: 0.5rem 0.75rem;
+    display: none;
   }
 }
 

--- a/mei-tra-frontend/components/game/GameInfo/index.tsx
+++ b/mei-tra-frontend/components/game/GameInfo/index.tsx
@@ -1,28 +1,23 @@
 import React, { useState } from 'react';
 import {
-  TrumpType,
   TeamScores,
   Player,
 } from '@/types/game.types';
-import { getTrumpDisplay } from '@/lib/utils/trumpDisplay';
 import styles from './index.module.scss';
 import { useTranslations } from 'next-intl';
 import { ConfirmModal } from '@/components/shared/ConfirmModal';
+
+type ScoreStatus = 'normal' | 'leading' | 'reach' | 'win';
+
 interface GameInfoProps {
-  currentTrump: TrumpType | null;
-  currentHighestDeclarationPlayer: string | null;
-  numberOfPairs: number;
   teamScores: TeamScores;
   pointsToWin: number;
   players: Player[];
-  actionSlot?: React.ReactNode;
+  actionSlot?: (onLeaveRequest: () => void) => React.ReactNode;
   onLeave?: () => void;
 }
 
 export const GameInfo: React.FC<GameInfoProps> = ({
-  currentTrump,
-  currentHighestDeclarationPlayer,
-  numberOfPairs,
   teamScores,
   pointsToWin,
   players,
@@ -36,6 +31,56 @@ export const GameInfo: React.FC<GameInfoProps> = ({
     const teamPlayers = players.filter(player => player.team === teamNumber);
     return teamPlayers.map(player => player.isCOM ? 'com' : player.name).join(' & ');
   };
+  const getScoreProgress = (score: number) => {
+    if (pointsToWin <= 0) {
+      return 0;
+    }
+
+    return Math.min(100, Math.max(0, (score / pointsToWin) * 100));
+  };
+  const getScoreStatus = (score: number, opposingScore: number): ScoreStatus => {
+    if (pointsToWin > 0 && score >= pointsToWin) {
+      return 'win';
+    }
+
+    if (pointsToWin > 0 && score < pointsToWin && pointsToWin - score <= 1) {
+      return 'reach';
+    }
+
+    if (score > opposingScore) {
+      return 'leading';
+    }
+
+    return 'normal';
+  };
+  const getScoreStatusLabel = (status: ScoreStatus) => {
+    switch (status) {
+      case 'reach':
+        return t('gameInfo.reach');
+      case 'win':
+        return t('gameInfo.win');
+      default:
+        return null;
+    }
+  };
+  const scoreTeams = [0, 1].map((teamNumber) => {
+    const score = teamScores[teamNumber].total;
+    const opposingScore = teamScores[teamNumber === 0 ? 1 : 0].total;
+    const status = getScoreStatus(score, opposingScore);
+
+    return {
+      teamNumber,
+      teamName: getTeamPlayerNames(teamNumber),
+      score,
+      progress: getScoreProgress(score),
+      status,
+      statusLabel: getScoreStatusLabel(status),
+    };
+  });
+  const scoreAnnouncement = scoreTeams
+    .filter(({ status }) => status === 'reach' || status === 'win')
+    .map(({ teamName, score, statusLabel }) => `${teamName}: ${score}/${pointsToWin} ${statusLabel}`)
+    .join('、');
 
   const handleLeaveClick = () => {
     setShowConfirmModal(true);
@@ -52,29 +97,54 @@ export const GameInfo: React.FC<GameInfoProps> = ({
 
   return (
     <>
+      <div className={styles.scoreAnnouncement} aria-atomic="true" aria-live="polite">
+        {scoreAnnouncement}
+      </div>
       <div className={styles.gameInfoContainer}>
         <div className={styles.gameInfoContent}>
-          {/* Current Trump */}
-          {currentTrump && (
-            <div className={styles.gameInfoTrump}>
-              <span className={styles.gameInfoTrumpText}>
-                👑 {currentHighestDeclarationPlayer} : {getTrumpDisplay(currentTrump)}{numberOfPairs}
-              </span>
-            </div>
-          )}
-
-          {/* Scores */}
           <div className={styles.gameInfoScores}>
-            <span className={styles.gameInfoScoreText0}>
-              {getTeamPlayerNames(0)}: {teamScores[0].total}/{pointsToWin}
-            </span>
-            <span className={styles.gameInfoScoreText1}>
-              {getTeamPlayerNames(1)}: {teamScores[1].total}/{pointsToWin}
-            </span>
+            {scoreTeams.map(({ teamNumber, teamName, score, progress, status, statusLabel }) => {
+              const isLeading = status === 'leading' || status === 'reach' || status === 'win';
+
+              return (
+                <div
+                  key={teamNumber}
+                  className={`${styles.gameInfoScore} ${
+                    teamNumber === 0 ? styles.team0 : styles.team1
+                  } ${isLeading ? styles.leadingTeam : ''} ${
+                    status === 'reach' ? styles.reachingTeam : ''
+                  } ${status === 'win' ? styles.winningTeam : ''}`}
+                  aria-label={teamName}
+                  aria-valuemax={pointsToWin}
+                  aria-valuemin={0}
+                  aria-valuenow={score}
+                  aria-valuetext={`${score}/${pointsToWin}${statusLabel ? ` ${statusLabel}` : ''}`}
+                  role="meter"
+                  style={{ '--team-score-progress': `${progress}%` } as React.CSSProperties}
+                >
+                  <div className={styles.gameInfoScoreContent}>
+                    <span className={styles.gameInfoScoreTeam} title={teamName}>
+                      {teamName}
+                    </span>
+                    <div className={styles.gameInfoMeter}>
+                      <div className={styles.gameInfoScoreFill} aria-hidden="true" />
+                      <div className={styles.gameInfoScoreMeta}>
+                        {statusLabel && (
+                          <span className={styles.gameInfoScoreStatus}>{statusLabel}</span>
+                        )}
+                        <span className={styles.gameInfoScoreValue}>
+                          {score}<span>/{pointsToWin}</span>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
           </div>
         </div>
         <div className={styles.gameInfoActions}>
-          {actionSlot}
+          {actionSlot?.(handleLeaveClick)}
           <button onClick={handleLeaveClick} className={styles.leaveButton}>
             {t('common.leave')}
           </button>

--- a/mei-tra-frontend/components/game/GameTable/index.module.scss
+++ b/mei-tra-frontend/components/game/GameTable/index.module.scss
@@ -1,18 +1,25 @@
+.gameTable {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
 .playerPositions {
   position: relative;
   display: grid;
   grid-template-areas:
     ".    top     ."
     "left field right"
-    ".    bottom  .";
-  grid-template-columns: 240px minmax(360px, 480px) 240px;
-  grid-template-rows: auto minmax(200px, 248px) auto;
-  gap: 0.2rem 1.1rem;
+    "bottom bottom bottom";
+  grid-template-columns: minmax(120px, 150px) minmax(340px, 540px) minmax(120px, 150px);
+  grid-template-rows: minmax(3.75rem, auto) minmax(10rem, 1fr) minmax(8.75rem, auto);
+  gap: 0.15rem 0.75rem;
   justify-content: center;
-  align-items: start;
+  align-items: center;
   flex: 1;
   min-height: 0;
-  padding: 0.7rem 1.5rem 0.9rem;
+  padding: 0.25rem clamp(0.75rem, 2vw, 1.5rem) 0.5rem;
 }
 
 .waitingCenter {
@@ -77,13 +84,17 @@
 }
 
 @media (max-width: 768px) {
+  .gameTable {
+    min-height: auto;
+  }
+
   .playerPositions {
     grid-template-areas:
       "left top right"
       "field field field"
       "bottom bottom bottom";
     grid-template-columns: 78px minmax(0, 1fr) 78px;
-    grid-template-rows: auto minmax(190px, 214px) auto;
+    grid-template-rows: auto minmax(158px, 1fr) auto;
     gap: 0.1rem 0.5rem;
     margin-top: 0.35rem;
     padding: 0.35rem 0.4rem 0.75rem;

--- a/mei-tra-frontend/components/game/GameTable/index.tsx
+++ b/mei-tra-frontend/components/game/GameTable/index.tsx
@@ -81,7 +81,6 @@ export const GameTable: React.FC<GameTableProps> = ({
   const [spectatorPerspectivePlayerId, setSpectatorPerspectivePlayerId] =
     useState<string | null>(null);
 
-  const currentHighestDeclarationPlayer = players.find(p => p.playerId === currentHighestDeclaration?.playerId)?.name;
   const hostPlayerId = players.find((player) => player.isHost)?.playerId ?? players[0]?.playerId ?? null;
   const tablePerspectivePlayerId = isSpectator
     ? spectatorPerspectivePlayerId ?? hostPlayerId
@@ -128,24 +127,22 @@ export const GameTable: React.FC<GameTableProps> = ({
   });
 
   return (
-    <>
+    <div className={styles.gameTable}>
       {!isWaiting && (
         <GameInfo
-          currentTrump={currentTrump}
-          currentHighestDeclarationPlayer={currentHighestDeclarationPlayer ?? null}
-          numberOfPairs={currentHighestDeclaration?.numberOfPairs ?? 0}
           teamScores={teamScores}
           pointsToWin={pointsToWin}
           players={players}
           actionSlot={
-            currentRoomId ? (
+            currentRoomId ? (onLeaveRequest) => (
               <GameDock
                 roomId={currentRoomId}
                 gameStarted={!isWaiting}
                 currentTrump={currentTrump}
                 gamePhase={gamePhase}
+                onLeaveRequest={onLeaveRequest}
               />
-            ) : null
+            ) : undefined
           }
           onLeave={onLeave}
         />
@@ -246,6 +243,6 @@ export const GameTable: React.FC<GameTableProps> = ({
           />
         )}
       </div>
-    </>
+    </div>
   );
 };

--- a/mei-tra-frontend/components/game/PlayAndCancelBtn/index.module.scss
+++ b/mei-tra-frontend/components/game/PlayAndCancelBtn/index.module.scss
@@ -65,9 +65,9 @@
     bottom: 0.25rem;
     left: 50%;
     transform: translateX(-50%);
-    width: min(92%, 320px);
+    width: min(82%, 280px);
     justify-content: space-between;
-    gap: 0.65rem;
+    gap: 0.5rem;
     padding: 0;
     z-index: 20;
   }
@@ -76,7 +76,8 @@
   .cancelButton {
     min-width: 0;
     flex: 1;
-    min-height: 3.15rem;
-    padding: 0.72rem 1rem;
+    min-height: 2.75rem;
+    padding: 0.5rem 0.7rem;
+    font-size: 0.9rem;
   }
 }

--- a/mei-tra-frontend/components/game/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/game/PlayerHand/index.module.scss
@@ -9,6 +9,7 @@
   padding: 0.25rem 0 5rem;
   min-height: var(--player-hand-card-container-min-height, 160px);
   overflow: visible;
+  z-index: var(--z-index-card);
 }
 
 .otherPlayerHandContainer{
@@ -20,7 +21,9 @@
   width: 100%;
   padding: 0.3rem 0 0;
   margin-left: 0;
-  min-height: 2.4rem;
+  min-height: 1.9rem;
+  position: relative;
+  z-index: var(--z-index-card);
 }
 
 .card {
@@ -45,12 +48,12 @@
 }
 
 .cardFaceDown{
-  width: 1.7rem;
+  width: 1.55rem;
   aspect-ratio: 2 / 3;
   border-radius: 0.25rem;
   display: flex;
   overflow: hidden;
-  margin-left: -0.9rem;
+  margin-left: -0.7rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   user-select: none;
   -webkit-user-select: none;
@@ -113,6 +116,56 @@
   border-radius: var(--radius-sm);
   margin-bottom: 0;
   background: transparent;
+}
+
+.declarationBadge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  margin-bottom: 0.25rem;
+  padding: 0.18rem 0.45rem;
+  border: 1px solid var(--mt-border-hairline);
+  border-radius: 999px;
+  background: var(--mt-surface-raised);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.12);
+  white-space: nowrap;
+}
+
+.declarationLabel {
+  color: var(--mt-text-secondary);
+  font-size: 0.66rem;
+  font-weight: 700;
+}
+
+.declarationValue {
+  display: flex;
+  align-items: center;
+  gap: 0.22rem;
+  color: var(--mt-text-primary);
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.declarationSuit {
+  color: var(--mt-text-primary);
+  font-size: 1.15rem;
+  font-weight: 900;
+  line-height: 0.8;
+}
+
+.declarationSuit[data-trump='herz'],
+.declarationSuit[data-trump='daiya'] {
+  color: var(--mt-danger);
+}
+
+.declarationSuit[data-trump='tra'] {
+  color: var(--mt-accent);
+}
+
+.declarationPairs {
+  min-width: 0.75rem;
+  text-align: center;
 }
 
 .playerInfoGroup{
@@ -334,7 +387,7 @@
   grid-area: top;
   align-self: start;
   justify-self: center;
-  margin-top: -1.45rem;
+  margin-top: 0.1rem;
 }
 
 .playerPosition.bottom {
@@ -387,7 +440,7 @@
 .playerPosition.top .playerInfoContainer,
 .playerPosition.left .playerInfoContainer,
 .playerPosition.right .playerInfoContainer {
-  min-width: 82px;
+  min-width: 68px;
   padding: 0.16rem;
   background: var(--mt-surface-raised-2);
 }
@@ -395,8 +448,8 @@
 .playerPosition.top .playerName,
 .playerPosition.left .playerName,
 .playerPosition.right .playerName {
-  max-width: 76px;
-  font-size: 0.76rem;
+  max-width: 64px;
+  font-size: 0.7rem;
 }
 
 .playerPosition.top .cardCount,
@@ -406,21 +459,70 @@
 }
 
 .playerPosition.bottom .playerInfo {
-  align-items: center;
-  row-gap: 0.1rem;
-  padding-top: 0.1rem;
+  display: grid;
+  grid-template-areas:
+    "status status"
+    "profile hand"
+    "fields fields";
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: end;
+  column-gap: clamp(0.4rem, 1.25vw, 1rem);
+  row-gap: 0.65rem;
+  width: min(100%, 48rem);
+  margin: 0 auto;
+  padding: 0.1rem 0.35rem 0;
 }
 
-  .playerPosition.bottom .playerInfoGroup {
-    width: 100%;
-    justify-content: flex-start;
-    align-items: center;
-    gap: 0.7rem;
-  }
+.bottomStatusZone {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  min-width: 0;
+}
 
-  .playerPosition.bottom .playerInfoGroup > :nth-child(2) {
-    margin-left: 0.35rem;
-  }
+.playerPosition.bottom .bottomStatusZone {
+  grid-area: status;
+  width: 100%;
+}
+
+.playerPosition.bottom .declarationContext {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  justify-self: start;
+}
+
+.declarationRow {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.declarationRow > :last-child:not(:first-child) {
+  margin-left: 0.4rem;
+}
+
+.playerPosition.bottom .declarationBadge {
+  margin-bottom: 0;
+}
+
+.playerPosition.bottom .playerInfoGroup {
+  grid-area: profile;
+  width: auto;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 0.45rem;
+  align-self: end;
+  position: relative;
+  z-index: 1;
+}
+
+.playerPosition.bottom .playerInfoGroup > :nth-child(2) {
+  margin-left: 0.15rem;
+}
 
 .playerPosition.bottom .playerInfoContainer {
   min-width: 94px;
@@ -436,6 +538,63 @@
   margin-left: 0.55rem;
 }
 
+.playerPosition.bottom .declarationAgariPanel {
+  min-width: 0;
+  min-height: 0;
+  padding: 0.2rem 0.3rem;
+  flex-direction: row;
+  gap: 0.3rem;
+  margin: 0;
+}
+
+.playerPosition.bottom .declarationAgariPanel .statusHeader {
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.playerPosition.bottom .declarationAgariPanel .statusCardFrame {
+  min-width: 1.8rem;
+  min-height: 2.7rem;
+  padding: 0;
+}
+
+.playerPosition.bottom .declarationAgariPanel .statusCardFrame > * {
+  transform: none;
+}
+
+.playerPosition.bottom .handContainer {
+  grid-area: hand;
+  min-width: 0;
+  min-height: 0;
+  padding: 0.2rem 0 2.6rem;
+}
+
+.handStatusPanels {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+}
+
+.playerPosition.bottom .handStatusPanels {
+  max-width: 100%;
+  margin: 0;
+}
+
+.playerPosition.bottom .card {
+  width: var(--player-hand-card-width, 72px);
+  margin: 0 max(-1.75rem, calc((2.5rem - var(--player-hand-card-width, 72px)) / 2));
+}
+
+.completedFields {
+  grid-area: fields;
+  justify-self: center;
+  min-width: 0;
+  width: min(100%, 42rem);
+}
+
 @media (max-width: 768px) {
   .playerPosition.top,
   .playerPosition.bottom,
@@ -447,13 +606,13 @@
   .playerPosition.top {
     align-self: start;
     padding-top: 0;
-    margin-top: -1rem;
+    margin-top: -0.15rem;
   }
 
   .playerPosition.left,
   .playerPosition.right {
     align-self: start;
-    margin-top: -0.2rem;
+    margin-top: 0.55rem;
   }
 
   .playerPosition.bottom {
@@ -568,20 +727,49 @@
   .playerPosition.bottom .playerInfo {
     width: 100%;
     max-width: 100%;
-    padding: 0 0.2rem 0.4rem;
+    display: grid;
+    grid-template-areas:
+      "status status"
+      "profile hand"
+      "fields fields";
+    grid-template-columns: 5.25rem minmax(0, 1fr);
+    align-items: end;
+    column-gap: 0;
+    row-gap: 0;
+    padding: 0 0.2rem 0.2rem;
     margin-bottom: 0;
-    margin-top: 0.35rem;
-    align-items: center;
-    display: flex;
-    flex-direction: column;
-    row-gap: 0.05rem;
+    margin-top: 0.1rem;
+  }
+
+  .declarationBadge {
+    margin-bottom: 0.15rem;
+    padding: 0.15rem 0.36rem;
+  }
+
+  .playerPosition.bottom .bottomStatusZone {
+    align-items: flex-end;
+    gap: 0.35rem;
+  }
+
+  .declarationLabel {
+    font-size: 0.6rem;
+  }
+
+  .declarationValue {
+    font-size: 0.7rem;
+  }
+
+  .declarationSuit {
+    font-size: 1rem;
   }
 
   .playerPosition.bottom .playerInfoGroup {
-    width: 100%;
+    grid-area: profile;
+    width: auto;
     justify-content: flex-start;
-    align-items: center;
-    gap: 0.5rem;
+    align-items: flex-end;
+    gap: 0.25rem;
+    align-self: end;
   }
 
   .playerPosition.bottom .playerInfoContainer {
@@ -591,7 +779,7 @@
 
   .playerPosition.bottom .statusPanel {
     align-self: center;
-    margin-top: -0.35rem;
+    margin-top: 0;
     min-width: 84px;
     min-height: 92px;
     padding: 0.38rem 0.45rem;
@@ -622,14 +810,47 @@
   }
 
   .playerPosition.bottom .handContainer {
+    grid-area: hand;
     width: 100%;
+    min-width: 0;
     justify-content: center;
     align-items: flex-end;
-    padding: 0 0 4.35rem;
-    margin-top: -1.3rem;
+    padding: 0 0 3.6rem;
+    margin: 0;
     overflow-x: visible;
     overflow-y: visible;
-    min-height: 154px;
+    min-height: 9.6rem;
+  }
+
+  .playerPosition.bottom .handStatusPanels {
+    gap: 0.35rem;
+    margin: 0 0 0.35rem;
+  }
+
+  .playerPosition.bottom .handStatusPanels .statusPanel {
+    margin-top: 0;
+  }
+
+  .playerPosition.bottom .handStatusPanels .agariStatusPanel {
+    margin-left: 0;
+  }
+
+  .playerPosition.bottom .declarationAgariPanel {
+    min-width: 0;
+    min-height: 0;
+    margin: 0;
+    padding: 0.16rem 0.25rem;
+  }
+
+  .playerPosition.bottom .declarationAgariPanel .statusCardFrame > * {
+    transform: none;
+  }
+
+  .completedFields {
+    grid-area: fields;
+    width: 100%;
+    margin-top: 0.9rem;
+    z-index: 3;
   }
 
   .playerPosition.bottom .card {

--- a/mei-tra-frontend/components/game/PlayerHand/index.tsx
+++ b/mei-tra-frontend/components/game/PlayerHand/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
-import { Player, GamePhase, GameActions, CompletedField, Field, TrumpType } from '@/types/game.types';
+import { Player, GamePhase, GameActions, CompletedField, Field, TrumpType, BlowDeclaration } from '@/types/game.types';
 import { FontSizePreset } from '@/types/user.types';
 import { NegriCard } from '@/components/game/NegriCard';
 import { Card } from '@/components/game/Card';
@@ -11,6 +11,7 @@ import { useAuth } from '@/hooks/useAuth';
 import styles from './index.module.scss';
 import { useCardValidation } from './hooks/useCardValidation';
 import { PlayAndCancelBtn } from '@/components/game/PlayAndCancelBtn';
+import { getTrumpDisplay } from '@/lib/utils/trumpDisplay';
 
 const HAND_CARD_METRICS: Record<
   FontSizePreset,
@@ -24,7 +25,7 @@ const HAND_CARD_METRICS: Record<
   }
 > = {
   standard: {
-    width: 72,
+    width: 80,
     overlap: '-15px',
     hoverLift: 28,
     hoverOverlap: '-0.6rem',
@@ -67,7 +68,7 @@ interface PlayerHandProps {
   gameActions: GameActions;
   position: string;
   agariCard?: string;
-  currentHighestDeclaration?: { playerId: string };
+  currentHighestDeclaration?: Pick<BlowDeclaration, 'playerId'> & Partial<Pick<BlowDeclaration, 'trumpType' | 'numberOfPairs'>>;
   completedFields: CompletedField[];
   currentPlayerId: string;
   players: Player[];
@@ -108,6 +109,7 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
 }) => {
   const t = useTranslations('playerHand');
   const tStatus = useTranslations('playerStatus');
+  const tBlow = useTranslations('blowControls');
   const { fontSizePreference } = useAuth();
   const [selectedCard, setSelectedCard] = useState<string | null>(null);
   const [selectedNegriCard, setSelectedNegriCard] = useState<string | null>(null);
@@ -122,8 +124,21 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
   const isCurrentPlayer = currentPlayerId === player.playerId;
   const canActAsCurrentPlayer = isCurrentPlayer && !isSpectator;
   const isWinningPlayer = currentHighestDeclaration?.playerId === player.playerId;
+  const playerDeclaration = isWinningPlayer && currentHighestDeclaration?.trumpType
+    ? {
+      trumpType: currentHighestDeclaration.trumpType,
+      numberOfPairs: currentHighestDeclaration.numberOfPairs,
+    }
+    : null;
   const shouldSelectNegri =
     gamePhase === 'play' && canActAsCurrentPlayer && isWinningPlayer && !negriCard;
+  const hasOwnNegriCard = Boolean(
+    isCurrentPlayer && negriCard && negriPlayerId === player.playerId,
+  );
+  const showAgariPanel = Boolean(isCurrentPlayer && agariCard && isWinningPlayer);
+  const showDeclarationNegri = position === 'bottom' && hasOwnNegriCard;
+  const showDeclarationAgari = position === 'bottom' && showAgariPanel;
+  const showHandStatusPanels = position === 'bottom' && shouldSelectNegri;
   const replaceWithComStatusLabel = isDisconnected
     ? tStatus('disconnected')
     : tStatus('idle');
@@ -264,7 +279,7 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
       <div className={styles.playerAvatar}>
         <PlayerAvatar
           player={player}
-          size="medium"
+          size={isCurrentPlayer ? 'medium' : 'small'}
           showName={true}
         />
       </div>
@@ -279,10 +294,64 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
       )}
     </>
   );
+  const declarationBadge = playerDeclaration ? (
+    <div className={styles.declarationBadge}>
+      <span className={styles.declarationLabel}>{t('bid')}</span>
+      <span className={styles.declarationValue}>
+        <span
+          aria-label={tBlow(playerDeclaration.trumpType)}
+          className={styles.declarationSuit}
+          data-trump={playerDeclaration.trumpType}
+        >
+          {getTrumpDisplay(playerDeclaration.trumpType)}
+        </span>
+        <span className={styles.declarationPairs}>{playerDeclaration.numberOfPairs}</span>
+      </span>
+    </div>
+  ) : null;
+  const bottomStatusZone = position === 'bottom' && (
+    declarationBadge || showDeclarationNegri || showDeclarationAgari || showHandStatusPanels
+  ) ? (
+    <div className={styles.bottomStatusZone}>
+      {(declarationBadge || showDeclarationNegri || showDeclarationAgari) && (
+        <div className={styles.declarationContext}>
+          {showDeclarationAgari && (
+            <div className={`${styles.statusPanel} ${styles.agariStatusPanel} ${styles.declarationAgariPanel}`}>
+              <div className={styles.statusHeader}>{t('agari')}</div>
+              <div className={styles.statusCardFrame}>
+                <Card card={agariCard!} />
+              </div>
+            </div>
+          )}
+          {(declarationBadge || showDeclarationNegri) && (
+            <div className={styles.declarationRow}>
+              {declarationBadge}
+              {showDeclarationNegri && (
+                <NegriCard
+                  negriCard={negriCard!}
+                  negriPlayerId={negriPlayerId!}
+                  currentPlayerId={currentPlayerId}
+                />
+              )}
+            </div>
+          )}
+        </div>
+      )}
+      {showHandStatusPanels && (
+        <div className={styles.handStatusPanels}>
+          <div className={styles.statusPanel}>
+            <div className={styles.statusHeader}>{t('negri')}</div>
+            <div className={styles.statusMessage}>{t('selectNegri')}</div>
+          </div>
+        </div>
+      )}
+    </div>
+  ) : null;
 
   return (
     <div className={`${styles.playerPosition} ${styles[position]}`}>
       <div className={styles.playerInfo}>
+        {position === 'bottom' ? bottomStatusZone : declarationBadge}
         <div className={styles.playerInfoGroup}>
           {isSpectator ? (
             <button
@@ -299,14 +368,14 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
               {playerInfoContent}
             </div>
           )}
-          {negriCard && negriPlayerId === player.playerId && (
+          {hasOwnNegriCard && !showHandStatusPanels && !showDeclarationNegri && (
             <NegriCard
-              negriCard={negriCard}
-              negriPlayerId={negriPlayerId}
+              negriCard={negriCard!}
+              negriPlayerId={negriPlayerId!}
               currentPlayerId={currentPlayerId}
             />
           )}
-          {shouldSelectNegri && (
+          {shouldSelectNegri && !showHandStatusPanels && (
             <div className={styles.statusPanel}>
               <div className={styles.statusHeader}>{t('negri')}</div>
               <div className={styles.statusMessage}>{t('selectNegri')}</div>
@@ -328,21 +397,23 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
                 </button>
               </div>
             )}
-          {isCurrentPlayer && agariCard && isWinningPlayer && (
+          {showAgariPanel && position !== 'bottom' && (
             <div className={`${styles.statusPanel} ${styles.agariStatusPanel}`}>
               <div className={styles.statusHeader}>{t('agari')}</div>
               <div className={styles.statusCardFrame}>
-                <Card card={agariCard} />
+                <Card card={agariCard!} />
               </div>
             </div>
           )}
         </div>
         {renderPlayerHand(isCurrentPlayer)}
         {completedFields.length > 0 && (
-          <CompletedFields
-            fields={completedFields}
-            players={players}
-          />
+          <div className={styles.completedFields}>
+            <CompletedFields
+              fields={completedFields}
+              players={players}
+            />
+          </div>
         )}
       </div>
     </div>

--- a/mei-tra-frontend/components/game/StrengthOrderDock.module.scss
+++ b/mei-tra-frontend/components/game/StrengthOrderDock.module.scss
@@ -1,5 +1,6 @@
 .dock {
   position: relative;
+  z-index: 110;
 }
 
 .topbar {
@@ -31,6 +32,7 @@
 
 .panel {
   position: absolute;
+  z-index: 110;
   bottom: calc(100% + 0.5rem);
   right: 0;
   min-width: 18rem;

--- a/mei-tra-frontend/components/layout/Navigation.module.scss
+++ b/mei-tra-frontend/components/layout/Navigation.module.scss
@@ -13,6 +13,22 @@ $desktop-breakpoint: 960px;
   border-bottom: 1px solid var(--mt-border-hairline);
 }
 
+@media (max-width: 768px) {
+  .gameNavigation .content {
+    min-height: 3.75rem;
+    padding: 0.45rem 0;
+  }
+
+  .gameNavigation .brandLogo {
+    width: 36px;
+    height: 36px;
+  }
+
+  .gameNavigation .brandName {
+    font-size: 1.1rem;
+  }
+}
+
 .container {
   max-width: 80rem;
   margin: 0 auto;

--- a/mei-tra-frontend/components/layout/Navigation.tsx
+++ b/mei-tra-frontend/components/layout/Navigation.tsx
@@ -173,7 +173,7 @@ export function Navigation({ gameStarted = false, inRoom = false }: NavigationPr
   const activeLanguageLabel = languageOptions.find((option) => option.value === currentLocale)?.label ?? currentLocale;
 
   return (
-    <nav className={styles.navigation}>
+    <nav className={`${styles.navigation} ${gameStarted ? styles.gameNavigation : ''}`}>
       <div className={styles.container}>
         <div className={styles.content}>
           <div className={styles.brand}>

--- a/mei-tra-frontend/messages/en.json
+++ b/mei-tra-frontend/messages/en.json
@@ -14,6 +14,10 @@
     "example": "Example:",
     "menu": "Menu"
   },
+  "gameInfo": {
+    "reach": "Reach",
+    "win": "WIN"
+  },
   "nav": {
     "rooms": "Rooms",
     "tutorial": "Docs",
@@ -481,6 +485,7 @@
   },
   "playerHand": {
     "cards": "cards",
+    "bid": "Bid:",
     "selectNegri": "Please select your Negri",
     "selectNegriWithAgari": "This card is Agari. Select your Negri.",
     "agari": "Agari",

--- a/mei-tra-frontend/messages/ja.json
+++ b/mei-tra-frontend/messages/ja.json
@@ -14,6 +14,10 @@
     "example": "例:",
     "menu": "メニュー"
   },
+  "gameInfo": {
+    "reach": "リーチ",
+    "win": "WIN"
+  },
   "nav": {
     "rooms": "ルーム一覧",
     "tutorial": "ドキュメント",
@@ -329,7 +333,7 @@
   },
   "blowControls": {
     "currentTurn": "現在のターン:",
-    "selectTrump": "トランプを選択",
+    "selectTrump": "キリを選択",
     "selectPairs": "ペア数を選択",
     "declare": "宣言",
     "pass": "パス",
@@ -481,6 +485,7 @@
   },
   "playerHand": {
     "cards": "枚",
+    "bid": "アゲ:",
     "selectNegri": "ネグリを選択してください",
     "selectNegriWithAgari": "このカードがアガリです。ネグリを選択してください",
     "agari": "アガリ",

--- a/mei-tra-frontend/public/cards/card_back.svg
+++ b/mei-tra-frontend/public/cards/card_back.svg
@@ -1,39 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 210 315" width="210" height="315">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#1a3a7a"/>
-      <stop offset="1" stop-color="#0f2355"/>
+    <linearGradient id="felt" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1b4a3a"/>
+      <stop offset="1" stop-color="#0e2a21"/>
     </linearGradient>
-    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#fff" stop-opacity="0.08"/>
-      <stop offset="0.5" stop-color="#fff" stop-opacity="0"/>
-      <stop offset="1" stop-color="#fff" stop-opacity="0.04"/>
-    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0" stop-color="#4f7b61" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#173d30" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="weave" width="12" height="12" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <path d="M0 2h12M0 8h12" stroke="#f4f0e3" stroke-opacity="0.05" stroke-width="1"/>
+    </pattern>
   </defs>
-  <!-- Card base -->
-  <rect width="210" height="315" rx="12" ry="12" fill="url(#bg)"/>
-  <!-- Inner border -->
-  <rect x="10" y="10" width="190" height="295" rx="8" ry="8" fill="none" stroke="#3a6bc7" stroke-width="1.5" stroke-opacity="0.4"/>
-  <!-- Inner frame -->
-  <rect x="18" y="18" width="174" height="279" rx="6" ry="6" fill="none" stroke="#3a6bc7" stroke-width="0.75" stroke-opacity="0.25"/>
-  <!-- Center diamond -->
-  <g transform="translate(105, 157.5)" fill="none" stroke="#4a7fd4" stroke-width="1.2" stroke-opacity="0.35">
-    <rect x="-40" y="-60" width="80" height="120" rx="4" ry="4" transform="rotate(0)"/>
-    <rect x="-28" y="-42" width="56" height="84" rx="3" ry="3"/>
+  <rect width="210" height="315" rx="12" fill="url(#felt)"/>
+  <rect width="210" height="315" rx="12" fill="url(#glow)"/>
+  <rect width="210" height="315" rx="12" fill="url(#weave)"/>
+  <rect x="6" y="6" width="198" height="303" rx="9" fill="none" stroke="#e0c784" stroke-width="2"/>
+  <rect x="13" y="13" width="184" height="289" rx="6" fill="none" stroke="#f4f0e3" stroke-opacity="0.62" stroke-width="1"/>
+  <g fill="#e0c784" fill-opacity="0.82">
+    <circle cx="24" cy="24" r="2.5"/>
+    <circle cx="186" cy="24" r="2.5"/>
+    <circle cx="24" cy="291" r="2.5"/>
+    <circle cx="186" cy="291" r="2.5"/>
   </g>
-  <!-- Corner accents -->
-  <g fill="#4a7fd4" fill-opacity="0.3">
-    <circle cx="35" cy="35" r="4"/>
-    <circle cx="175" cy="35" r="4"/>
-    <circle cx="35" cy="280" r="4"/>
-    <circle cx="175" cy="280" r="4"/>
+  <g transform="translate(105 157.5)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="-30" y="-30" width="60" height="60" rx="7" stroke="#e0c784" stroke-width="1.5" transform="rotate(45)"/>
+    <circle r="25" stroke="#f4f0e3" stroke-opacity="0.82" stroke-width="1"/>
+    <path d="M0-20c9 7 14 15 14 24S9 21 0 27C-9 21-14 13-14 4S-9-13 0-20Z" stroke="#e0c784" stroke-width="2"/>
+    <path d="M0-20c9 7 14 15 14 24S9 21 0 27C-9 21-14 13-14 4S-9-13 0-20Z" stroke="#e0c784" stroke-width="2" transform="rotate(180)"/>
+    <circle r="3" fill="#f4f0e3"/>
   </g>
-  <!-- Subtle center emblem -->
-  <g transform="translate(105, 157.5)" fill="#4a7fd4" fill-opacity="0.2">
-    <polygon points="0,-20 12,10 -12,10"/>
-    <polygon points="0,20 12,-10 -12,-10"/>
-  </g>
-  <!-- Shine overlay -->
-  <rect width="210" height="315" rx="12" ry="12" fill="url(#shine)"/>
 </svg>


### PR DESCRIPTION
## Summary
- Rebuild the in-game table into a compact, one-screen layout for mobile and desktop.
- Keep player status, profile, hand, completed fields, score meters, and game tools readable without overlapping state-specific offsets.
- Refresh the mobile game menu, strength-order stacking, card backs, and player declaration display.

## Details
- Add score progress meters with reach and win emphasis, plus compact completed-field tiles.
- Reserve hand action space and place game statuses in a dedicated zone above the hand.
- Hide other players' Negri cards and rename the active bid label to アゲ.

## Validation
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `npm test -- --runInBand` (19 suites, 55 tests)
- `git diff --check`
