### PR TITLE
コールドスタート後の再接続を安定化

### DIFF
--- a/.agents/skills/refactor-meitra/SKILL.md
+++ b/.agents/skills/refactor-meitra/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: refactor-meitra
+description: Meitra（明専トランプ / old-maid）の既存設計に沿って、安全にコードをリファクタリング・設計レビューする。frontend、NestJS backend、Socket.IO、Supabase、COM自動進行、再接続、room/player同期、ゲーム状態、互換migration、アクセシビリティUIを変更するときに使う。ゲームルール、座席とプレイヤーidentity、scale-to-zero復帰、原子的永続化、transport契約、段階移行を壊さず、責務を適切な層へ移すためのSkill。
+---
+
+# Refactor Meitra
+
+## 基本方針
+
+Meitraでは全体を重いClean Architectureへ寄せず、壊れたときの影響が大きい境界だけを厚く守る。
+
+- ゲームルール、phase遷移、再接続、COM置換、room/player同期、永続化を強く分離する。
+- 通常の画面、route、controller、DI wiringはNext.js / NestJS標準へ近づける。
+- ファイルを短くすることではなく、正しさのsource of truthを一つにする。
+- 抽象化は実在する重複、競合、復元失敗、変更理由に対してのみ追加する。
+
+詳細な現行構成、不変条件、検証表が必要なら `references/meitra-architecture.md` を読む。
+
+## 1. 現状を固定する
+
+1. repo rootの `AGENTS.md`、`README.md`、対象コードを先に読む。
+2. 対象に合う `docs/developer-guide/` の章だけを読む。
+3. `git status --short --branch` と対象diffを確認し、既存変更を保護する。
+4. docsとコードが違う場合はコードを正とし、必要なdocsだけを更新する。
+5. 入出力、state遷移、emit、DB更新、timerを端から端まで追う。
+
+古いarchiveや推測だけで責務を移動しない。
+
+## 2. 不変条件を書く
+
+変更前に、今回守る条件をtest名へ落とせる粒度で列挙する。
+
+- 4人2チーム、座席順、turn順、team所属を保つ。
+- 人間、COM、空席の置換で同じseat identityを保つ。
+- `playerId`、`userId`、`socketId`を混同しない。
+- blow、play、field completion、round endを一度だけ進める。
+- process再起動後にDBから必要状態を復元する。
+- 同じplayer情報を複数箇所へ非原子的に書かない。
+- 旧data / event / migrationへの互換性を明示する。
+- 文字倍率、狭い画面、modal、カード配置を壊さない。
+
+## 3. 責務を配置する
+
+| 置き場所 | 持たせる責務 | 持たせない責務 |
+| --- | --- | --- |
+| Gateway / Controller | auth、parse、room参加、UseCase呼び出し、event dispatch | ゲーム判定、復旧loop、DB merge |
+| UseCase | 1操作の検証、service協調、結果event | transport詳細、汎用CRUD |
+| Domain service | card、blow、play、score、chombo、phase | Socket emit、Supabase query |
+| Application / session service | reconnect、COM、timer、room lifecycle、復旧 | UI表示加工 |
+| Gateway effects | 送信先とevent列の組み立て | ruleの再計算 |
+| Repository / adapter | query、RPC、JSONB変換、dual-read/write | gameplay workflow |
+| `contracts/` | REST DTO、Socket payload | UI state、DB row、domain object |
+| frontend hook / context | socket lifecycle、UI state投影、action送信 | server権威のrule判定 |
+| React component | 表示、入力、アクセシビリティ | 再接続や永続化の調整 |
+
+同じdataを使うかではなく、どの変更理由で一緒に変わるかで分ける。
+
+## 4. 薄い境界へ直す
+
+1. Gatewayやcomponentのworkflowを既存UseCase / serviceへ委譲する。
+2. 共有ruleはゲーム用語で読めるpure helperまたはdomain serviceへ一つだけ置く。
+3. I/O、timer、state mutationを便利helperへ隠さない。
+4. 既存interface tokenとDI wiringを維持し、必要な境界だけ追加する。
+5. transport / domain / persistence / UI間の変換をadapterへ集める。
+6. callbackを使う場合もtransport固有処理だけをGateway側に残す。
+
+Gatewayを薄くするとは行数を減らすことではない。接続と送信を残し、retry、phase復旧、COM連続処理、永続化整合性をapplication serviceへ移す。
+
+## 5. 永続化と再接続を守る
+
+- process memoryと`socketId`を唯一のsource of truthにしない。
+- identity / seat / team / ready / hostはroster、handやpass状態はgame snapshotに置く。
+- `playerOrder`を安定した座席順、`playerStates`を`playerId`単位のgameplay stateとして扱う。
+- relationとJSONBを跨ぐ更新はRPC / transactionで原子的に行う。
+- versionで古いsnapshotの上書きを拒否し、同一roomの保存を直列化する。
+- persistence failureを成功扱いせず、空stateをcacheしない。
+- reconnectはDBから再構成できることを基準にする。
+- COM turn、完了field、pending revealなどの中断処理を再入可能かつ冪等にする。
+- timerは進行のsource of truthではなく、persisted pending stateを再開するためのhintにする。
+
+互換移行は次の3段階に分ける。
+
+1. 新schema / JSON / dual-readを追加する。
+2. atomic RPCと新write pathへ切り替える。
+3. 本番観測とrollback期間後に旧field / column / fallbackを削除する。
+
+## 6. frontendを守る
+
+- backend eventをcomponentへ散らさず、hook / contextでUI stateへ投影する。
+- `room-sync`を主系統とし、互換eventを増やす前に既存fallbackを確認する。
+- `sessionStorage.roomId`などのreconnect inputをUI convenienceとして削除しない。
+- 文字倍率ではcard、meter、control、modal、viewportも一緒に検証する。
+- 固定heightで情報を切らず、wrap、overflow、可変gridを使う。
+- modal / navigation / chatで局所的な`z-index`競争を作らない。
+- disabled操作はclick、keyboard、route遷移を実際に止める。
+
+スクリーンショット起点の変更は該当倍率とviewportで視覚確認する。
+
+## 7. 隣接scenarioを監査する
+
+- join / leave / reconnect / auth更新
+- COM placeholder / 人間置換 / 切断後COM化
+- 満室復帰 / vacant seat / team shuffle
+- blow / pass / broken reveal / COM autoplay
+- card play / field completion / round / game over
+- cold start / scale-to-zero / timer消失後の再開
+- spectator / chat / profileなど重なるUI
+
+`0`が有効値のIDやteamではtruthy fallbackを使わない。
+
+## 8. 検証と報告
+
+1. 対象service / UseCase / adapterのunit test
+2. reconnect、COM、phase、競合の回帰test
+3. backend test、build、lint
+4. frontend test、lint、build
+5. Supabase RPC、rollback、concurrency、backfill test
+6. 複数session、倍率別UI、可能なら実際のcold start
+
+実行していないproduction、Fly scale-to-zero、実端末確認を完了扱いにしない。最後に、移した責務、守った不変条件、通った検証、未検証項目、残るcompatibility debtを分けて報告する。

--- a/.agents/skills/refactor-meitra/agents/openai.yaml
+++ b/.agents/skills/refactor-meitra/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Refactor Meitra"
+  short_description: "Refactor Meitra without breaking realtime game invariants"
+  default_prompt: "Use $refactor-meitra to refactor this Meitra code while preserving game rules, reconnect behavior, and migration safety."

--- a/.agents/skills/refactor-meitra/references/meitra-architecture.md
+++ b/.agents/skills/refactor-meitra/references/meitra-architecture.md
@@ -1,0 +1,189 @@
+# Meitra Architecture Reference
+
+現行コードは変化するため、必ずrepoの `README.md`、対象コード、該当する `docs/developer-guide/` を再確認する。
+
+## 選択的に境界を厚くする
+
+Meitraの複雑性はCRUDではなく、ゲームルールとrealtime例外の組み合わせにある。
+
+厚く守る領域:
+
+- rule evaluationとstate mutation
+- phase transition
+- reconnect / session recovery
+- human / COM / vacant seat置換
+- room/player sync契約
+- atomic persistenceとversion conflict
+- replay / audit log
+
+framework標準へ近づける領域:
+
+- NestJS module、controller、DI wiring
+- Next.js page / route composition
+- 通常のprofile、list、detail UI
+- 単純なproxy routeとtransport adapter
+
+## 現行の層
+
+### Interface adapter
+
+- `mei-tra-backend/src/game.gateway.ts`
+- `mei-tra-backend/src/social.gateway.ts`
+- `mei-tra-backend/src/controllers/`
+
+socket handshake、auth、payload parse、room join/leave、UseCase呼び出し、event dispatchを担当する。
+
+### Application / UseCase
+
+- `mei-tra-backend/src/use-cases/`
+
+1操作単位のworkflowを担当する。複数serviceを束ね、success / error / event / delayed effectを返す。
+
+### Domain
+
+- `CardService`
+- `BlowService`
+- `PlayService`
+- `ScoreService`
+- `ChomboService`
+- `GamePhaseService`
+
+ゲームルールとphaseの正しさを持つ。UI、Socket、Supabaseへ同じ判定を複製しない。
+
+### Application / session service
+
+- `RoomService`
+- `RoomJoinService`
+- `GameStateService`
+- `GameStateManager`
+- `PlayerConnectionManager`
+- `SeatRestorationService`
+- `PlayerReferenceRemapperService`
+- `ComSessionService`
+- `ComAutoPlayService`
+- `ComAutoPlayRecoveryService`
+- `TurnMonitorService`
+
+room lifecycle、reconnect、置換、timer、復旧、永続化調整を担当する。
+
+### Infrastructure
+
+- `mei-tra-backend/src/repositories/`
+- `mei-tra-backend/src/database/`
+- `mei-tra-backend/supabase/migrations/`
+
+query、RPC、row / JSONB mapping、互換read/writeを担当する。
+
+### Frontend
+
+- `mei-tra-frontend/app/`: routeとpage composition
+- `mei-tra-frontend/hooks/`: game / room / socket state coordinator
+- `mei-tra-frontend/contexts/`: auth、social socket、cross-page state
+- `mei-tra-frontend/components/`: feature単位の表示とinteraction
+- `mei-tra-frontend/types/`: UI state / view model
+- `contracts/`: frontend/backend共通のwire contract
+
+## Identityとsource of truth
+
+| 概念 | 主なsource of truth | 注意点 |
+| --- | --- | --- |
+| Auth account | Supabase Auth | `userId`は認証identity |
+| Profile | `user_profiles` | 表示名、avatar、preferences、stats |
+| Room | `rooms` | metadata、host参照、lifecycle |
+| Seat / roster | `room_players` | `playerId`、seat、team、ready、host、COM |
+| Gameplay state | `game_states` | deck、phase、turn、scores、`playerStates`、`playerOrder` |
+| Connection | process memory | `socketId`、接続中フラグ、timerは再生成可能にする |
+| Audit / replay | `game_history` | snapshotの代替ではなくaction log |
+| Transport shape | `contracts/` | DB rowやdomain typeを置かない |
+
+- `playerId`: room / game内でseatを指す安定identity。
+- `userId`: Supabase Auth account。guestやCOMには存在しない場合がある。
+- `socketId`: 接続ごとに変わる一時identity。永続化やseat復旧のkeyにしない。
+- `playerOrder`: seat / turn順を保持する。
+- `playerStates[playerId]`: hand、pass、broken flagsなどgameplay stateを保持する。
+
+## 必須の不変条件
+
+### Roster
+
+- player数は最大4人で、seatと`playerId`が重複しない。
+- COM placeholder IDが衝突しない。
+- team値`0`をfalse扱いしない。
+- partnerが対面になるseat orderを保つ。
+- `rooms.host_id`とplayerのhost flagを一致させる。
+
+### Replacement / reconnection
+
+- 人間とCOMの置換でhand、turn、team、宣言参照を失わない。
+- player ID変更時はturn、field、blow、winner、idle、timer参照を一括remapする。
+- backend再起動後、DB snapshotとrosterからroomを再構成する。
+- socket room membershipとtimerをreconnect時に再登録する。
+
+### Phase
+
+- phase transitionを複数経路から二重実行しない。
+- blowの行動済み判定を共通helperで統一する。
+- 4枚揃ったfield completionを冪等に再開する。
+- delayed eventやtimer消失後もCOM turnを再triggerする。
+- retryをroom単位で多重実行せず、backoff上限と取消手段を持つ。
+
+### Persistence
+
+- relationとJSONBのroster変更を同一transactionで保存する。
+- version compare-and-swapで古いsnapshotを拒否する。
+- room単位のwriteを直列化する。
+- RPC途中失敗時に全更新をrollbackする。
+- DB failureを成功responseや空stateへ変換しない。
+
+## Migration playbook
+
+### PR A: 読めるようにする
+
+- 新column / JSON shapeとdual-readを追加する。
+- old snapshotからnew shapeへ復元できるtestを追加する。
+- backfillの件数と不変条件を検証する。
+
+### PR B: 新経路へ書く
+
+- atomic RPCとversion checkを追加する。
+- repository writeを新経路へ切り替える。
+- migration未適用環境だけ旧pathへfallbackする。
+- concurrency、rollback、roster置換を検証する。
+
+### PR C: 旧経路を消す
+
+- productionで新read/writeとerror rateを観測する。
+- rollback期間と古いdeployがないことを確認する。
+- legacy field、column、dual-read/writeを削除する。
+
+PR Cを日付だけで開始せず、観測証拠とrollback条件で開始する。
+
+## Refactoring smells
+
+| smell | 優先する対応 |
+| --- | --- |
+| Gatewayにretry map / timer / loopが増える | application/session serviceへ抽出する |
+| UseCaseごとにrule判定が違う | ゲーム用語のpure helperへ統合する |
+| rosterとJSON playerを別々に更新する | atomic roster RPCへ統合する |
+| `socketId`でDB playerを復元する | stable identityを使う |
+| Repositoryがgame phaseを判断する | domain / UseCaseへ移す |
+| Componentがruleを再計算する | hookとserver authorityを使う |
+| `team || 0`のfallback | `team ?? 0`またはvalidationを使う |
+| catchして空stateを返す | recoverableとfatal errorを分ける |
+| 全画面倍率でoverflowする | semantic scaleとlayout制約を分ける |
+| 巨大な`z-index`を足す | 共通layer tokenを設計する |
+
+## Validation matrix
+
+| 変更領域 | 最低限の検証 |
+| --- | --- |
+| Game rule | 対象unit、phase前後、invalid action、COM経路 |
+| Player identity | human↔COM、vacant seat、満室復帰、team shuffle |
+| Reconnect | waiting、blow、play、field completion、game over |
+| Persistence | create/load、partial update、version conflict、rollback、旧JSON復元 |
+| Gateway | auth、room membership、event recipient、duplicate trigger |
+| Frontend socket | reconnect、主eventと互換event、listener cleanup |
+| Accessibility UI | 1.0x / 1.5x / 2.0x、mobile / desktop、keyboard、modal、card overlap |
+| Scale-to-zero | cold start、room reload、COM turn、失われたtimer再構築 |
+
+未検証のproduction behaviorは未検証と報告する。

--- a/contracts/game.ts
+++ b/contracts/game.ts
@@ -89,6 +89,15 @@ export interface GameStatePayload {
   pointsToWin: number;
 }
 
+export type ReconnectionFailureCode =
+  | 'roomUnavailable'
+  | 'sessionInvalid'
+  | 'stateInconsistent';
+
+export interface BackToLobbyPayload {
+  code: ReconnectionFailureCode;
+}
+
 export interface UpdatePhasePayload {
   phase: TransportGamePhase;
   scores: TransportTeamScores;

--- a/docs/developer-guide/05-data-auth-persistence.md
+++ b/docs/developer-guide/05-data-auth-persistence.md
@@ -197,7 +197,10 @@ Supabase Auth の canonical user は `auth.users` です。一方、このアプ
 
 ### 5.4 game room / player の source of truth
 
-- persistence: `rooms`, `room_players`
+- room metadata: `rooms`
+- player identity / seat / team / ready / host: `room_players`
+- player gameplay state: `game_states.state_data.playerStates`
+- socket 接続情報: `GameStateService` 内の memory state
 - runtime: room ごとの `GameStateService`
 - frontend 表示: `types/room.types.ts`, `types/game.types.ts`
 
@@ -275,7 +278,7 @@ profile は現在も進化中の schema です。
 
 ### 7.1 room と room players
 
-room metadata は `rooms`、参加者は `room_players` にあります。`SupabaseRoomRepository` は対象 room 群の player rows をまとめて取得し、memory 上で group 化して `Room` を構築します。
+room metadata は `rooms`、参加者の identity と座席情報は `room_players` にあります。`SupabaseRoomRepository` は対象 room 群の player rows をまとめて取得し、memory 上で group 化して `Room` を構築します。ロスター変更は `persist_room_roster_atomic()` が `room_players`、`rooms.host_id`、`game_states` を一つの transaction で更新します。
 
 この説明が指す主なコードは次です。
 
@@ -286,7 +289,7 @@ room metadata は `rooms`、参加者は `room_players` にあります。`Supab
 - repository 境界:
   - `mei-tra-backend/src/repositories/interfaces/room.repository.interface.ts`
   - `mei-tra-backend/src/repositories/implementations/supabase-room.repository.ts`
-  - `create()`, `findById()`, `addPlayer()`, `removePlayer()`, `updatePlayer()`, `findRecentFinishedByUserId()`
+  - `create()`, `findById()`, `findRecentFinishedByUserId()`
 - application / session 境界:
   - `mei-tra-backend/src/services/room.service.ts`
   - `mei-tra-backend/src/services/room-join.service.ts`
@@ -297,21 +300,24 @@ room metadata は `rooms`、参加者は `room_players` にあります。`Supab
 
 - room に player が複数いるので read path が重い
 - runtime 上の `room.players` と waiting room UI が強く結び付いている
-- `isCOM`, `isReady`, `isHost` などは player row にも保持される
+- `isCOM`, `isReady`, `isHost`, `team`, `userId`, `name` は `room_players` が正である
+- `socketId` と認証済み接続状態は再接続ごとに変わるため永続化せず、memory 上で管理する
+- application service から `room_players` を個別 CRUD せず、完成したロスターを原子的に保存する
 - finished room も一定期間残し、プロフィールの recent matches から参照する
 
 ### 7.2 game state
 
-`game_states` には players, deck, agari, blowState, playState を `state_data` JSONB に持ちつつ、current player index や team scores は別カラムでも持ちます。
+`game_states` は deck, agari, blowState, playState と player ごとの gameplay state を `state_data` JSONB に持ちつつ、current player index や team scores は別カラムでも持ちます。`playerStates` は `playerId` を key にして hand / pass / broken flags だけを保存し、`playerOrder` が座席順を保持します。identity は `room_players` から合成します。
 
 この説明が指す主なコードは次です。
 
 - DB schema:
   - `mei-tra-backend/supabase/migrations/001_initial_schema.sql` の `game_states`
+  - `mei-tra-backend/supabase/migrations/20260719124824_atomic_room_state_persistence.sql` 以降の `version` / atomic RPC
 - repository 境界:
   - `mei-tra-backend/src/repositories/interfaces/game-state.repository.interface.ts`
   - `mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts`
-  - `create()`, `findByRoomId()`, `update()`, `updatePlayers()`, `updatePlayerConnection()`, `updateGamePhase()`
+  - `create()`, `findByRoomId()`, `update()`, `persistRoomRoster()`
 - runtime state 境界:
   - `mei-tra-backend/src/services/game-state.service.ts`
   - `mei-tra-backend/src/services/game-state-manager.service.ts`
@@ -329,13 +335,15 @@ room metadata は `rooms`、参加者は `room_players` にあります。`Supab
 
 - state snapshot をまとめて保存しやすい
 - reconnect 時の復元がしやすい
+- `version` により古い snapshot からの上書きを拒否できる
+- `atomic_update_game_state()` が JSONB merge と scalar 更新を row lock 内で処理する
 
 欠点:
 
 - JSON shape と TypeScript 型がずれると runtime bug になる
-- 部分更新時に merge ロジックが必要
+- relation と JSONB を跨ぐロスター更新には transaction が必要
 
-`SupabaseGameStateRepository.update()` が current `state_data` を読んで merge しているのは、この欠点を吸収するためです。
+新コードは `load_room_game_state()` で room player と game state を同じ snapshot から読み、`atomic_update_game_state()` と `persist_room_roster_atomic()` で更新します。migration 未適用環境向けに旧 read / write path を一時的に残し、`state_data.players` と `room_players` の旧 gameplay columns も互換データとして同期します。新形式の安定稼働確認後に、この互換データを削除します。
 
 ### 7.3 chat
 
@@ -724,8 +732,8 @@ JSONB snapshot は reconnect に強い一方で、shape drift に弱いです。
 | `auth.users` | 認証アカウント本体 | frontend auth, Supabase trigger |
 | `user_profiles` | 表示名、avatar、統計、preferences | AuthContext, AuthService, UserProfileRepository |
 | `rooms` | ルーム本体。finished room は recent matches 用に一定期間保持 | RoomRepository, RoomService |
-| `room_players` | 座席、ready、team、socket/user 対応 | RoomRepository, RoomService |
-| `game_states` | ゲーム進行 snapshot | GameStateRepository, GameStateService |
+| `room_players` | player identity、座席、ready、team、host、user 対応 | RoomRepository, RoomService, atomic roster RPC |
+| `game_states` | ゲーム進行 snapshot、player gameplay state、version | GameStateRepository, GameStateService |
 | `game_history` | action log / audit / replay 補助線 | `SupabaseGameHistoryRepository`, `GameEventLogService`, `GameHistoryController`, `GetUserRecentGameHistoryUseCase` |
 | `chat_rooms` | chat room metadata | ChatRoomRepository, ChatService |
 | `chat_members` | chat membership | migration / policy 前提 |

--- a/mei-tra-backend/.gitignore
+++ b/mei-tra-backend/.gitignore
@@ -62,3 +62,4 @@ backups/
 # Tracked schema sources
 !database/schema.sql
 !supabase/migrations/*.sql
+!supabase/tests/*.sql

--- a/mei-tra-backend/src/__tests__/game.gateway.com-recovery.spec.ts
+++ b/mei-tra-backend/src/__tests__/game.gateway.com-recovery.spec.ts
@@ -1,0 +1,75 @@
+import { Socket } from 'socket.io';
+import { GameGateway } from '../game.gateway';
+
+const createGateway = (): GameGateway => {
+  const GatewayConstructor = GameGateway as unknown as new (
+    ...dependencies: object[]
+  ) => GameGateway;
+  return new GatewayConstructor(...Array.from({ length: 31 }, () => ({})));
+};
+
+interface ActiveReconnectGatewayHarness {
+  activityTracker: { incrementConnections: jest.Mock };
+  authService: { getUserFromSocketToken: jest.Mock };
+  reconnectionUseCase: { execute: jest.Mock };
+  joinRoomGatewayEffectsService: {
+    buildActiveReconnectEvents: jest.Mock;
+  };
+  comAutoPlayRecoveryService: { trigger: jest.Mock };
+  dispatchEvents: jest.Mock;
+  startTurnAckMonitor: jest.Mock;
+}
+
+describe('GameGateway COM recovery integration', () => {
+  it('delegates COM recovery after an active-game reconnection', async () => {
+    const gateway = createGateway();
+    const testGateway = gateway as unknown as ActiveReconnectGatewayHarness;
+    const startTurnAckMonitor = jest.fn().mockResolvedValue(undefined);
+    const triggerRecovery = jest.fn();
+    const authenticatedUser = {
+      id: 'user-1',
+      email: 'user@example.com',
+      profile: { displayName: 'User 1' },
+    };
+
+    testGateway.activityTracker = {
+      incrementConnections: jest.fn(),
+    };
+    testGateway.authService = {
+      getUserFromSocketToken: jest.fn().mockResolvedValue(authenticatedUser),
+    };
+    testGateway.reconnectionUseCase = {
+      execute: jest.fn().mockResolvedValue({
+        success: true,
+        mode: 'active-game',
+        roomId: 'room-1',
+        roomsList: [],
+        room: { id: 'room-1', players: [] },
+        selfPlayerId: 'user-1',
+        reconnectToken: 'user-1',
+        currentTurnPlayerId: 'com-1',
+        gameState: { players: [], gamePhase: 'play' },
+      }),
+    };
+    testGateway.joinRoomGatewayEffectsService = {
+      buildActiveReconnectEvents: jest.fn().mockResolvedValue([]),
+    };
+    testGateway.comAutoPlayRecoveryService = { trigger: triggerRecovery };
+    testGateway.dispatchEvents = jest.fn();
+    testGateway.startTurnAckMonitor = startTurnAckMonitor;
+
+    const client = {
+      id: 'socket-1',
+      handshake: { auth: { token: 'token', roomId: 'room-1' } },
+      data: {},
+      join: jest.fn().mockResolvedValue(undefined),
+      emit: jest.fn(),
+      disconnect: jest.fn(),
+    } as unknown as Socket;
+
+    await gateway.handleConnection(client);
+
+    expect(startTurnAckMonitor).toHaveBeenCalledWith('room-1', 'com-1');
+    expect(triggerRecovery).toHaveBeenCalledWith('room-1', expect.anything());
+  });
+});

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -31,14 +31,16 @@ import { GatewayEvent } from './use-cases/interfaces/gateway-event.interface';
 import { IDeclareBlowUseCase } from './use-cases/interfaces/declare-blow.use-case.interface';
 import { IPassBlowUseCase } from './use-cases/interfaces/pass-blow.use-case.interface';
 import { ISelectNegriUseCase } from './use-cases/interfaces/select-negri.use-case.interface';
-import { IPlayCardUseCase } from './use-cases/interfaces/play-card.use-case.interface';
+import {
+  CompleteFieldTrigger,
+  IPlayCardUseCase,
+} from './use-cases/interfaces/play-card.use-case.interface';
 import { ISelectBaseSuitUseCase } from './use-cases/interfaces/select-base-suit.use-case.interface';
 import { IRevealBrokenHandUseCase } from './use-cases/interfaces/reveal-broken-hand.use-case.interface';
-import { ICompleteFieldUseCase } from './use-cases/interfaces/complete-field.use-case.interface';
+import { CompleteFieldResponse } from './use-cases/interfaces/complete-field.use-case.interface';
 import { IProcessGameOverUseCase } from './use-cases/interfaces/process-game-over.use-case.interface';
 import { IUpdateAuthUseCase } from './use-cases/interfaces/update-auth.use-case.interface';
 import { IWatchRoomUseCase } from './use-cases/interfaces/watch-room.use-case.interface';
-import { IComAutoPlayUseCase } from './use-cases/interfaces/com-autoplay-use-case.interface';
 import { IActivityTrackerService } from './services/interfaces/activity-tracker-service.interface';
 import { createSocketCorsOriginHandler } from './config/frontend-origins';
 import { SessionUser } from './types/session.types';
@@ -53,6 +55,10 @@ import { ModeratePlayerUseCase } from './use-cases/moderate-player.use-case';
 import { ShuffleTeamsUseCase } from './use-cases/shuffle-teams.use-case';
 import { Room } from './types/room.types';
 import { toRoomContract, toRoomContracts } from './types/room-adapters';
+import {
+  ComAutoPlayRecoveryHandlers,
+  ComAutoPlayRecoveryService,
+} from './services/com-autoplay-recovery.service';
 
 const DISCONNECT_TO_COM_TIMEOUT_MS = 2 * 60 * 1000;
 
@@ -70,6 +76,11 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer() server: Server;
   private readonly logger = new Logger(GameGateway.name);
   private playerRooms: Map<string, string> = new Map(); // socketId -> roomId
+  private readonly comAutoPlayRecoveryHandlers: ComAutoPlayRecoveryHandlers = {
+    dispatchEvents: (events) => this.dispatchEvents(events),
+    processFieldCompletion: (roomId, response) =>
+      this.processFieldCompletionResult(roomId, response),
+  };
 
   constructor(
     @Inject('IGameStateService')
@@ -96,8 +107,6 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     private readonly selectBaseSuitUseCase: ISelectBaseSuitUseCase,
     @Inject('IRevealBrokenHandUseCase')
     private readonly revealBrokenHandUseCase: IRevealBrokenHandUseCase,
-    @Inject('ICompleteFieldUseCase')
-    private readonly completeFieldUseCase: ICompleteFieldUseCase,
     @Inject('IProcessGameOverUseCase')
     private readonly processGameOverUseCase: IProcessGameOverUseCase,
     @Inject('IUpdateAuthUseCase')
@@ -109,13 +118,12 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     @Inject('IFillWithComUseCase')
     private readonly fillWithComUseCase: IFillWithComUseCase,
     private readonly authService: AuthService,
-    @Inject('IComAutoPlayUseCase')
-    private readonly comAutoPlayUseCase: IComAutoPlayUseCase,
     @Inject('IWatchRoomUseCase')
     private readonly watchRoomUseCase: IWatchRoomUseCase,
     @Inject('IActivityTrackerService')
     private readonly activityTracker: IActivityTrackerService,
     private readonly turnMonitorService: TurnMonitorService,
+    private readonly comAutoPlayRecoveryService: ComAutoPlayRecoveryService,
     private readonly reconnectionUseCase: ReconnectionUseCase,
     private readonly moderatePlayerUseCase: ModeratePlayerUseCase,
     private readonly shuffleTeamsUseCase: ShuffleTeamsUseCase,
@@ -337,7 +345,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   private async processFieldCompletionResult(
     roomId: string,
-    response: Awaited<ReturnType<ICompleteFieldUseCase['execute']>>,
+    response: CompleteFieldResponse,
   ) {
     if (!response.success) {
       this.server
@@ -348,14 +356,6 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     this.dispatchEvents(response.events);
     this.dispatchEvents(response.delayedEvents);
-
-    const delayedEvents = response.delayedEvents ?? [];
-    const maxDelay = delayedEvents.reduce(
-      (max, event) => Math.max(max, event.delayMs ?? 0),
-      0,
-    );
-
-    const scheduleAutoPlay = () => this.triggerComAutoPlayIfNeeded(roomId);
 
     if (response.gameOver) {
       await this.processGameOverUseCase.execute({
@@ -368,16 +368,13 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       setTimeout(() => {
         void this.closeFinishedRoom(roomId);
       }, closeDelay);
-    } else if (maxDelay > 0) {
-      setTimeout(scheduleAutoPlay, maxDelay + 100);
-    } else {
-      scheduleAutoPlay();
     }
   }
 
   private async closeFinishedRoom(roomId: string): Promise<void> {
     try {
       this.clearTurnAckMonitor(roomId);
+      this.comAutoPlayRecoveryService.clearRoom(roomId);
 
       const socketIds = Array.from(
         this.server.sockets.adapter.rooms.get(roomId) ?? [],
@@ -426,71 +423,16 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   private triggerComAutoPlayIfNeeded(roomId: string): void {
-    // Non-blocking: fire and forget
-    void this.runComAutoPlayLoop(roomId);
+    this.comAutoPlayRecoveryService.trigger(
+      roomId,
+      this.comAutoPlayRecoveryHandlers,
+    );
   }
 
-  private async runComAutoPlayLoop(roomId: string): Promise<void> {
-    let iteration = 0;
-    const MAX_ITERATIONS = 10; // Safety limit: max 10 consecutive COM plays
-
-    while (iteration < MAX_ITERATIONS) {
-      const result = await this.comAutoPlayUseCase.execute({ roomId });
-
-      if (!result.success) {
-        console.error(`COM auto-play failed: ${result.error}`);
-        return;
-      }
-
-      // イベント配信（遅延含む）
-      this.dispatchEvents(result.events);
-      this.dispatchEvents(result.delayedEvents);
-
-      const delayedEvents = result.delayedEvents ?? [];
-      const maxDelay = delayedEvents.reduce(
-        (max, event) => Math.max(max, event.delayMs ?? 0),
-        0,
-      );
-
-      if (result.completeFieldTrigger) {
-        const trigger = result.completeFieldTrigger;
-        setTimeout(() => {
-          void this.completeFieldUseCase
-            .execute({ roomId: trigger.roomId, field: trigger.field })
-            .then((response) =>
-              this.processFieldCompletionResult(trigger.roomId, response),
-            )
-            .catch((error) => {
-              console.error('Error completing field:', error);
-              this.server
-                .to(trigger.roomId)
-                .emit('error-message', 'Failed to complete field');
-            });
-        }, trigger.delayMs);
-        return; // Wait for completion result before continuing loop
-      }
-
-      if (maxDelay > 0) {
-        setTimeout(
-          () => this.triggerComAutoPlayIfNeeded(roomId),
-          maxDelay + 100,
-        );
-        return;
-      }
-
-      if (!result.shouldContinue) {
-        return; // Stop the loop - no more COM players
-      }
-
-      iteration++;
-
-      // Non-blocking wait - yields to event loop
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-    }
-
-    // Safety: log if we hit the iteration limit
-    console.error(
-      `[GameGateway] COM auto-play loop exceeded ${MAX_ITERATIONS} iterations for room ${roomId}. Possible infinite loop prevented.`,
+  private scheduleFieldCompletion(trigger: CompleteFieldTrigger): void {
+    this.comAutoPlayRecoveryService.scheduleFieldCompletion(
+      trigger,
+      this.comAutoPlayRecoveryHandlers,
     );
   }
 
@@ -580,6 +522,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       if (result.currentTurnPlayerId) {
         void this.startTurnAckMonitor(roomId, result.currentTurnPlayerId);
       }
+      this.triggerComAutoPlayIfNeeded(roomId);
       return;
     }
 
@@ -1470,23 +1413,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       this.dispatchEvents(result.events);
 
       if (result.completeFieldTrigger) {
-        const trigger = result.completeFieldTrigger;
-        setTimeout(() => {
-          void this.completeFieldUseCase
-            .execute({
-              roomId: trigger.roomId,
-              field: trigger.field,
-            })
-            .then((response) =>
-              this.processFieldCompletionResult(trigger.roomId, response),
-            )
-            .catch((error) => {
-              console.error('Error completing field:', error);
-              this.server
-                .to(trigger.roomId)
-                .emit('error-message', 'Failed to complete field');
-            });
-        }, trigger.delayMs);
+        this.scheduleFieldCompletion(result.completeFieldTrigger);
       } else {
         this.triggerComAutoPlayIfNeeded(data.roomId);
       }

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -8,7 +8,9 @@ import {
 import { Inject, Logger } from '@nestjs/common';
 import { Server, Socket } from 'socket.io';
 import type {
+  BackToLobbyPayload,
   PlayCardPayload,
+  ReconnectionFailureCode,
   RequestAgariPayload,
   RevealAgariPayload,
 } from '@contracts/game';
@@ -407,6 +409,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
   private async sendBackToLobby(
     client: Socket,
     reason: string,
+    code: ReconnectionFailureCode,
     roomId?: string,
   ): Promise<void> {
     console.warn(
@@ -417,8 +420,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
     this.playerRooms.delete(client.id);
     await this.spectatorGatewayEffectsService.leaveCurrentRoom(client);
-    client.emit('back-to-lobby');
-    client.emit('error-message', reason);
+    const payload: BackToLobbyPayload = { code };
+    client.emit('back-to-lobby', payload);
     this.emitRoomsListToSocket(client, await this.roomService.listRooms());
   }
 
@@ -539,7 +542,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       });
 
       if (!result.success) {
-        await this.sendBackToLobby(client, result.reason, roomId);
+        await this.sendBackToLobby(client, result.reason, result.code, roomId);
         return;
       }
 

--- a/mei-tra-backend/src/game.module.ts
+++ b/mei-tra-backend/src/game.module.ts
@@ -51,6 +51,7 @@ import { GameEventLogService } from './services/game-event-log.service';
 import { GameHistoryController } from './controllers/game-history.controller';
 import { GetGameHistoryUseCase } from './use-cases/get-game-history.use-case';
 import { GetUserRecentGameHistoryUseCase } from './use-cases/get-user-recent-game-history.use-case';
+import { ComAutoPlayRecoveryService } from './services/com-autoplay-recovery.service';
 
 @Module({
   imports: [RepositoriesModule, AuthModule, SocialModule],
@@ -59,6 +60,7 @@ import { GetUserRecentGameHistoryUseCase } from './use-cases/get-user-recent-gam
     GameGateway,
     ActivityTrackerService,
     TurnMonitorService,
+    ComAutoPlayRecoveryService,
     PlayerReferenceRemapperService,
     UserGameStatsService,
     ComSessionService,

--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
@@ -1,0 +1,255 @@
+import { SupabaseService } from '../../database/supabase.service';
+import { GameState } from '../../types/game.types';
+import { RoomPlayer } from '../../types/room.types';
+import { SupabaseGameStateRepository } from './supabase-game-state.repository';
+
+describe('SupabaseGameStateRepository', () => {
+  const gameStateRow = {
+    id: 'game-state-1',
+    room_id: '00000000-0000-0000-0000-000000000001',
+    state_data: {
+      players: [
+        {
+          playerId: 'player-1',
+          name: 'Legacy name',
+          hand: ['legacy-card'],
+          team: 0,
+          isPasser: false,
+        },
+      ],
+      playerStates: {
+        'player-1': {
+          hand: ['S1'],
+          isPasser: true,
+          hasBroken: true,
+          hasRequiredBroken: false,
+        },
+      },
+      playerOrder: ['player-1'],
+      deck: [],
+      blowState: {
+        currentTrump: null,
+        currentHighestDeclaration: null,
+        declarations: [],
+        actionHistory: [],
+        lastPasser: null,
+        isRoundCancelled: false,
+        currentBlowIndex: 0,
+      },
+      playState: {
+        currentField: null,
+        negriCard: null,
+        neguri: {},
+        fields: [],
+        lastWinnerId: null,
+        openDeclared: false,
+        openDeclarerId: null,
+      },
+    },
+    current_player_index: 0,
+    game_phase: 'waiting' as const,
+    round_number: 1,
+    points_to_win: 8,
+    team_scores: {
+      0: { play: 0, total: 0 },
+      1: { play: 0, total: 0 },
+    },
+    team_score_records: { 0: [], 1: [] },
+    team_assignments: { 'player-1': 1 },
+    version: 4,
+    created_at: '2026-07-19T00:00:00.000Z',
+    updated_at: '2026-07-19T00:00:00.000Z',
+  };
+
+  const roomPlayerRow = {
+    id: 'room-player-1',
+    room_id: gameStateRow.room_id,
+    player_id: 'player-1',
+    socket_id: null,
+    user_id: '00000000-0000-0000-0000-000000000101',
+    name: 'Current name',
+    hand: ['room-card'],
+    team: 1,
+    is_passer: false,
+    has_broken: false,
+    has_required_broken: false,
+    is_ready: true,
+    is_host: true,
+    is_com: false,
+    joined_at: '2026-07-19T00:00:00.000Z',
+  };
+
+  function createState(): GameState {
+    return {
+      version: 4,
+      players: [
+        {
+          playerId: 'player-1',
+          name: 'Current name',
+          hand: ['S1'],
+          team: 1,
+          isPasser: true,
+          isCOM: false,
+          hasBroken: true,
+          hasRequiredBroken: false,
+        },
+      ],
+      currentPlayerIndex: 0,
+      gamePhase: 'waiting',
+      deck: [],
+      teamScores: {
+        0: { play: 0, total: 0 },
+        1: { play: 0, total: 0 },
+      },
+      teamScoreRecords: { 0: [], 1: [] },
+      blowState: gameStateRow.state_data.blowState,
+      playState: gameStateRow.state_data.playState,
+      roundNumber: 1,
+      pointsToWin: 8,
+      teamAssignments: { 'player-1': 1 },
+    };
+  }
+
+  function createRoomPlayer(): RoomPlayer {
+    return {
+      socketId: 'transient-socket',
+      playerId: 'player-1',
+      userId: roomPlayerRow.user_id,
+      isAuthenticated: true,
+      name: 'Current name',
+      hand: ['S1'],
+      team: 1,
+      isPasser: true,
+      isCOM: false,
+      hasBroken: true,
+      hasRequiredBroken: false,
+      isReady: true,
+      isHost: true,
+      joinedAt: new Date(roomPlayerRow.joined_at),
+    };
+  }
+
+  it('loads identity from room_players and gameplay from playerStates', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: {
+        gameState: gameStateRow,
+        roomPlayers: [roomPlayerRow],
+      },
+      error: null,
+    });
+    const repository = new SupabaseGameStateRepository({
+      client: { rpc },
+    } as unknown as SupabaseService);
+
+    const state = await repository.findByRoomId(gameStateRow.room_id);
+
+    expect(state?.version).toBe(4);
+    expect(state?.players).toEqual([
+      expect.objectContaining({
+        playerId: 'player-1',
+        name: 'Current name',
+        team: 1,
+        hand: ['S1'],
+        isPasser: true,
+        hasBroken: true,
+      }),
+    ]);
+  });
+
+  it('does not revive legacy players missing from the authoritative roster', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: {
+        gameState: gameStateRow,
+        roomPlayers: [],
+      },
+      error: null,
+    });
+    const repository = new SupabaseGameStateRepository({
+      client: { rpc },
+    } as unknown as SupabaseService);
+
+    const state = await repository.findByRoomId(gameStateRow.room_id);
+
+    expect(state?.players).toEqual([]);
+  });
+
+  it('passes the expected version to atomic state updates', async () => {
+    const order = jest.fn().mockResolvedValue({
+      data: [roomPlayerRow],
+      error: null,
+    });
+    const eq = jest.fn().mockReturnValue({ order });
+    const select = jest.fn().mockReturnValue({ eq });
+    const rpc = jest.fn().mockResolvedValue({
+      data: { ...gameStateRow, version: 5 },
+      error: null,
+    });
+    const repository = new SupabaseGameStateRepository({
+      client: {
+        rpc,
+        from: jest.fn().mockReturnValue({ select }),
+      },
+    } as unknown as SupabaseService);
+
+    const state = await repository.update(
+      gameStateRow.room_id,
+      { roundNumber: 2 },
+      4,
+    );
+
+    expect(rpc).toHaveBeenCalledWith('atomic_update_game_state', {
+      p_room_id: gameStateRow.room_id,
+      p_state_patch: {},
+      p_scalar_patch: { roundNumber: 2 },
+      p_expected_version: 4,
+    });
+    expect(state?.version).toBe(5);
+  });
+
+  it('persists the complete roster without socket metadata', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: { ...gameStateRow, version: 5 },
+      error: null,
+    });
+    const repository = new SupabaseGameStateRepository({
+      client: { rpc },
+    } as unknown as SupabaseService);
+
+    const state = await repository.persistRoomRoster(
+      gameStateRow.room_id,
+      [createRoomPlayer()],
+      createState(),
+      'player-1',
+    );
+
+    expect(rpc).toHaveBeenCalledWith(
+      'persist_room_roster_atomic',
+      expect.objectContaining({
+        p_expected_version: 4,
+        p_host_id: 'player-1',
+        p_player_order: ['player-1'],
+        p_player_states: {
+          'player-1': {
+            hand: ['S1'],
+            isPasser: true,
+            hasBroken: true,
+            hasRequiredBroken: false,
+          },
+        },
+        p_room_players: [
+          {
+            playerId: 'player-1',
+            userId: roomPlayerRow.user_id,
+            name: 'Current name',
+            team: 1,
+            isReady: true,
+            isHost: true,
+            isCOM: false,
+            joinedAt: roomPlayerRow.joined_at,
+          },
+        ],
+      }),
+    );
+    expect(state?.version).toBe(5);
+  });
+});

--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts
@@ -10,13 +10,34 @@ import {
 } from '../../types/game.types';
 import {
   PersistedGamePlayer,
+  PersistedPlayerGameplayState,
+  PersistedPlayerStates,
   toPersistedGamePlayer,
+  toPersistedPlayerStates,
   toRuntimePlayer,
 } from '../../types/player-adapters';
 import { Database } from '../../types/database.types';
+import { RoomPlayer } from '../../types/room.types';
 
 type GameStateRow = Database['public']['Tables']['game_states']['Row'];
 type GameStateUpdate = Database['public']['Tables']['game_states']['Update'];
+type RoomPlayerRow = Database['public']['Tables']['room_players']['Row'];
+
+interface LoadedRoomGameState {
+  gameState: GameStateRow;
+  roomPlayers: RoomPlayerRow[];
+}
+
+interface RosterPlayerSnapshot {
+  playerId: string;
+  name: string;
+  team: number;
+  isCOM?: boolean;
+  hand: string[];
+  isPasser: boolean;
+  hasBroken: boolean;
+  hasRequiredBroken: boolean;
+}
 
 @Injectable()
 export class SupabaseGameStateRepository implements IGameStateRepository {
@@ -39,6 +60,8 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
             players: gameState.players.map((player) =>
               toPersistedGamePlayer(player),
             ),
+            playerStates: toPersistedPlayerStates(gameState.players),
+            playerOrder: gameState.players.map((player) => player.playerId),
             deck: gameState.deck,
             agari: gameState.agari,
             blowState: gameState.blowState,
@@ -69,6 +92,30 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
 
   async findByRoomId(roomId: string): Promise<GameState | null> {
     try {
+      const { data: loadedState, error: loadError } = await this.supabase.rpc(
+        'load_room_game_state',
+        { p_room_id: roomId },
+      );
+
+      if (!loadError) {
+        if (!loadedState) {
+          return null;
+        }
+
+        const payload = loadedState as LoadedRoomGameState;
+        return this.mapDatabaseToGameState(
+          payload.gameState,
+          payload.roomPlayers,
+        );
+      }
+
+      if (!this.isMissingRpcError(loadError)) {
+        throw new Error(`Failed to load room game state: ${loadError.message}`);
+      }
+
+      this.logger.warn(
+        'load_room_game_state RPC is unavailable; using legacy reads',
+      );
       const { data, error } = await this.supabase
         .from('game_states')
         .select('*')
@@ -82,7 +129,8 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
         throw new Error(`Failed to fetch game state: ${error.message}`);
       }
 
-      return this.mapDatabaseToGameState(data);
+      const roomPlayers = await this.fetchRoomPlayers(roomId);
+      return this.mapDatabaseToGameState(data, roomPlayers);
     } catch (error) {
       this.logger.error('Error finding game state by room ID:', error);
       throw error;
@@ -92,86 +140,331 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
   async update(
     roomId: string,
     gameState: Partial<GameState>,
+    expectedVersion?: number,
   ): Promise<GameState | null> {
     try {
-      const updateData: Partial<GameStateUpdate> = {};
-
-      if (
-        gameState.players ||
-        gameState.deck ||
-        gameState.agari ||
-        gameState.blowState ||
-        gameState.playState
-      ) {
-        // Get current state data first
-        const { data: currentData } = await this.supabase
-          .from('game_states')
-          .select('state_data')
-          .eq('room_id', roomId)
-          .single();
-
-        const currentStateData =
-          (currentData?.state_data as Record<string, any>) || {};
-
-        updateData.state_data = {
-          ...currentStateData,
-          ...(gameState.players && {
-            players: gameState.players.map((player) =>
-              toPersistedGamePlayer(player),
-            ),
-          }),
-          ...(gameState.deck && { deck: gameState.deck }),
-          ...(gameState.agari !== undefined && { agari: gameState.agari }),
-          ...(gameState.blowState && { blowState: gameState.blowState }),
-          ...(gameState.playState && { playState: gameState.playState }),
-        };
-      }
-
-      if (gameState.currentPlayerIndex !== undefined)
-        updateData.current_player_index = gameState.currentPlayerIndex;
-      if (gameState.gamePhase !== undefined)
-        updateData.game_phase = gameState.gamePhase;
-      if (gameState.roundNumber !== undefined)
-        updateData.round_number = gameState.roundNumber;
-      if (gameState.pointsToWin !== undefined)
-        updateData.points_to_win = gameState.pointsToWin;
-      if (gameState.teamScores) updateData.team_scores = gameState.teamScores;
-      if (gameState.teamScoreRecords) {
-        // Convert Date objects to strings for database storage
-        const convertedRecords: Record<
-          string,
-          Array<{ points: number; timestamp: string; reason: string }>
-        > = {};
-        Object.entries(gameState.teamScoreRecords).forEach(
-          ([team, records]) => {
-            convertedRecords[team] = records.map((record) => ({
-              points: record.points,
-              timestamp: record.timestamp.toISOString(),
-              reason: record.reason,
-            }));
-          },
-        );
-        updateData.team_score_records = convertedRecords;
-      }
-      if (gameState.teamAssignments)
-        updateData.team_assignments = gameState.teamAssignments;
-
-      const { data, error } = await this.supabase
-        .from('game_states')
-        .update(updateData)
-        .eq('room_id', roomId)
-        .select()
-        .single();
+      const { data, error } = await this.supabase.rpc(
+        'atomic_update_game_state',
+        {
+          p_room_id: roomId,
+          p_state_patch: this.buildStatePatch(gameState),
+          p_scalar_patch: this.buildScalarPatch(gameState),
+          p_expected_version: expectedVersion ?? null,
+        },
+      );
 
       if (error) {
+        if (this.isMissingRpcError(error)) {
+          this.logger.warn(
+            'atomic_update_game_state RPC is unavailable; using legacy update',
+          );
+          return this.updateLegacy(roomId, gameState);
+        }
         throw new Error(`Failed to update game state: ${error.message}`);
       }
 
-      return this.mapDatabaseToGameState(data);
+      if (!data) {
+        return null;
+      }
+
+      const roomPlayers = await this.fetchRoomPlayers(roomId);
+      return this.mapDatabaseToGameState(data as GameStateRow, roomPlayers);
     } catch (error) {
       this.logger.error('Error updating game state:', error);
       throw error;
     }
+  }
+
+  async persistRoomRoster(
+    roomId: string,
+    roomPlayers: RoomPlayer[],
+    gameState: GameState,
+    hostId?: string,
+  ): Promise<GameState | null> {
+    const playerStates = toPersistedPlayerStates(gameState.players);
+    const playerOrder = gameState.players.map((player) => player.playerId);
+    const legacyPlayers = gameState.players.map((player) =>
+      toPersistedGamePlayer(player),
+    );
+    const persistedRoomPlayers = roomPlayers.map((player) => ({
+      playerId: player.playerId,
+      userId: player.userId ?? null,
+      name: player.name,
+      team: player.team,
+      isReady: player.isReady,
+      isHost: player.isHost,
+      isCOM: player.isCOM ?? false,
+      joinedAt: player.joinedAt.toISOString(),
+    }));
+
+    try {
+      const { data, error } = await this.supabase.rpc(
+        'persist_room_roster_atomic',
+        {
+          p_room_id: roomId,
+          p_room_players: persistedRoomPlayers,
+          p_player_states: playerStates,
+          p_player_order: playerOrder,
+          p_legacy_players: legacyPlayers,
+          p_team_assignments: gameState.teamAssignments,
+          p_host_id: hostId ?? null,
+          p_expected_version: gameState.version ?? null,
+        },
+      );
+
+      if (error) {
+        if (this.isMissingRpcError(error)) {
+          this.logger.warn(
+            'persist_room_roster_atomic RPC is unavailable; using legacy roster writes',
+          );
+          await this.persistRoomRosterLegacy(
+            roomId,
+            roomPlayers,
+            gameState,
+            hostId,
+          );
+          return this.findByRoomId(roomId);
+        }
+        throw new Error(`Failed to persist room roster: ${error.message}`);
+      }
+
+      return data
+        ? this.mapDatabaseToGameState(data as GameStateRow, roomPlayers)
+        : null;
+    } catch (error) {
+      this.logger.error('Error persisting room roster:', error);
+      throw error;
+    }
+  }
+
+  private buildStatePatch(
+    gameState: Partial<GameState>,
+  ): Record<string, unknown> {
+    const patch: Record<string, unknown> = {};
+
+    if (gameState.players) {
+      patch.players = gameState.players.map((player) =>
+        toPersistedGamePlayer(player),
+      );
+      patch.playerStates = toPersistedPlayerStates(gameState.players);
+      patch.playerOrder = gameState.players.map((player) => player.playerId);
+    }
+    if (gameState.deck) patch.deck = gameState.deck;
+    if (gameState.agari !== undefined) patch.agari = gameState.agari;
+    if (gameState.blowState) patch.blowState = gameState.blowState;
+    if (gameState.playState) patch.playState = gameState.playState;
+    if (gameState.pendingBrokenHandReveal !== undefined) {
+      patch.pendingBrokenHandReveal = gameState.pendingBrokenHandReveal;
+    }
+
+    return patch;
+  }
+
+  private buildScalarPatch(
+    gameState: Partial<GameState>,
+  ): Record<string, unknown> {
+    const patch: Record<string, unknown> = {};
+
+    if (gameState.currentPlayerIndex !== undefined) {
+      patch.currentPlayerIndex = gameState.currentPlayerIndex;
+    }
+    if (gameState.gamePhase !== undefined) {
+      patch.gamePhase = gameState.gamePhase;
+    }
+    if (gameState.roundNumber !== undefined) {
+      patch.roundNumber = gameState.roundNumber;
+    }
+    if (gameState.pointsToWin !== undefined) {
+      patch.pointsToWin = gameState.pointsToWin;
+    }
+    if (gameState.teamScores) patch.teamScores = gameState.teamScores;
+    if (gameState.teamScoreRecords) {
+      patch.teamScoreRecords = this.convertScoreRecordsForPersistence(
+        gameState.teamScoreRecords,
+      );
+    }
+    if (gameState.teamAssignments) {
+      patch.teamAssignments = gameState.teamAssignments;
+    }
+
+    return patch;
+  }
+
+  private convertScoreRecordsForPersistence(
+    recordsByTeam: GameState['teamScoreRecords'],
+  ): Record<
+    string,
+    Array<{ points: number; timestamp: string; reason: string }>
+  > {
+    return Object.fromEntries(
+      Object.entries(recordsByTeam).map(([team, records]) => [
+        team,
+        records.map((record) => ({
+          points: record.points,
+          timestamp: record.timestamp.toISOString(),
+          reason: record.reason,
+        })),
+      ]),
+    );
+  }
+
+  private async updateLegacy(
+    roomId: string,
+    gameState: Partial<GameState>,
+  ): Promise<GameState | null> {
+    const updateData: Partial<GameStateUpdate> = {};
+    const statePatch = this.buildStatePatch(gameState);
+
+    if (Object.keys(statePatch).length > 0) {
+      const { data: currentData } = await this.supabase
+        .from('game_states')
+        .select('state_data')
+        .eq('room_id', roomId)
+        .single();
+      updateData.state_data = {
+        ...((currentData?.state_data as Record<string, unknown>) ?? {}),
+        ...statePatch,
+      };
+    }
+
+    if (gameState.currentPlayerIndex !== undefined) {
+      updateData.current_player_index = gameState.currentPlayerIndex;
+    }
+    if (gameState.gamePhase !== undefined) {
+      updateData.game_phase = gameState.gamePhase;
+    }
+    if (gameState.roundNumber !== undefined) {
+      updateData.round_number = gameState.roundNumber;
+    }
+    if (gameState.pointsToWin !== undefined) {
+      updateData.points_to_win = gameState.pointsToWin;
+    }
+    if (gameState.teamScores) updateData.team_scores = gameState.teamScores;
+    if (gameState.teamScoreRecords) {
+      updateData.team_score_records = this.convertScoreRecordsForPersistence(
+        gameState.teamScoreRecords,
+      );
+    }
+    if (gameState.teamAssignments) {
+      updateData.team_assignments = gameState.teamAssignments;
+    }
+
+    const { data, error } = await this.supabase
+      .from('game_states')
+      .update(updateData)
+      .eq('room_id', roomId)
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to update game state: ${error.message}`);
+    }
+
+    const roomPlayers = await this.fetchRoomPlayers(roomId);
+    return this.mapDatabaseToGameState(data, roomPlayers);
+  }
+
+  private async persistRoomRosterLegacy(
+    roomId: string,
+    roomPlayers: RoomPlayer[],
+    gameState: GameState,
+    hostId?: string,
+  ): Promise<void> {
+    const existingPlayers = await this.fetchRoomPlayers(roomId);
+    const desiredIds = new Set(roomPlayers.map((player) => player.playerId));
+
+    await Promise.all(
+      existingPlayers
+        .filter((player) => !desiredIds.has(player.player_id))
+        .map((player) =>
+          this.supabase
+            .from('room_players')
+            .delete()
+            .eq('room_id', roomId)
+            .eq('player_id', player.player_id),
+        ),
+    );
+
+    const statePlayers = new Map(
+      gameState.players.map((player) => [player.playerId, player]),
+    );
+    const rows = roomPlayers.map((player) => {
+      const statePlayer = statePlayers.get(player.playerId);
+      return {
+        room_id: roomId,
+        player_id: player.playerId,
+        socket_id: null,
+        user_id: player.userId ?? null,
+        name: player.name,
+        hand: [...(statePlayer?.hand ?? [])],
+        team: player.team,
+        is_passer: statePlayer?.isPasser ?? false,
+        has_broken: statePlayer?.hasBroken ?? false,
+        has_required_broken: statePlayer?.hasRequiredBroken ?? false,
+        is_ready: player.isReady,
+        is_host: player.isHost,
+        is_com: player.isCOM ?? false,
+        joined_at: player.joinedAt.toISOString(),
+      };
+    });
+
+    if (rows.length > 0) {
+      const { error } = await this.supabase
+        .from('room_players')
+        .upsert(rows, { onConflict: 'room_id,player_id' });
+      if (error) {
+        throw new Error(
+          `Failed to persist legacy room roster: ${error.message}`,
+        );
+      }
+    }
+
+    const roomUpdate: Record<string, unknown> = {
+      last_activity_at: new Date().toISOString(),
+    };
+    if (hostId) roomUpdate.host_id = hostId;
+    const { error: roomError } = await this.supabase
+      .from('rooms')
+      .update(roomUpdate)
+      .eq('id', roomId);
+    if (roomError) {
+      throw new Error(
+        `Failed to update legacy room roster: ${roomError.message}`,
+      );
+    }
+
+    const persistedState = await this.updateLegacy(roomId, {
+      players: gameState.players,
+      teamAssignments: gameState.teamAssignments,
+    });
+    if (!persistedState) {
+      throw new Error(`Game state not found for room ${roomId}`);
+    }
+  }
+
+  private async fetchRoomPlayers(roomId: string): Promise<RoomPlayerRow[]> {
+    const { data, error } = await this.supabase
+      .from('room_players')
+      .select('*')
+      .eq('room_id', roomId)
+      .order('joined_at', { ascending: true });
+
+    if (error) {
+      throw new Error(`Failed to fetch room players: ${error.message}`);
+    }
+
+    return (data ?? []) as RoomPlayerRow[];
+  }
+
+  private isMissingRpcError(error: {
+    code?: string;
+    message?: string;
+  }): boolean {
+    return (
+      error.code === 'PGRST202' ||
+      error.code === '42883' ||
+      error.message?.includes('Could not find the function') === true
+    );
   }
 
   async delete(roomId: string): Promise<void> {
@@ -195,31 +488,7 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
     players: DomainPlayer[],
   ): Promise<boolean> {
     try {
-      const { data: currentData } = await this.supabase
-        .from('game_states')
-        .select('state_data')
-        .eq('room_id', roomId)
-        .single();
-
-      const currentStateData =
-        (currentData?.state_data as Record<string, any>) || {};
-
-      const { error } = await this.supabase
-        .from('game_states')
-        .update({
-          state_data: {
-            ...currentStateData,
-            players: players.map((player) => toPersistedGamePlayer(player)),
-          },
-        })
-        .eq('room_id', roomId);
-
-      if (error) {
-        this.logger.error('Failed to update players:', error);
-        return false;
-      }
-
-      return true;
+      return Boolean(await this.update(roomId, { players }));
     } catch (error) {
       this.logger.error('Error updating players:', error);
       return false;
@@ -260,20 +529,12 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
 
   async updateGamePhase(roomId: string, phase: string): Promise<boolean> {
     try {
-      const { error } = await this.supabase
-        .from('game_states')
-        .update({
-          game_phase:
+      return Boolean(
+        await this.update(roomId, {
+          gamePhase:
             phase as Database['public']['Tables']['game_states']['Row']['game_phase'],
-        })
-        .eq('room_id', roomId);
-
-      if (error) {
-        this.logger.error('Failed to update game phase:', error);
-        return false;
-      }
-
-      return true;
+        }),
+      );
     } catch (error) {
       this.logger.error('Error updating game phase:', error);
       return false;
@@ -285,17 +546,7 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
     index: number,
   ): Promise<boolean> {
     try {
-      const { error } = await this.supabase
-        .from('game_states')
-        .update({ current_player_index: index })
-        .eq('room_id', roomId);
-
-      if (error) {
-        this.logger.error('Failed to update current player index:', error);
-        return false;
-      }
-
-      return true;
+      return Boolean(await this.update(roomId, { currentPlayerIndex: index }));
     } catch (error) {
       this.logger.error('Error updating current player index:', error);
       return false;
@@ -307,17 +558,21 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
     updates: Partial<GameStateUpdate>,
   ): Promise<boolean> {
     try {
-      const { error } = await this.supabase
-        .from('game_states')
-        .update(updates)
-        .eq('room_id', roomId);
-
-      if (error) {
-        this.logger.error('Failed to bulk update game state:', error);
-        return false;
+      const gameStateUpdates: Partial<GameState> = {};
+      if (updates.round_number !== undefined) {
+        gameStateUpdates.roundNumber = updates.round_number;
+      }
+      if (updates.current_player_index !== undefined) {
+        gameStateUpdates.currentPlayerIndex = updates.current_player_index;
+      }
+      if (updates.game_phase !== undefined) {
+        gameStateUpdates.gamePhase = updates.game_phase;
+      }
+      if (updates.points_to_win !== undefined) {
+        gameStateUpdates.pointsToWin = updates.points_to_win;
       }
 
-      return true;
+      return Boolean(await this.update(roomId, gameStateUpdates));
     } catch (error) {
       this.logger.error('Error bulk updating game state:', error);
       return false;
@@ -347,25 +602,92 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
     }
   }
 
-  private mapDatabaseToGameState(dbGameState: GameStateRow): GameState {
+  private mapDatabaseToGameState(
+    dbGameState: GameStateRow,
+    roomPlayers?: Array<RoomPlayerRow | RoomPlayer>,
+  ): GameState {
     const stateData = dbGameState.state_data || {};
     const teamAssignments = dbGameState.team_assignments as {
       [playerId: string]: 0 | 1;
     };
-    const players = Array.isArray(stateData.players)
-      ? stateData.players
-          .map((player) => {
-            const persistedPlayer = player as Partial<PersistedGamePlayer>;
-            const fallbackTeam =
-              typeof persistedPlayer.playerId === 'string'
-                ? teamAssignments[persistedPlayer.playerId]
-                : undefined;
-            return toRuntimePlayer(persistedPlayer, fallbackTeam);
-          })
-          .filter((player): player is DomainPlayer => Boolean(player))
-      : [];
+    const legacyPlayers = new Map<string, Partial<PersistedGamePlayer>>(
+      Array.isArray(stateData.players)
+        ? stateData.players
+            .filter(
+              (player): player is PersistedGamePlayer =>
+                typeof (player as PersistedGamePlayer)?.playerId === 'string',
+            )
+            .map((player) => [player.playerId, player])
+        : [],
+    );
+    const playerStates =
+      stateData.playerStates && typeof stateData.playerStates === 'object'
+        ? (stateData.playerStates as PersistedPlayerStates)
+        : {};
+    const hasAuthoritativeRoster = roomPlayers !== undefined;
+    const rosterPlayers = (roomPlayers ?? []).map((player) =>
+      this.toRosterPlayerSnapshot(player),
+    );
+    const roomPlayersById = new Map(
+      rosterPlayers.map((player) => [player.playerId, player]),
+    );
+    const persistedOrder = (
+      Array.isArray(stateData.playerOrder)
+        ? stateData.playerOrder.filter(
+            (playerId): playerId is string => typeof playerId === 'string',
+          )
+        : []
+    ).filter(
+      (playerId) => !hasAuthoritativeRoster || roomPlayersById.has(playerId),
+    );
+    const playerOrder = [
+      ...persistedOrder,
+      ...rosterPlayers
+        .map((player) => player.playerId)
+        .filter((playerId) => !persistedOrder.includes(playerId)),
+      ...(!hasAuthoritativeRoster
+        ? Array.from(legacyPlayers.keys()).filter(
+            (playerId) => !persistedOrder.includes(playerId),
+          )
+        : []),
+    ];
+    const players = playerOrder
+      .map((playerId) => {
+        const roomPlayer = roomPlayersById.get(playerId);
+        const legacyPlayer = legacyPlayers.get(playerId);
+        const gameplay = playerStates[playerId] as
+          | PersistedPlayerGameplayState
+          | undefined;
+        const fallbackTeam = teamAssignments[playerId];
+
+        return toRuntimePlayer(
+          {
+            ...legacyPlayer,
+            playerId,
+            name: roomPlayer?.name ?? legacyPlayer?.name,
+            team: roomPlayer?.team as 0 | 1 | undefined,
+            isCOM: roomPlayer?.isCOM ?? legacyPlayer?.isCOM,
+            hand: gameplay?.hand ?? roomPlayer?.hand ?? legacyPlayer?.hand,
+            isPasser:
+              gameplay?.isPasser ??
+              roomPlayer?.isPasser ??
+              legacyPlayer?.isPasser,
+            hasBroken:
+              gameplay?.hasBroken ??
+              roomPlayer?.hasBroken ??
+              legacyPlayer?.hasBroken,
+            hasRequiredBroken:
+              gameplay?.hasRequiredBroken ??
+              roomPlayer?.hasRequiredBroken ??
+              legacyPlayer?.hasRequiredBroken,
+          },
+          fallbackTeam,
+        );
+      })
+      .filter((player): player is DomainPlayer => Boolean(player));
 
     return {
+      version: dbGameState.version,
       players,
       currentPlayerIndex: dbGameState.current_player_index,
       gamePhase: dbGameState.game_phase,
@@ -379,10 +701,39 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
       ),
       blowState: stateData.blowState,
       playState: stateData.playState,
+      pendingBrokenHandReveal: stateData.pendingBrokenHandReveal ?? null,
       agari: stateData.agari,
       roundNumber: dbGameState.round_number,
       pointsToWin: dbGameState.points_to_win,
       teamAssignments,
+    };
+  }
+
+  private toRosterPlayerSnapshot(
+    player: RoomPlayerRow | RoomPlayer,
+  ): RosterPlayerSnapshot {
+    if ('player_id' in player) {
+      return {
+        playerId: player.player_id,
+        name: player.name,
+        team: player.team,
+        isCOM: player.is_com,
+        hand: [...player.hand],
+        isPasser: player.is_passer,
+        hasBroken: player.has_broken,
+        hasRequiredBroken: player.has_required_broken,
+      };
+    }
+
+    return {
+      playerId: player.playerId,
+      name: player.name,
+      team: player.team,
+      isCOM: player.isCOM,
+      hand: [...player.hand],
+      isPasser: player.isPasser,
+      hasBroken: player.hasBroken ?? false,
+      hasRequiredBroken: player.hasRequiredBroken ?? false,
     };
   }
 

--- a/mei-tra-backend/src/repositories/implementations/supabase-room.repository.spec.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-room.repository.spec.ts
@@ -34,6 +34,7 @@ describe('SupabaseRoomRepository', () => {
       team: number;
       is_host: boolean;
       is_ready: boolean;
+      is_com: boolean;
       hand: string[];
       is_passer: boolean;
       has_broken: boolean;
@@ -54,6 +55,7 @@ describe('SupabaseRoomRepository', () => {
       has_required_broken: overrides.has_required_broken ?? false,
       is_ready: overrides.is_ready ?? false,
       is_host: overrides.is_host ?? false,
+      is_com: overrides.is_com ?? false,
       joined_at: joinedAt,
     };
   }

--- a/mei-tra-backend/src/repositories/implementations/supabase-room.repository.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-room.repository.ts
@@ -498,7 +498,7 @@ export class SupabaseRoomRepository implements IRoomRepository {
       hasRequiredBroken: dbPlayer.has_required_broken,
       isReady: dbPlayer.is_ready,
       isHost: dbPlayer.is_host,
-      isCOM: dbPlayer.player_id.startsWith('com-'),
+      isCOM: dbPlayer.is_com,
       joinedAt: new Date(dbPlayer.joined_at),
     };
   }

--- a/mei-tra-backend/src/repositories/interfaces/game-state.repository.interface.ts
+++ b/mei-tra-backend/src/repositories/interfaces/game-state.repository.interface.ts
@@ -3,6 +3,7 @@ import {
   DomainPlayer,
   PlayerConnectionMetadata,
 } from '../../types/game.types';
+import { RoomPlayer } from '../../types/room.types';
 
 export interface IGameStateRepository {
   // Game state CRUD operations
@@ -11,6 +12,13 @@ export interface IGameStateRepository {
   update(
     roomId: string,
     gameState: Partial<GameState>,
+    expectedVersion?: number,
+  ): Promise<GameState | null>;
+  persistRoomRoster(
+    roomId: string,
+    roomPlayers: RoomPlayer[],
+    gameState: GameState,
+    hostId?: string,
   ): Promise<GameState | null>;
   delete(roomId: string): Promise<void>;
 

--- a/mei-tra-backend/src/services/__tests__/com-autoplay-recovery.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-autoplay-recovery.service.spec.ts
@@ -1,0 +1,270 @@
+import { Logger } from '@nestjs/common';
+import { IRoomService } from '../interfaces/room-service.interface';
+import { IComAutoPlayUseCase } from '../../use-cases/interfaces/com-autoplay-use-case.interface';
+import { ICompleteFieldUseCase } from '../../use-cases/interfaces/complete-field.use-case.interface';
+import { GatewayEvent } from '../../use-cases/interfaces/gateway-event.interface';
+import {
+  ComAutoPlayRecoveryHandlers,
+  ComAutoPlayRecoveryService,
+} from '../com-autoplay-recovery.service';
+
+const flushPromises = async (): Promise<void> => {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+};
+
+const createService = () => {
+  const roomService = {
+    getRoomGameState: jest.fn(),
+  };
+  const comAutoPlayUseCase = {
+    execute: jest.fn(),
+  };
+  const completeFieldUseCase = {
+    execute: jest.fn(),
+  };
+  const handlers: ComAutoPlayRecoveryHandlers = {
+    dispatchEvents: jest.fn(),
+    processFieldCompletion: jest.fn().mockResolvedValue(undefined),
+  };
+  const service = new ComAutoPlayRecoveryService(
+    roomService as unknown as IRoomService,
+    comAutoPlayUseCase as IComAutoPlayUseCase,
+    completeFieldUseCase as ICompleteFieldUseCase,
+  );
+
+  return {
+    service,
+    roomService,
+    comAutoPlayUseCase,
+    completeFieldUseCase,
+    handlers,
+  };
+};
+
+describe('ComAutoPlayRecoveryService', () => {
+  it('completes a persisted full field when its timer was lost', async () => {
+    const {
+      service,
+      roomService,
+      comAutoPlayUseCase,
+      completeFieldUseCase,
+      handlers,
+    } = createService();
+    const field = {
+      cards: ['A♠', 'K♠', 'Q♠', 'J♠'],
+      playedBy: ['p1', 'p2', 'p3', 'com-1'],
+      baseCard: 'A♠',
+      dealerId: 'p1',
+      isComplete: true,
+    };
+    const state = {
+      gamePhase: 'play',
+      playState: { currentField: field },
+      pendingBrokenHandReveal: null,
+    };
+    const completionResponse = { success: true, events: [] };
+
+    roomService.getRoomGameState.mockResolvedValue({
+      getState: () => state,
+    });
+    completeFieldUseCase.execute.mockImplementation(() => {
+      state.playState.currentField = {
+        ...field,
+        cards: [],
+        playedBy: [],
+        isComplete: false,
+      };
+      return Promise.resolve(completionResponse);
+    });
+    comAutoPlayUseCase.execute.mockResolvedValue({
+      success: true,
+      events: [],
+      shouldContinue: false,
+    });
+
+    service.trigger('room-1', handlers);
+    await flushPromises();
+    await flushPromises();
+
+    expect(completeFieldUseCase.execute).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      field,
+    });
+    expect(handlers.processFieldCompletion).toHaveBeenCalledWith(
+      'room-1',
+      completionResponse,
+    );
+    expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes duplicate recovery triggers and reruns once afterward', async () => {
+    const { service, roomService, comAutoPlayUseCase, handlers } =
+      createService();
+    let finishFirstRun:
+      | ((value: {
+          success: boolean;
+          events: never[];
+          shouldContinue: boolean;
+        }) => void)
+      | undefined;
+    const firstRun = new Promise<{
+      success: boolean;
+      events: never[];
+      shouldContinue: boolean;
+    }>((resolve) => {
+      finishFirstRun = resolve;
+    });
+
+    roomService.getRoomGameState.mockResolvedValue({
+      getState: () => ({
+        gamePhase: 'play',
+        playState: { currentField: null },
+        pendingBrokenHandReveal: null,
+      }),
+    });
+    comAutoPlayUseCase.execute.mockReturnValueOnce(firstRun).mockResolvedValue({
+      success: true,
+      events: [],
+      shouldContinue: false,
+    });
+
+    service.trigger('room-1', handlers);
+    service.trigger('room-1', handlers);
+    await flushPromises();
+
+    expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(1);
+
+    finishFirstRun?.({
+      success: true,
+      events: [],
+      shouldContinue: false,
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries COM auto-play after a transient failure', async () => {
+    jest.useFakeTimers();
+    const loggerError = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation();
+    const { service, roomService, comAutoPlayUseCase, handlers } =
+      createService();
+
+    roomService.getRoomGameState.mockResolvedValue({
+      getState: () => ({
+        gamePhase: 'play',
+        playState: { currentField: null },
+        pendingBrokenHandReveal: null,
+      }),
+    });
+    comAutoPlayUseCase.execute
+      .mockResolvedValueOnce({
+        success: false,
+        events: [],
+        shouldContinue: false,
+        error: 'temporary persistence error',
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        events: [],
+        shouldContinue: false,
+      });
+
+    service.trigger('room-1', handlers);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(5_000);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(2);
+    service.clearRoom('room-1');
+    loggerError.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it('cancels scheduled continuation when the room is cleared', async () => {
+    jest.useFakeTimers();
+    const { service, roomService, comAutoPlayUseCase, handlers } =
+      createService();
+
+    roomService.getRoomGameState.mockResolvedValue({
+      getState: () => ({
+        gamePhase: 'play',
+        playState: { currentField: null },
+        pendingBrokenHandReveal: null,
+      }),
+    });
+    comAutoPlayUseCase.execute.mockResolvedValue({
+      success: true,
+      events: [],
+      shouldContinue: true,
+    });
+
+    service.trigger('room-1', handlers);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(1);
+    service.clearRoom('room-1');
+    await jest.advanceTimersByTimeAsync(2_000);
+
+    expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('suppresses events from an in-flight run after the room is cleared', async () => {
+    const { service, roomService, comAutoPlayUseCase, handlers } =
+      createService();
+    let finishRun:
+      | ((value: {
+          success: boolean;
+          events: GatewayEvent[];
+          shouldContinue: boolean;
+        }) => void)
+      | undefined;
+    const pendingRun = new Promise<{
+      success: boolean;
+      events: GatewayEvent[];
+      shouldContinue: boolean;
+    }>((resolve) => {
+      finishRun = resolve;
+    });
+
+    roomService.getRoomGameState.mockResolvedValue({
+      getState: () => ({
+        gamePhase: 'play',
+        playState: { currentField: null },
+        pendingBrokenHandReveal: null,
+      }),
+    });
+    comAutoPlayUseCase.execute.mockReturnValue(pendingRun);
+
+    service.trigger('room-1', handlers);
+    await flushPromises();
+    service.clearRoom('room-1');
+    finishRun?.({
+      success: true,
+      events: [
+        {
+          scope: 'room',
+          roomId: 'room-1',
+          event: 'update-turn',
+          payload: 'com-1',
+        },
+      ],
+      shouldContinue: false,
+    });
+    await flushPromises();
+
+    expect(handlers.dispatchEvents).not.toHaveBeenCalled();
+  });
+});

--- a/mei-tra-backend/src/services/__tests__/game-state-phase.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/game-state-phase.spec.ts
@@ -12,7 +12,8 @@ describe('GameStateService phase transitions', () => {
     repository = {
       create: jest.fn().mockResolvedValue(true),
       findByRoomId: jest.fn().mockResolvedValue(null),
-      update: jest.fn().mockResolvedValue(true),
+      update: jest.fn().mockResolvedValue({ version: 1 }),
+      persistRoomRoster: jest.fn().mockResolvedValue({ version: 1 }),
       delete: jest.fn().mockResolvedValue(true),
       updatePlayerConnection: jest.fn().mockResolvedValue(true),
       updateGamePhase: jest.fn().mockResolvedValue(true),
@@ -34,9 +35,11 @@ describe('GameStateService phase transitions', () => {
     await service.transitionPhase('blow');
 
     expect(service.getState().gamePhase).toBe('blow');
-    expect(repository.update).toHaveBeenCalledWith('room-1', {
-      gamePhase: 'blow',
-    });
+    expect(repository.update).toHaveBeenCalledWith(
+      'room-1',
+      { gamePhase: 'blow' },
+      0,
+    );
   });
 
   it('rejects an illegal transition and keeps the previous phase', async () => {
@@ -46,5 +49,61 @@ describe('GameStateService phase transitions', () => {
       'Invalid game phase transition: blow -> deal',
     );
     expect(service.getState().gamePhase).toBe('blow');
+  });
+
+  it('serializes concurrent persistence with the latest version', async () => {
+    const expectedVersions: Array<number | undefined> = [];
+    repository.update.mockImplementation(
+      async (_roomId, updates, expectedVersion) => {
+        expectedVersions.push(expectedVersion);
+        return {
+          ...service.getState(),
+          ...updates,
+          version: (expectedVersion ?? 0) + 1,
+        };
+      },
+    );
+
+    await Promise.all([service.saveState(), service.saveState()]);
+
+    expect(expectedVersions).toEqual([0, 1]);
+    expect(service.getState().version).toBe(2);
+  });
+
+  it('records a completed field without persisting an intermediate snapshot', () => {
+    const state = service.getState();
+    state.players = [
+      {
+        playerId: 'player-1',
+        name: 'Player 1',
+        team: 0,
+        hand: [],
+        isPasser: false,
+      },
+    ];
+    const currentField = {
+      cards: ['S1', 'S2', 'S3', 'S4'],
+      playedBy: ['player-1', 'player-2', 'player-3', 'player-4'],
+      baseCard: 'S1',
+      dealerId: 'player-1',
+      isComplete: true,
+    };
+    state.playState = {
+      currentField,
+      negriCard: null,
+      neguri: {},
+      fields: [],
+      lastWinnerId: null,
+      openDeclared: false,
+      openDeclarerId: null,
+    };
+
+    const completedField = service.completeField(currentField, 'player-1');
+
+    expect(completedField).toEqual(
+      expect.objectContaining({ winnerId: 'player-1', winnerTeam: 0 }),
+    );
+    expect(state.playState.fields).toHaveLength(1);
+    expect(repository.update).not.toHaveBeenCalled();
   });
 });

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -39,7 +39,7 @@ describe('Reconnection Token Management', () => {
       gameStateRepository = {
         findByRoomId: jest.fn(),
         create: jest.fn(),
-        update: jest.fn(),
+        update: jest.fn().mockResolvedValue({} as GameState),
         delete: jest.fn(),
         updateCurrentPlayerIndex: jest.fn(),
         updatePlayers: jest.fn(),
@@ -247,6 +247,56 @@ describe('Reconnection Token Management', () => {
         await expect(gameStateService.loadState(roomId)).resolves.not.toThrow();
       });
     });
+
+    describe('reconcileWaitingRoomPlayers', () => {
+      it('repairs and persists a stale waiting-room roster', async () => {
+        const roomId = 'room-cold-start';
+        const roomPlayers: RoomPlayer[] = [
+          {
+            socketId: 'stale-socket',
+            playerId: 'seat-1',
+            userId: 'user-1',
+            isAuthenticated: true,
+            name: 'User 1',
+            hand: [],
+            team: 1,
+            isPasser: false,
+            isCOM: false,
+            hasBroken: false,
+            hasRequiredBroken: false,
+            isReady: true,
+            isHost: true,
+            joinedAt: new Date('2026-07-19T00:00:00.000Z'),
+          },
+        ];
+
+        gameStateService.setRoomId(roomId);
+        gameStateService.getState().players = [];
+
+        await gameStateService.reconcileWaitingRoomPlayers(roomPlayers);
+
+        expect(gameStateService.getState().players).toEqual([
+          expect.objectContaining({
+            playerId: 'seat-1',
+            name: 'User 1',
+            team: 1,
+          }),
+        ]);
+        expect(gameStateService.getState().teamAssignments).toEqual({
+          'seat-1': 1,
+        });
+        expect(gameStateService.findPlayerByReconnectToken('user-1')).toEqual(
+          expect.objectContaining({ playerId: 'seat-1' }),
+        );
+        expect(gameStateRepository.update).toHaveBeenCalledWith(
+          roomId,
+          expect.objectContaining({
+            players: gameStateService.getState().players,
+            teamAssignments: { 'seat-1': 1 },
+          }),
+        );
+      });
+    });
   });
 
   describe('RoomService - Reconnection Features', () => {
@@ -309,7 +359,7 @@ describe('Reconnection Token Management', () => {
       gameStateRepository = {
         findByRoomId: jest.fn(),
         create: jest.fn(),
-        update: jest.fn(),
+        update: jest.fn().mockResolvedValue({} as GameState),
         delete: jest.fn(),
         updateCurrentPlayerIndex: jest.fn(),
         updatePlayers: jest.fn(),
@@ -899,6 +949,57 @@ describe('Reconnection Token Management', () => {
         expect(restoredRoom?.players[0].playerId).toBe(playerId);
         expect(restoredRoom?.players[0].hand).toEqual(['H2', 'D3', 'C4']);
         expect(restoredRoom?.players[0].team).toBe(0);
+      });
+
+      it('should allow an existing player to rejoin a full waiting room', async () => {
+        const roomId = 'room-123';
+        const existingPlayer: RoomPlayer = {
+          socketId: 'socket-old',
+          playerId: 'player-1',
+          userId: 'user-1',
+          isAuthenticated: true,
+          name: 'Test Player',
+          team: 0,
+          hand: [],
+          isPasser: false,
+          hasBroken: false,
+          hasRequiredBroken: false,
+          isReady: true,
+          isHost: true,
+          joinedAt: new Date(),
+        };
+        const roomState = bindRoomRepositoryToState({
+          ...baseRoom,
+          id: roomId,
+          status: RoomStatus.WAITING,
+          settings: { ...baseRoom.settings, maxPlayers: 1 },
+          players: [existingPlayer],
+        });
+
+        const result = await roomService.joinRoom(roomId, {
+          socketId: 'socket-new',
+          playerId: 'player-1',
+          userId: 'user-1',
+          isAuthenticated: true,
+          name: 'Test Player',
+        });
+
+        expect(result).toBe(true);
+        expect(roomRepository.addPlayer).not.toHaveBeenCalled();
+        expect(roomRepository.updatePlayer).toHaveBeenCalledWith(
+          roomId,
+          'player-1',
+          expect.objectContaining({ socketId: 'socket-new' }),
+        );
+        expect(roomState.getPersistedRoom()?.players[0].socketId).toBe(
+          'socket-new',
+        );
+        expect(gameStateRepository.update).toHaveBeenCalledWith(
+          roomId,
+          expect.objectContaining({
+            players: [expect.objectContaining({ playerId: 'player-1' })],
+          }),
+        );
       });
 
       it('should preserve host status when the room host replaces a COM placeholder', async () => {

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -40,6 +40,18 @@ describe('Reconnection Token Management', () => {
         findByRoomId: jest.fn(),
         create: jest.fn(),
         update: jest.fn().mockResolvedValue({} as GameState),
+        persistRoomRoster: jest
+          .fn()
+          .mockImplementation(
+            async (
+              _roomId: string,
+              _roomPlayers: RoomPlayer[],
+              state: GameState,
+            ) => ({
+              ...state,
+              version: (state.version ?? 0) + 1,
+            }),
+          ),
         delete: jest.fn(),
         updateCurrentPlayerIndex: jest.fn(),
         updatePlayers: jest.fn(),
@@ -246,6 +258,18 @@ describe('Reconnection Token Management', () => {
 
         await expect(gameStateService.loadState(roomId)).resolves.not.toThrow();
       });
+
+      it('should surface persistence failures instead of caching empty state', async () => {
+        const roomId = 'room-load-failure';
+        gameStateRepository.findByRoomId.mockRejectedValue(
+          new Error('database unavailable'),
+        );
+
+        await expect(gameStateService.loadState(roomId)).rejects.toThrow(
+          'database unavailable',
+        );
+        expect(gameStateRepository.create).not.toHaveBeenCalled();
+      });
     });
 
     describe('reconcileWaitingRoomPlayers', () => {
@@ -288,12 +312,14 @@ describe('Reconnection Token Management', () => {
         expect(gameStateService.findPlayerByReconnectToken('user-1')).toEqual(
           expect.objectContaining({ playerId: 'seat-1' }),
         );
-        expect(gameStateRepository.update).toHaveBeenCalledWith(
+        expect(gameStateRepository.persistRoomRoster).toHaveBeenCalledWith(
           roomId,
+          roomPlayers,
           expect.objectContaining({
             players: gameStateService.getState().players,
             teamAssignments: { 'seat-1': 1 },
           }),
+          'seat-1',
         );
       });
     });
@@ -360,6 +386,18 @@ describe('Reconnection Token Management', () => {
         findByRoomId: jest.fn(),
         create: jest.fn(),
         update: jest.fn().mockResolvedValue({} as GameState),
+        persistRoomRoster: jest
+          .fn()
+          .mockImplementation(
+            async (
+              _roomId: string,
+              _roomPlayers: RoomPlayer[],
+              state: GameState,
+            ) => ({
+              ...state,
+              version: (state.version ?? 0) + 1,
+            }),
+          ),
         delete: jest.fn(),
         updateCurrentPlayerIndex: jest.fn(),
         updatePlayers: jest.fn(),
@@ -497,11 +535,66 @@ describe('Reconnection Token Management', () => {
         }
       });
 
+      gameStateRepository.persistRoomRoster.mockImplementation(
+        async (roomId, roomPlayers, state, hostId) => {
+          if (persistedRoom?.id === roomId) {
+            persistedRoom = cloneRoom({
+              ...persistedRoom,
+              hostId: hostId ?? persistedRoom.hostId,
+              players: roomPlayers.map((player) => ({
+                ...player,
+                socketId: '',
+              })),
+            });
+          }
+          return {
+            ...state,
+            version: (state.version ?? 0) + 1,
+          };
+        },
+      );
+
       return {
         getPersistedRoom: () =>
           persistedRoom ? cloneRoom(persistedRoom) : null,
       };
     };
+
+    it('does not overwrite current gameplay when updating roster metadata', async () => {
+      const player = makeGamePlayer('player-1', 'Player 1', 0, {
+        hand: ['stale-card'],
+      });
+      bindRoomRepositoryToState({
+        ...baseRoom,
+        players: [
+          {
+            ...player,
+            socketId: 'socket-1',
+            isReady: true,
+            isHost: true,
+            joinedAt: new Date(),
+          },
+        ],
+      });
+      const gameState = await roomService.getRoomGameState(baseRoom.id);
+      gameState.getState().players = [
+        {
+          ...player,
+          hand: ['current-card'],
+        },
+      ];
+
+      await roomService.updatePlayerInRoom(baseRoom.id, player.playerId, {
+        team: 1,
+      });
+
+      expect(gameState.getState().players[0]).toEqual(
+        expect.objectContaining({
+          team: 1,
+          hand: ['current-card'],
+        }),
+      );
+    });
 
     describe('convertPlayerToCOM', () => {
       it('should convert player to com and save to vacantSeats', async () => {
@@ -534,20 +627,10 @@ describe('Reconnection Token Management', () => {
 
         expect(result).toBe(true);
 
-        expect(roomRepository.removePlayer).toHaveBeenCalledWith(
-          roomId,
-          playerId,
-        );
-
-        expect(roomRepository.addPlayer).toHaveBeenCalled();
-
-        // Verify com player was created
-        /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-        const addPlayerCall = (roomRepository.addPlayer as jest.Mock).mock
-          .calls[0][1];
-        expect(addPlayerCall.playerId).toContain('com-');
-        expect(addPlayerCall.name).toBe('COM');
-        /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+        const persistedRoster =
+          gameStateRepository.persistRoomRoster.mock.calls[0][1];
+        expect(persistedRoster[0].playerId).toContain('com-');
+        expect(persistedRoster[0].name).toBe('COM');
       });
 
       it('should keep reconnectToken when converting to com', async () => {
@@ -986,19 +1069,15 @@ describe('Reconnection Token Management', () => {
 
         expect(result).toBe(true);
         expect(roomRepository.addPlayer).not.toHaveBeenCalled();
-        expect(roomRepository.updatePlayer).toHaveBeenCalledWith(
+        expect(roomRepository.updatePlayer).not.toHaveBeenCalled();
+        expect(roomState.getPersistedRoom()?.players[0].socketId).toBe('');
+        expect(gameStateRepository.persistRoomRoster).toHaveBeenCalledWith(
           roomId,
-          'player-1',
-          expect.objectContaining({ socketId: 'socket-new' }),
-        );
-        expect(roomState.getPersistedRoom()?.players[0].socketId).toBe(
-          'socket-new',
-        );
-        expect(gameStateRepository.update).toHaveBeenCalledWith(
-          roomId,
+          [expect.objectContaining({ playerId: 'player-1' })],
           expect.objectContaining({
             players: [expect.objectContaining({ playerId: 'player-1' })],
           }),
+          'player-1',
         );
       });
 
@@ -1017,6 +1096,7 @@ describe('Reconnection Token Management', () => {
           team: 0,
           hand: [],
           isPasser: false,
+          isCOM: true,
           hasBroken: false,
           hasRequiredBroken: false,
           isReady: false,
@@ -1037,13 +1117,17 @@ describe('Reconnection Token Management', () => {
         const result = await roomService.joinRoom(roomId, hostUser);
 
         expect(result).toBe(true);
-        expect(roomRepository.addPlayer.mock.calls).toContainEqual([
+        expect(gameStateRepository.persistRoomRoster).toHaveBeenCalledWith(
           roomId,
-          expect.objectContaining({
-            playerId: 'player-1',
-            isHost: true,
-          }),
-        ]);
+          [
+            expect.objectContaining({
+              playerId: 'player-1',
+              isHost: true,
+            }),
+          ],
+          expect.any(Object),
+          'player-1',
+        );
       });
 
       it('should normalize duplicate host flags based on room.hostId', async () => {
@@ -1744,11 +1828,26 @@ describe('Reconnection Token Management', () => {
           isHost: false,
           joinedAt: new Date(),
         };
+        const comPlayer2: RoomPlayer = {
+          ...leavingPlayer,
+          socketId: 'com-2',
+          playerId: 'com-2',
+          name: 'COM',
+          team: 0,
+          isCOM: true,
+          isReady: false,
+        };
+        const comPlayer3: RoomPlayer = {
+          ...comPlayer2,
+          socketId: 'com-3',
+          playerId: 'com-3',
+          team: 1,
+        };
 
         const room: Room = {
           ...baseRoom,
           status: RoomStatus.WAITING,
-          players: [hostPlayer, leavingPlayer],
+          players: [hostPlayer, comPlayer2, comPlayer3, leavingPlayer],
         };
 
         const roomState = bindRoomRepositoryToState(room);
@@ -1772,18 +1871,41 @@ describe('Reconnection Token Management', () => {
             hasBroken: false,
             hasRequiredBroken: false,
           },
+          makeGamePlayer(
+            comPlayer2.playerId,
+            comPlayer2.name,
+            comPlayer2.team,
+            {
+              isCOM: true,
+              isPasser: true,
+            },
+          ),
+          makeGamePlayer(
+            comPlayer3.playerId,
+            comPlayer3.name,
+            comPlayer3.team,
+            {
+              isCOM: true,
+              isPasser: true,
+            },
+          ),
         ];
         gameState.getState().teamAssignments = {
           [hostPlayer.playerId]: hostPlayer.team,
           [leavingPlayer.playerId]: leavingPlayer.team,
+          [comPlayer2.playerId]: comPlayer2.team,
+          [comPlayer3.playerId]: comPlayer3.team,
         };
 
         await roomService.leaveRoom(roomId, playerId);
 
         const updatedRoom = roomState.getPersistedRoom();
         const replacementCom = updatedRoom?.players.find(
-          (player) => player.isCOM,
+          (player) => player.playerId === 'com-1',
         );
+        expect(
+          new Set(updatedRoom?.players.map((player) => player.playerId)).size,
+        ).toBe(4);
         expect(replacementCom?.team).toBe(1);
         expect(gameState.getState().players[1].playerId).toBe(
           replacementCom?.playerId,
@@ -1887,11 +2009,6 @@ describe('Reconnection Token Management', () => {
 
         await roomService.leaveRoom(roomId, playerId);
 
-        const replacementCom = roomRepository.addPlayer.mock.calls[0]?.[1] as
-          | RoomPlayer
-          | undefined;
-        expect(replacementCom?.isCOM).toBe(true);
-        expect(replacementCom?.isPasser).toBe(false);
         expect(gameState.getState().players[0].isCOM).toBe(true);
         expect(gameState.getState().players[0].isPasser).toBe(false);
       });

--- a/mei-tra-backend/src/services/com-autoplay-recovery.service.ts
+++ b/mei-tra-backend/src/services/com-autoplay-recovery.service.ts
@@ -1,0 +1,338 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { IRoomService } from './interfaces/room-service.interface';
+import {
+  ComAutoPlayResponse,
+  IComAutoPlayUseCase,
+} from '../use-cases/interfaces/com-autoplay-use-case.interface';
+import {
+  CompleteFieldResponse,
+  ICompleteFieldUseCase,
+} from '../use-cases/interfaces/complete-field.use-case.interface';
+import { CompleteFieldTrigger } from '../use-cases/interfaces/play-card.use-case.interface';
+import { GatewayEvent } from '../use-cases/interfaces/gateway-event.interface';
+import { BROKEN_HAND_REVEAL_PENDING_TTL_MS } from '../use-cases/helpers/broken-hand.helper';
+
+const COM_AUTO_PLAY_RETRY_DELAY_MS = 5_000;
+const COM_AUTO_PLAY_CONTINUE_DELAY_MS = 2_000;
+const MAX_COM_AUTO_PLAY_RETRY_DELAY_MS = 60_000;
+
+export interface ComAutoPlayRecoveryHandlers {
+  dispatchEvents(events?: GatewayEvent[]): void;
+  processFieldCompletion(
+    roomId: string,
+    response: CompleteFieldResponse,
+  ): Promise<void>;
+}
+
+@Injectable()
+export class ComAutoPlayRecoveryService {
+  private readonly logger = new Logger(ComAutoPlayRecoveryService.name);
+  private readonly activeRooms = new Set<string>();
+  private readonly pendingReruns = new Set<string>();
+  private readonly retryTimeouts = new Map<string, NodeJS.Timeout>();
+  private readonly fieldCompletionTimeouts = new Map<string, NodeJS.Timeout>();
+  private readonly retryAttempts = new Map<string, number>();
+  private readonly roomGenerations = new Map<string, number>();
+
+  constructor(
+    @Inject('IRoomService')
+    private readonly roomService: IRoomService,
+    @Inject('IComAutoPlayUseCase')
+    private readonly comAutoPlayUseCase: IComAutoPlayUseCase,
+    @Inject('ICompleteFieldUseCase')
+    private readonly completeFieldUseCase: ICompleteFieldUseCase,
+  ) {}
+
+  trigger(roomId: string, handlers: ComAutoPlayRecoveryHandlers): void {
+    if (this.activeRooms.has(roomId)) {
+      this.pendingReruns.add(roomId);
+      return;
+    }
+
+    this.clearRetry(roomId);
+    this.activeRooms.add(roomId);
+    const generation = this.getRoomGeneration(roomId);
+
+    void (async () => {
+      const recoveredInterruptedProgress = await this.resumeInterruptedProgress(
+        roomId,
+        handlers,
+        generation,
+      );
+      if (
+        !recoveredInterruptedProgress &&
+        this.isCurrentGeneration(roomId, generation)
+      ) {
+        await this.runAutoPlayStep(roomId, handlers, generation);
+      }
+    })()
+      .catch((error) => {
+        if (!this.isCurrentGeneration(roomId, generation)) {
+          return;
+        }
+        this.logger.error(
+          `COM auto-play recovery failed for room ${roomId}`,
+          error instanceof Error ? error.stack : String(error),
+        );
+        this.scheduleRetry(roomId, handlers);
+      })
+      .finally(() => {
+        this.activeRooms.delete(roomId);
+        if (this.pendingReruns.delete(roomId)) {
+          this.trigger(roomId, handlers);
+        }
+      });
+  }
+
+  scheduleFieldCompletion(
+    trigger: CompleteFieldTrigger,
+    handlers: ComAutoPlayRecoveryHandlers,
+  ): void {
+    if (this.fieldCompletionTimeouts.has(trigger.roomId)) {
+      return;
+    }
+
+    const generation = this.getRoomGeneration(trigger.roomId);
+    const timeout = setTimeout(() => {
+      this.fieldCompletionTimeouts.delete(trigger.roomId);
+      if (!this.isCurrentGeneration(trigger.roomId, generation)) {
+        return;
+      }
+      void this.completeFieldUseCase
+        .execute({ roomId: trigger.roomId, field: trigger.field })
+        .then((response) =>
+          this.handleFieldCompletionResponse(
+            trigger.roomId,
+            response,
+            handlers,
+            generation,
+          ),
+        )
+        .catch((error) => {
+          if (!this.isCurrentGeneration(trigger.roomId, generation)) {
+            return;
+          }
+          this.logger.error(
+            `Error completing field in room ${trigger.roomId}`,
+            error instanceof Error ? error.stack : String(error),
+          );
+          this.scheduleRetry(trigger.roomId, handlers);
+        });
+    }, trigger.delayMs);
+
+    this.fieldCompletionTimeouts.set(trigger.roomId, timeout);
+  }
+
+  clearRoom(roomId: string): void {
+    this.roomGenerations.set(roomId, this.getRoomGeneration(roomId) + 1);
+    this.clearRetry(roomId);
+    const fieldCompletionTimeout = this.fieldCompletionTimeouts.get(roomId);
+    if (fieldCompletionTimeout) {
+      clearTimeout(fieldCompletionTimeout);
+      this.fieldCompletionTimeouts.delete(roomId);
+    }
+    this.pendingReruns.delete(roomId);
+    this.retryAttempts.delete(roomId);
+  }
+
+  private async resumeInterruptedProgress(
+    roomId: string,
+    handlers: ComAutoPlayRecoveryHandlers,
+    generation: number,
+  ): Promise<boolean> {
+    const roomGameState = await this.roomService.getRoomGameState(roomId);
+    if (!this.isCurrentGeneration(roomId, generation)) {
+      return true;
+    }
+    const state = roomGameState.getState();
+    const currentField = state.playState?.currentField;
+
+    if (
+      state.gamePhase === 'play' &&
+      currentField?.isComplete &&
+      currentField.cards.length === 4
+    ) {
+      if (!this.fieldCompletionTimeouts.has(roomId)) {
+        const response = await this.completeFieldUseCase.execute({
+          roomId,
+          field: {
+            ...currentField,
+            cards: [...currentField.cards],
+            playedBy: [...(currentField.playedBy ?? [])],
+          },
+        });
+        await this.handleFieldCompletionResponse(
+          roomId,
+          response,
+          handlers,
+          generation,
+        );
+      }
+      return true;
+    }
+
+    const pendingReveal = state.pendingBrokenHandReveal;
+    if (state.gamePhase === 'blow' && pendingReveal) {
+      const retryDelay = Math.max(
+        100,
+        pendingReveal.startedAt +
+          BROKEN_HAND_REVEAL_PENDING_TTL_MS -
+          Date.now() +
+          100,
+      );
+      this.scheduleContinuation(roomId, handlers, retryDelay);
+      return true;
+    }
+
+    return false;
+  }
+
+  private async runAutoPlayStep(
+    roomId: string,
+    handlers: ComAutoPlayRecoveryHandlers,
+    generation: number,
+  ): Promise<void> {
+    const result = await this.comAutoPlayUseCase.execute({ roomId });
+    if (!this.isCurrentGeneration(roomId, generation)) {
+      return;
+    }
+
+    if (!result.success) {
+      this.logger.error(`COM auto-play failed: ${result.error}`);
+      this.scheduleRetry(roomId, handlers);
+      return;
+    }
+
+    this.retryAttempts.delete(roomId);
+    handlers.dispatchEvents(result.events);
+    handlers.dispatchEvents(result.delayedEvents);
+
+    if (result.completeFieldTrigger) {
+      this.scheduleFieldCompletion(result.completeFieldTrigger, handlers);
+      return;
+    }
+
+    const maxDelay = this.getMaxEventDelay(result);
+    if (maxDelay > 0) {
+      this.scheduleContinuation(roomId, handlers, maxDelay + 100);
+      return;
+    }
+
+    if (result.shouldContinue) {
+      this.scheduleContinuation(
+        roomId,
+        handlers,
+        COM_AUTO_PLAY_CONTINUE_DELAY_MS,
+      );
+    }
+  }
+
+  private async handleFieldCompletionResponse(
+    roomId: string,
+    response: CompleteFieldResponse,
+    handlers: ComAutoPlayRecoveryHandlers,
+    generation: number,
+  ): Promise<void> {
+    if (!this.isCurrentGeneration(roomId, generation)) {
+      return;
+    }
+    await handlers.processFieldCompletion(roomId, response);
+    if (!this.isCurrentGeneration(roomId, generation)) {
+      return;
+    }
+
+    if (!response.success) {
+      this.scheduleRetry(roomId, handlers);
+      return;
+    }
+
+    if (response.gameOver) {
+      this.retryAttempts.delete(roomId);
+      return;
+    }
+
+    this.retryAttempts.delete(roomId);
+    const maxDelay = this.getMaxEventDelay(response);
+    if (maxDelay > 0) {
+      this.scheduleContinuation(roomId, handlers, maxDelay + 100);
+      return;
+    }
+
+    this.trigger(roomId, handlers);
+  }
+
+  private getMaxEventDelay(
+    response: Pick<
+      ComAutoPlayResponse | CompleteFieldResponse,
+      'delayedEvents'
+    >,
+  ): number {
+    return (response.delayedEvents ?? []).reduce(
+      (maxDelay, event) => Math.max(maxDelay, event.delayMs ?? 0),
+      0,
+    );
+  }
+
+  private scheduleRetry(
+    roomId: string,
+    handlers: ComAutoPlayRecoveryHandlers,
+    delayMs: number = COM_AUTO_PLAY_RETRY_DELAY_MS,
+  ): void {
+    if (this.retryTimeouts.has(roomId)) {
+      return;
+    }
+
+    const attempt = (this.retryAttempts.get(roomId) ?? 0) + 1;
+    this.retryAttempts.set(roomId, attempt);
+    const retryDelay = Math.min(
+      delayMs * 2 ** (attempt - 1),
+      MAX_COM_AUTO_PLAY_RETRY_DELAY_MS,
+    );
+    this.scheduleTrigger(roomId, handlers, retryDelay);
+  }
+
+  private scheduleContinuation(
+    roomId: string,
+    handlers: ComAutoPlayRecoveryHandlers,
+    delayMs: number,
+  ): void {
+    this.retryAttempts.delete(roomId);
+    this.scheduleTrigger(roomId, handlers, delayMs);
+  }
+
+  private scheduleTrigger(
+    roomId: string,
+    handlers: ComAutoPlayRecoveryHandlers,
+    delayMs: number,
+  ): void {
+    if (this.retryTimeouts.has(roomId)) {
+      return;
+    }
+
+    const generation = this.getRoomGeneration(roomId);
+    const timeout = setTimeout(() => {
+      this.retryTimeouts.delete(roomId);
+      if (!this.isCurrentGeneration(roomId, generation)) {
+        return;
+      }
+      this.trigger(roomId, handlers);
+    }, delayMs);
+    this.retryTimeouts.set(roomId, timeout);
+  }
+
+  private clearRetry(roomId: string): void {
+    const timeout = this.retryTimeouts.get(roomId);
+    if (timeout) {
+      clearTimeout(timeout);
+      this.retryTimeouts.delete(roomId);
+    }
+  }
+
+  private getRoomGeneration(roomId: string): number {
+    return this.roomGenerations.get(roomId) ?? 0;
+  }
+
+  private isCurrentGeneration(roomId: string, generation: number): boolean {
+    return this.getRoomGeneration(roomId) === generation;
+  }
+}

--- a/mei-tra-backend/src/services/com-session.service.ts
+++ b/mei-tra-backend/src/services/com-session.service.ts
@@ -99,6 +99,7 @@ export class ComSessionService {
       (player) => player.isCOM && !player.isReady,
     ).length;
     const slotsToFill = capacity - actualCount - placeholderCount;
+    let rosterChanged = false;
 
     for (let i = 0; i < slotsToFill; i++) {
       const idx = actualCount + placeholderCount + i;
@@ -110,11 +111,24 @@ export class ComSessionService {
       ).length;
       const team = (team0Count <= team1Count ? 0 : 1) as Team;
       const placeholder = this.createCOMPlaceholder(idx, team);
-      await this.roomRepository.addPlayer(roomId, placeholder);
+      const addSuccess = await this.roomRepository.addPlayer(
+        roomId,
+        placeholder,
+      );
+      if (!addSuccess) {
+        throw new Error(
+          `Failed to persist COM placeholder ${placeholder.playerId}`,
+        );
+      }
       room.players.push(placeholder);
       state.players.push(toDomainPlayer(placeholder));
       state.teamAssignments[placeholder.playerId] = placeholder.team;
       gameState.registerPlayerToken(placeholder.playerId, placeholder.playerId);
+      rosterChanged = true;
+    }
+
+    if (rosterChanged) {
+      await gameState.persistRoster();
     }
   }
 

--- a/mei-tra-backend/src/services/com-session.service.ts
+++ b/mei-tra-backend/src/services/com-session.service.ts
@@ -1,5 +1,4 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
-import { IRoomRepository } from '../repositories/interfaces/room.repository.interface';
+import { Inject, Injectable } from '@nestjs/common';
 import { DomainPlayer, Team } from '../types/game.types';
 import { toDomainPlayer, toRoomPlayer } from '../types/player-adapters';
 import { Room, RoomPlayer } from '../types/room.types';
@@ -21,11 +20,7 @@ export type VacantSeats = Record<
 
 @Injectable()
 export class ComSessionService {
-  private readonly logger = new Logger(ComSessionService.name);
-
   constructor(
-    @Inject('IRoomRepository')
-    private readonly roomRepository: IRoomRepository,
     @Inject('IComPlayerService')
     private readonly comPlayerService: IComPlayerService,
     private readonly playerReferenceRemapper: PlayerReferenceRemapperService,
@@ -92,6 +87,7 @@ export class ComSessionService {
     room: Room,
     gameState: GameStateService,
   ): Promise<void> {
+    void roomId;
     const state = gameState.getState();
     const capacity = room.settings?.maxPlayers ?? 4;
     const actualCount = room.players.filter((player) => !player.isCOM).length;
@@ -111,15 +107,6 @@ export class ComSessionService {
       ).length;
       const team = (team0Count <= team1Count ? 0 : 1) as Team;
       const placeholder = this.createCOMPlaceholder(idx, team);
-      const addSuccess = await this.roomRepository.addPlayer(
-        roomId,
-        placeholder,
-      );
-      if (!addSuccess) {
-        throw new Error(
-          `Failed to persist COM placeholder ${placeholder.playerId}`,
-        );
-      }
       room.players.push(placeholder);
       state.players.push(toDomainPlayer(placeholder));
       state.teamAssignments[placeholder.playerId] = placeholder.team;
@@ -128,34 +115,35 @@ export class ComSessionService {
     }
 
     if (rosterChanged) {
-      await gameState.persistRoster();
+      await gameState.persistRoster(room.players, room.hostId);
     }
   }
 
   async fillVacantSeatsWithCOM(
     roomId: string,
     room: Room,
-    gameState?: GameStateService,
+    gameState: GameStateService,
   ): Promise<void> {
+    void roomId;
     const lobbyComPlaceholders = room.players.filter((player) => player.isCOM);
 
-    await Promise.all(
-      lobbyComPlaceholders.map(async (comPlaceholder) => {
-        await this.roomRepository.removePlayer(roomId, comPlaceholder.playerId);
-        room.players = room.players.filter(
-          (player) => player.playerId !== comPlaceholder.playerId,
-        );
-        if (gameState) {
-          const state = gameState.getState();
-          state.players = state.players.filter(
-            (player) => player.playerId !== comPlaceholder.playerId,
-          );
-        }
-      }),
+    const placeholderIds = new Set(
+      lobbyComPlaceholders.map((player) => player.playerId),
     );
+    room.players = room.players.filter(
+      (player) => !placeholderIds.has(player.playerId),
+    );
+    const state = gameState.getState();
+    state.players = state.players.filter(
+      (player) => !placeholderIds.has(player.playerId),
+    );
+    placeholderIds.forEach((playerId) => {
+      delete state.teamAssignments[playerId];
+    });
 
     const maxPlayers = room.settings?.maxPlayers ?? 4;
     if (room.players.length >= maxPlayers) {
+      await gameState.persistRoster(room.players, room.hostId);
       return;
     }
 
@@ -184,34 +172,23 @@ export class ComSessionService {
         joinedAt: new Date(),
       });
 
-      const addResult = await this.roomRepository.addPlayer(
-        roomId,
-        roomComPlayer,
-      );
-      if (!addResult) {
-        this.logger.error(
-          `Failed to add COM player ${roomComPlayer.playerId} to room ${roomId}`,
-        );
-        throw new Error(`Failed to add COM player ${roomComPlayer.playerId}`);
-      }
-
       room.players.push(roomComPlayer);
-      if (gameState) {
-        const state = gameState.getState();
-        state.players.push(toDomainPlayer(comPlayer));
-        gameState.registerPlayerToken(
-          roomComPlayer.playerId,
-          roomComPlayer.playerId,
-        );
-      }
+      state.players.push(toDomainPlayer(comPlayer));
+      state.teamAssignments[roomComPlayer.playerId] = roomComPlayer.team;
+      gameState.registerPlayerToken(
+        roomComPlayer.playerId,
+        roomComPlayer.playerId,
+      );
     }
+
+    await gameState.persistRoster(room.players, room.hostId);
   }
 
   async convertPlayerToCOM(
     roomId: string,
     playerId: string,
     room: Room,
-    gameState: GameStateService | undefined,
+    gameState: GameStateService,
     vacantSeats: VacantSeats,
   ): Promise<boolean> {
     const playerIndex = room.players.findIndex(
@@ -225,10 +202,10 @@ export class ComSessionService {
       vacantSeats[roomId] = {};
     }
 
-    const state = gameState?.getState();
-    const gsIndex = state
-      ? state.players.findIndex((player) => player.playerId === playerId)
-      : -1;
+    const state = gameState.getState();
+    const gsIndex = state.players.findIndex(
+      (player) => player.playerId === playerId,
+    );
 
     const originalHand = room.players[playerIndex].hand ?? [];
     const uniqueIdx = `timeout-${playerIndex}-${Date.now()}`;
@@ -241,7 +218,7 @@ export class ComSessionService {
     vacantSeats[roomId][playerIndex] = {
       roomPlayer: this.cloneRoomPlayer(room.players[playerIndex]),
       gamePlayer:
-        gsIndex !== -1 && state
+        gsIndex !== -1
           ? this.cloneGamePlayer(state.players[gsIndex])
           : undefined,
       replacementPlayerId: comPlayer.playerId,
@@ -249,30 +226,26 @@ export class ComSessionService {
 
     room.players[playerIndex] = comPlayer;
 
-    await this.roomRepository.removePlayer(roomId, playerId);
-    await this.roomRepository.addPlayer(roomId, comPlayer);
-
-    if (gameState && state) {
-      if (gsIndex !== -1) {
-        const originalGameHand = state.players[gsIndex].hand ?? [];
-        const comGamePlayer = this.createActiveCOMReplacement(
-          uniqueIdx,
-          state.players[gsIndex],
-          [...originalGameHand],
-        );
-        state.players[gsIndex] = toDomainPlayer(comGamePlayer);
-        this.playerReferenceRemapper.remapGameStatePlayerIdReferences(
-          state,
-          playerId,
-          comGamePlayer.playerId,
-        );
-        if (state.teamAssignments[playerId] != null) {
-          delete state.teamAssignments[playerId];
-        }
-        state.teamAssignments[comGamePlayer.playerId] = comGamePlayer.team;
+    if (gsIndex !== -1) {
+      const originalGameHand = state.players[gsIndex].hand ?? [];
+      const comGamePlayer = this.createActiveCOMReplacement(
+        uniqueIdx,
+        state.players[gsIndex],
+        [...originalGameHand],
+      );
+      state.players[gsIndex] = toDomainPlayer(comGamePlayer);
+      this.playerReferenceRemapper.remapGameStatePlayerIdReferences(
+        state,
+        playerId,
+        comGamePlayer.playerId,
+      );
+      if (state.teamAssignments[playerId] != null) {
+        delete state.teamAssignments[playerId];
       }
+      state.teamAssignments[comGamePlayer.playerId] = comGamePlayer.team;
     }
 
+    await gameState.persistRoster(room.players, room.hostId);
     return true;
   }
 }

--- a/mei-tra-backend/src/services/game-state-manager.service.ts
+++ b/mei-tra-backend/src/services/game-state-manager.service.ts
@@ -5,6 +5,7 @@ import {
   GameState,
   PlayerConnectionMetadata,
 } from '../types/game.types';
+import { RoomPlayer } from '../types/room.types';
 import { GamePhaseService } from './game-phase.service';
 
 export class GameStateManager {
@@ -32,11 +33,15 @@ export class GameStateManager {
     };
 
     if (roomId) {
-      try {
-        await this.repository.update(roomId, newState);
-      } catch {
-        // Keep in-memory state even if persistence fails.
+      const persistedState = await this.repository.update(
+        roomId,
+        newState,
+        currentState.version,
+      );
+      if (!persistedState) {
+        throw new Error(`Game state not found for room ${roomId}`);
       }
+      nextState.version = persistedState.version;
     }
 
     return nextState;
@@ -62,54 +67,69 @@ export class GameStateManager {
 
       await this.repository.create(roomId, initialState);
       return null;
-    } catch {
-      return null;
+    } catch (error) {
+      this.logger.error(`Failed to load game state for room ${roomId}`, error);
+      throw error;
     }
   }
 
   async configureGameSettings(
     roomId: string | null,
+    currentState: GameState,
     pointsToWin: number,
-  ): Promise<void> {
+  ): Promise<GameState> {
     if (!roomId) {
-      return;
+      return { ...currentState, pointsToWin };
     }
 
-    try {
-      await this.repository.update(roomId, { pointsToWin });
-    } catch {
-      // Silent fail
+    const persistedState = await this.repository.update(
+      roomId,
+      { pointsToWin },
+      currentState.version,
+    );
+    if (!persistedState) {
+      throw new Error(`Game state not found for room ${roomId}`);
     }
+    return persistedState;
   }
 
-  async saveState(roomId: string | null, state: GameState): Promise<void> {
+  async saveState(roomId: string | null, state: GameState): Promise<GameState> {
     if (!roomId) {
-      return;
+      return state;
     }
 
-    try {
-      await this.repository.update(roomId, state);
-    } catch {
-      // Silent fail
+    const persistedState = await this.repository.update(
+      roomId,
+      state,
+      state.version,
+    );
+    if (!persistedState) {
+      throw new Error(`Game state not found for room ${roomId}`);
     }
+    return persistedState;
   }
 
   async persistRoster(
     roomId: string | null,
-    state: Pick<GameState, 'players' | 'teamAssignments'>,
-  ): Promise<void> {
+    roomPlayers: RoomPlayer[],
+    state: GameState,
+    hostId?: string,
+  ): Promise<GameState> {
     if (!roomId) {
       throw new Error('Cannot persist roster without a room ID');
     }
 
-    const persistedState = await this.repository.update(roomId, {
-      players: state.players,
-      teamAssignments: state.teamAssignments,
-    });
+    const persistedState = await this.repository.persistRoomRoster(
+      roomId,
+      roomPlayers,
+      state,
+      hostId,
+    );
 
     if (!persistedState) {
       throw new Error(`Game state not found for room ${roomId}`);
     }
+    return persistedState;
   }
 
   async persistPlayerConnectionUpdate(
@@ -130,32 +150,42 @@ export class GameStateManager {
 
   async persistCurrentPlayerIndex(
     roomId: string | null,
+    state: GameState,
     currentPlayerIndex: number,
-  ): Promise<void> {
+  ): Promise<number | undefined> {
     if (!roomId) {
-      return;
+      return state.version;
     }
 
-    try {
-      await this.repository.updateCurrentPlayerIndex(
-        roomId,
-        currentPlayerIndex,
-      );
-    } catch (error) {
-      this.logger.error('Failed to persist turn change:', error);
+    const persistedState = await this.repository.update(
+      roomId,
+      { currentPlayerIndex },
+      state.version,
+    );
+    if (!persistedState) {
+      throw new Error(`Game state not found for room ${roomId}`);
     }
+    return persistedState.version;
   }
 
-  persistRoundNumber(roomId: string | null, roundNumber: number): void {
+  async persistRoundNumber(
+    roomId: string | null,
+    state: GameState,
+    roundNumber: number,
+  ): Promise<number | undefined> {
     if (!roomId) {
-      return;
+      return state.version;
     }
 
-    this.repository
-      .bulkUpdate(roomId, { round_number: roundNumber })
-      .catch((error) => {
-        this.logger.error('Failed to persist round number:', error);
-      });
+    const persistedState = await this.repository.update(
+      roomId,
+      { roundNumber },
+      state.version,
+    );
+    if (!persistedState) {
+      throw new Error(`Game state not found for room ${roomId}`);
+    }
+    return persistedState.version;
   }
 
   async resetState(roomId: string | null, state: GameState): Promise<void> {

--- a/mei-tra-backend/src/services/game-state-manager.service.ts
+++ b/mei-tra-backend/src/services/game-state-manager.service.ts
@@ -94,6 +94,24 @@ export class GameStateManager {
     }
   }
 
+  async persistRoster(
+    roomId: string | null,
+    state: Pick<GameState, 'players' | 'teamAssignments'>,
+  ): Promise<void> {
+    if (!roomId) {
+      throw new Error('Cannot persist roster without a room ID');
+    }
+
+    const persistedState = await this.repository.update(roomId, {
+      players: state.players,
+      teamAssignments: state.teamAssignments,
+    });
+
+    if (!persistedState) {
+      throw new Error(`Game state not found for room ${roomId}`);
+    }
+  }
+
   async persistPlayerConnectionUpdate(
     roomId: string | null,
     playerId: string,

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -37,6 +37,7 @@ export class GameStateService implements IGameStateService {
   private readonly playerIds: Map<string, string>;
   private readonly disconnectedPlayers: Map<string, NodeJS.Timeout>;
   private readonly gamePhaseService: GamePhaseService;
+  private persistenceQueue: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly cardService: CardService,
@@ -62,6 +63,7 @@ export class GameStateService implements IGameStateService {
 
   private initializeState(pointsToWin: number = 10): void {
     this.state = {
+      version: 0,
       players: [],
       deck: [],
       currentPlayerIndex: 0,
@@ -207,19 +209,24 @@ export class GameStateService implements IGameStateService {
     return this.connectionManager.upsertSessionUser(sessionUser);
   }
 
+  private enqueuePersistence<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.persistenceQueue.then(operation, operation);
+    this.persistenceQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
   async updateState(newState: Partial<GameState>): Promise<void> {
-    this.state = await this.stateManager.updateState(
-      this.roomId,
-      this.state,
-      newState,
+    this.state = await this.enqueuePersistence(() =>
+      this.stateManager.updateState(this.roomId, this.state, newState),
     );
   }
 
   async transitionPhase(nextPhase: GamePhase): Promise<void> {
-    this.state = await this.stateManager.transitionPhase(
-      this.roomId,
-      this.state,
-      nextPhase,
+    this.state = await this.enqueuePersistence(() =>
+      this.stateManager.transitionPhase(this.roomId, this.state, nextPhase),
     );
   }
 
@@ -234,7 +241,7 @@ export class GameStateService implements IGameStateService {
 
       const sanitized = this.sanitizePlayers();
       if (sanitized) {
-        await this.stateManager.updateState(roomId, this.state, {
+        this.state = await this.stateManager.updateState(roomId, this.state, {
           players: this.state.players,
           currentPlayerIndex: this.state.currentPlayerIndex,
         });
@@ -252,16 +259,33 @@ export class GameStateService implements IGameStateService {
   }
 
   async configureGameSettings(pointsToWin: number): Promise<void> {
-    this.state.pointsToWin = pointsToWin;
-    await this.stateManager.configureGameSettings(this.roomId, pointsToWin);
+    this.state = await this.enqueuePersistence(() =>
+      this.stateManager.configureGameSettings(
+        this.roomId,
+        this.state,
+        pointsToWin,
+      ),
+    );
   }
 
   async saveState(): Promise<void> {
-    await this.stateManager.saveState(this.roomId, this.state);
+    this.state = await this.enqueuePersistence(() =>
+      this.stateManager.saveState(this.roomId, this.state),
+    );
   }
 
-  async persistRoster(): Promise<void> {
-    await this.stateManager.persistRoster(this.roomId, this.state);
+  async persistRoster(
+    roomPlayers: RoomPlayer[],
+    hostId?: string,
+  ): Promise<void> {
+    this.state = await this.enqueuePersistence(() =>
+      this.stateManager.persistRoster(
+        this.roomId,
+        roomPlayers,
+        this.state,
+        hostId,
+      ),
+    );
   }
 
   async reconcileWaitingRoomPlayers(roomPlayers: RoomPlayer[]): Promise<void> {
@@ -300,7 +324,8 @@ export class GameStateService implements IGameStateService {
       }
     });
 
-    await this.persistRoster();
+    const hostId = roomPlayers.find((player) => player.isHost)?.playerId;
+    await this.persistRoster(roomPlayers, hostId);
   }
 
   addPlayer(
@@ -513,9 +538,12 @@ export class GameStateService implements IGameStateService {
     // Persist the turn change
     if (this.roomId) {
       try {
-        await this.stateManager.persistCurrentPlayerIndex(
-          this.roomId,
-          this.state.currentPlayerIndex,
+        this.state.version = await this.enqueuePersistence(() =>
+          this.stateManager.persistCurrentPlayerIndex(
+            this.roomId,
+            this.state,
+            this.state.currentPlayerIndex,
+          ),
         );
       } catch {
         // Keep in-memory turn changes even if persistence fails.
@@ -575,10 +603,7 @@ export class GameStateService implements IGameStateService {
     return currentPlayer?.playerId === playerId;
   }
 
-  async completeField(
-    field: Field,
-    winnerId: string,
-  ): Promise<CompletedField | null> {
+  completeField(field: Field, winnerId: string): CompletedField | null {
     const state = this.getState();
     if (!state.playState) {
       return null;
@@ -593,16 +618,13 @@ export class GameStateService implements IGameStateService {
     const winnerTeam =
       state.players.find((p) => p.playerId === winnerId)?.team ?? (0 as const);
     const completedField: CompletedField = {
-      cards: field.cards,
+      cards: [...field.cards],
       winnerId: winnerId,
       winnerTeam,
       dealerId: field.dealerId,
     };
 
     state.playState.fields.push(completedField);
-
-    // Persist the completed field
-    await this.saveState();
 
     return completedField;
   }
@@ -611,7 +633,9 @@ export class GameStateService implements IGameStateService {
     this.initializeState();
 
     // Clear persisted state
-    await this.stateManager.resetState(this.roomId, this.state);
+    await this.enqueuePersistence(() =>
+      this.stateManager.resetState(this.roomId, this.state),
+    );
   }
 
   async resetRoundState(): Promise<void> {
@@ -640,7 +664,15 @@ export class GameStateService implements IGameStateService {
 
   set roundNumber(value: number) {
     this.state.roundNumber = value;
-    void this.stateManager.persistRoundNumber(this.roomId, value);
+    void this.enqueuePersistence(() =>
+      this.stateManager.persistRoundNumber(this.roomId, this.state, value),
+    )
+      .then((version) => {
+        this.state.version = version;
+      })
+      .catch((error) => {
+        this.logger.error('Failed to persist round number:', error);
+      });
   }
 
   get currentTurn(): string | null {
@@ -654,10 +686,19 @@ export class GameStateService implements IGameStateService {
     );
     if (playerIndex !== -1) {
       this.state.currentPlayerIndex = playerIndex;
-      void this.stateManager.persistCurrentPlayerIndex(
-        this.roomId,
-        playerIndex,
-      );
+      void this.enqueuePersistence(() =>
+        this.stateManager.persistCurrentPlayerIndex(
+          this.roomId,
+          this.state,
+          playerIndex,
+        ),
+      )
+        .then((version) => {
+          this.state.version = version;
+        })
+        .catch((error) => {
+          this.logger.error('Failed to persist turn change:', error);
+        });
     }
   }
 

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -20,6 +20,7 @@ import { PlayerConnectionManager } from './player-connection-manager.service';
 import { GamePhaseService } from './game-phase.service';
 import { PlayerConnectionState, SessionUser } from '../types/session.types';
 import {
+  toDomainPlayer,
   toRuntimePlayer,
   toTransportPlayers,
   TransportPlayer,
@@ -257,6 +258,49 @@ export class GameStateService implements IGameStateService {
 
   async saveState(): Promise<void> {
     await this.stateManager.saveState(this.roomId, this.state);
+  }
+
+  async persistRoster(): Promise<void> {
+    await this.stateManager.persistRoster(this.roomId, this.state);
+  }
+
+  async reconcileWaitingRoomPlayers(roomPlayers: RoomPlayer[]): Promise<void> {
+    const currentPlayers = new Map(
+      this.state.players.map((player) => [player.playerId, player]),
+    );
+
+    this.state.players = roomPlayers.map((roomPlayer) => {
+      const currentPlayer = currentPlayers.get(roomPlayer.playerId);
+      if (!currentPlayer) {
+        return toDomainPlayer(roomPlayer);
+      }
+
+      return toDomainPlayer({
+        ...roomPlayer,
+        hand: currentPlayer.hand,
+        isPasser: currentPlayer.isPasser,
+        hasBroken: currentPlayer.hasBroken,
+        hasRequiredBroken: currentPlayer.hasRequiredBroken,
+      });
+    });
+    this.state.teamAssignments = Object.fromEntries(
+      roomPlayers.map((player) => [player.playerId, player.team]),
+    );
+
+    roomPlayers.forEach((player) => {
+      this.connectionManager.registerPlayerToken(
+        player.playerId,
+        player.playerId,
+      );
+      if (player.userId) {
+        this.connectionManager.registerPlayerToken(
+          player.userId,
+          player.playerId,
+        );
+      }
+    });
+
+    await this.persistRoster();
   }
 
   addPlayer(

--- a/mei-tra-backend/src/services/interfaces/game-state-service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/game-state-service.interface.ts
@@ -1,5 +1,6 @@
 import { DomainPlayer } from '../../types/game.types';
 import { PlayerConnectionState, SessionUser } from '../../types/session.types';
+import { RoomPlayer } from '../../types/room.types';
 
 export interface IGameStateService {
   addPlayer(
@@ -30,4 +31,6 @@ export interface IGameStateService {
     connectionState: PlayerConnectionState,
   ): Promise<void>;
   getPlayerConnectionState(playerId: string): PlayerConnectionState | null;
+  persistRoster(): Promise<void>;
+  reconcileWaitingRoomPlayers(roomPlayers: RoomPlayer[]): Promise<void>;
 }

--- a/mei-tra-backend/src/services/interfaces/game-state-service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/game-state-service.interface.ts
@@ -31,6 +31,6 @@ export interface IGameStateService {
     connectionState: PlayerConnectionState,
   ): Promise<void>;
   getPlayerConnectionState(playerId: string): PlayerConnectionState | null;
-  persistRoster(): Promise<void>;
+  persistRoster(roomPlayers: RoomPlayer[], hostId?: string): Promise<void>;
   reconcileWaitingRoomPlayers(roomPlayers: RoomPlayer[]): Promise<void>;
 }

--- a/mei-tra-backend/src/services/interfaces/room-service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/room-service.interface.ts
@@ -23,6 +23,10 @@ export interface IRoomService {
     playerId: string,
     updates: Partial<RoomPlayer>,
   ): Promise<boolean>;
+  updatePlayersInRoom(
+    roomId: string,
+    updatesByPlayerId: Record<string, Partial<RoomPlayer>>,
+  ): Promise<boolean>;
   canStartGame(roomId: string): Promise<{ canStart: boolean; reason?: string }>;
   getRoomGameState(roomId: string): Promise<GameStateService>;
   convertPlayerToCOM(roomId: string, playerId: string): Promise<boolean>;

--- a/mei-tra-backend/src/services/room-join.service.ts
+++ b/mei-tra-backend/src/services/room-join.service.ts
@@ -39,15 +39,65 @@ export class RoomJoinService {
   }: JoinRoomParams): Promise<boolean> {
     const state = gameState.getState();
 
-    if (this.countActualPlayers(room.players) >= room.settings.maxPlayers) {
-      return false;
-    }
-
     const existingPlayer = room.players.find(
       (player) => player.playerId === user.playerId,
     );
     if (existingPlayer) {
+      const statePlayer = state.players.find(
+        (player) => player.playerId === existingPlayer.playerId,
+      );
+      const isWaitingRoom =
+        state.gamePhase === null || state.gamePhase === 'waiting';
+      if (!statePlayer && !isWaitingRoom) {
+        return false;
+      }
+
+      const updatedPlayer: RoomPlayer = {
+        ...existingPlayer,
+        ...user,
+        userId: user.userId ?? existingPlayer.userId,
+        isAuthenticated: user.isAuthenticated ?? existingPlayer.isAuthenticated,
+      };
+      const updateSuccess = await this.roomRepository.updatePlayer(
+        roomId,
+        existingPlayer.playerId,
+        updatedPlayer,
+      );
+      if (!updateSuccess) {
+        return false;
+      }
+
+      Object.assign(existingPlayer, updatedPlayer);
+      if (statePlayer) {
+        statePlayer.name = updatedPlayer.name;
+        statePlayer.team = updatedPlayer.team;
+      } else {
+        state.players.push(toDomainPlayer(updatedPlayer));
+      }
+      state.teamAssignments[updatedPlayer.playerId] = updatedPlayer.team;
+
+      gameState.registerPlayerToken(
+        updatedPlayer.playerId,
+        updatedPlayer.playerId,
+      );
+      if (updatedPlayer.userId) {
+        gameState.registerPlayerToken(
+          updatedPlayer.userId,
+          updatedPlayer.playerId,
+        );
+      }
+      await gameState.applyPlayerConnectionState(updatedPlayer.playerId, {
+        socketId: updatedPlayer.socketId,
+        userId: updatedPlayer.userId,
+        isAuthenticated: updatedPlayer.isAuthenticated,
+      });
+      await gameState.persistRoster();
+      await this.roomRepository.updateLastActivity(roomId);
       return true;
+    }
+
+    if (this.countActualPlayers(room.players) >= room.settings.maxPlayers) {
+      return false;
     }
 
     const roomVacant = vacantSeats[roomId] || {};
@@ -284,6 +334,15 @@ export class RoomJoinService {
     state.teamAssignments[player.playerId] = player.team;
 
     gameState.registerPlayerToken(player.playerId, player.playerId);
+    if (player.userId) {
+      gameState.registerPlayerToken(player.userId, player.playerId);
+    }
+    await gameState.applyPlayerConnectionState(player.playerId, {
+      socketId: player.socketId,
+      userId: player.userId,
+      isAuthenticated: player.isAuthenticated,
+    });
+    await gameState.persistRoster();
 
     await this.roomRepository.updateLastActivity(roomId);
     return true;

--- a/mei-tra-backend/src/services/room-join.service.ts
+++ b/mei-tra-backend/src/services/room-join.service.ts
@@ -1,5 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
-import { IRoomRepository } from '../repositories/interfaces/room.repository.interface';
+import { Injectable } from '@nestjs/common';
 import { DomainPlayer, Team } from '../types/game.types';
 import { toDomainPlayer } from '../types/player-adapters';
 import { Room, RoomPlayer } from '../types/room.types';
@@ -25,8 +24,6 @@ interface RestoredSeatData {
 @Injectable()
 export class RoomJoinService {
   constructor(
-    @Inject('IRoomRepository')
-    private readonly roomRepository: IRoomRepository,
     private readonly playerReferenceRemapperService: PlayerReferenceRemapperService,
   ) {}
 
@@ -37,6 +34,7 @@ export class RoomJoinService {
     user,
     vacantSeats,
   }: JoinRoomParams): Promise<boolean> {
+    void roomId;
     const state = gameState.getState();
 
     const existingPlayer = room.players.find(
@@ -58,15 +56,6 @@ export class RoomJoinService {
         userId: user.userId ?? existingPlayer.userId,
         isAuthenticated: user.isAuthenticated ?? existingPlayer.isAuthenticated,
       };
-      const updateSuccess = await this.roomRepository.updatePlayer(
-        roomId,
-        existingPlayer.playerId,
-        updatedPlayer,
-      );
-      if (!updateSuccess) {
-        return false;
-      }
-
       Object.assign(existingPlayer, updatedPlayer);
       if (statePlayer) {
         statePlayer.name = updatedPlayer.name;
@@ -91,8 +80,7 @@ export class RoomJoinService {
         userId: updatedPlayer.userId,
         isAuthenticated: updatedPlayer.isAuthenticated,
       });
-      await gameState.persistRoster();
-      await this.roomRepository.updateLastActivity(roomId);
+      await gameState.persistRoster(room.players, room.hostId);
       return true;
     }
 
@@ -248,19 +236,6 @@ export class RoomJoinService {
         : new Date(),
     };
 
-    if (replacingComId) {
-      await this.roomRepository.removePlayer(roomId, replacingComId);
-      const addSuccess = await this.roomRepository.addPlayer(roomId, player);
-      if (!addSuccess) {
-        return false;
-      }
-    } else {
-      const addSuccess = await this.roomRepository.addPlayer(roomId, player);
-      if (!addSuccess) {
-        return false;
-      }
-    }
-
     if (assignedIndex !== -1) {
       room.players[assignedIndex] = player;
     } else {
@@ -342,9 +317,7 @@ export class RoomJoinService {
       userId: player.userId,
       isAuthenticated: player.isAuthenticated,
     });
-    await gameState.persistRoster();
-
-    await this.roomRepository.updateLastActivity(roomId);
+    await gameState.persistRoster(room.players, room.hostId);
     return true;
   }
 

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -76,22 +76,15 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     this.comSessionService =
       comSessionService ??
       new ComSessionService(
-        this.roomRepository,
         this.comPlayerService,
         this.playerReferenceRemapperService,
       );
     this.seatRestorationService =
       seatRestorationService ??
-      new SeatRestorationService(
-        this.roomRepository,
-        this.playerReferenceRemapperService,
-      );
+      new SeatRestorationService(this.playerReferenceRemapperService);
     this.roomJoinService =
       roomJoinService ??
-      new RoomJoinService(
-        this.roomRepository,
-        this.playerReferenceRemapperService,
-      );
+      new RoomJoinService(this.playerReferenceRemapperService);
     // 定期的なクリーンアップを開始
     this.startCleanupTask();
   }
@@ -357,7 +350,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     const room = await this.getRoom(roomId);
     if (!room) return;
 
-    const gameState = this.roomGameStates.get(roomId);
+    const gameState = await this.getRoomGameState(roomId);
     await this.comSessionService.fillVacantSeatsWithCOM(
       roomId,
       room,
@@ -372,7 +365,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
   async convertPlayerToCOM(roomId: string, playerId: string): Promise<boolean> {
     const room = await this.getRoom(roomId);
     if (!room) return false;
-    const gameState = this.roomGameStates.get(roomId);
+    const gameState = await this.getRoomGameState(roomId);
     return this.comSessionService.convertPlayerToCOM(
       roomId,
       playerId,
@@ -442,10 +435,6 @@ export class RoomService implements IRoomService, OnModuleDestroy {
 
         room.players[playerIndex] = comPlayer;
 
-        // データベースでは元のプレイヤーを削除してCOMプレイヤーを追加
-        await this.roomRepository.removePlayer(roomId, playerId);
-        await this.roomRepository.addPlayer(roomId, comPlayer);
-
         // ゲーム状態も同時に更新（手札を引き継ぐ）
         if (gsIndex !== -1) {
           const originalGameHand = state.players[gsIndex].hand ?? [];
@@ -477,16 +466,15 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       );
       if (playerIndex !== -1) {
         const leavingPlayer = room.players[playerIndex];
+        const state = gameState.getState();
+        const gsIndex = state.players.findIndex((p) => p.playerId === playerId);
+        const seatIndex = gsIndex !== -1 ? gsIndex : playerIndex;
         const comPlaceholder = this.createCOMPlaceholder(
-          playerIndex,
+          seatIndex,
           leavingPlayer.team,
         );
         room.players[playerIndex] = comPlaceholder;
-        await this.roomRepository.removePlayer(roomId, playerId);
-        await this.roomRepository.addPlayer(roomId, comPlaceholder);
 
-        const state = gameState.getState();
-        const gsIndex = state.players.findIndex((p) => p.playerId === playerId);
         if (gsIndex !== -1) {
           state.players[gsIndex] = toDomainPlayer(comPlaceholder);
           if (state.teamAssignments[playerId] != null) {
@@ -499,9 +487,6 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       gameState.removePlayerToken(playerId);
     }
 
-    // ゲーム状態をDBに保存（COMプレイヤーへの置き換えを永続化）
-    await gameState.saveState();
-
     // If all players are COM placeholders (no human players), delete the room
     if (room.players.every((p) => p.isCOM === true)) {
       await this.deleteRoom(roomId);
@@ -513,18 +498,13 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       const newHost = room.players.find((p) => !p.isCOM);
       if (newHost) {
         room.hostId = newHost.playerId;
-        newHost.isHost = true;
-        // データベースのホスト情報も更新
-        await this.roomRepository.updatePlayer(roomId, newHost.playerId, {
-          isHost: true,
-        });
-        // ルームのhostIdのみ更新（プレイヤー情報は再取得しない）
-        await this.roomRepository.update(roomId, { hostId: newHost.playerId });
       }
     }
 
-    // アクティビティ時刻のみ更新（プレイヤー情報の再取得を避ける）
-    await this.updateRoomActivity(roomId);
+    room.players.forEach((player) => {
+      player.isHost = player.playerId === room.hostId;
+    });
+    await gameState.persistRoster(room.players, room.hostId);
     return true;
   }
 
@@ -561,7 +541,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
         this.vacantSeats,
       );
     if (restored) {
-      await this.updateRoomActivity(roomId);
+      this.logger.log(`Restored player ${playerId} in room ${roomId}`);
     }
     return restored;
   }
@@ -587,7 +567,66 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     playerId: string,
     updates: Partial<RoomPlayer>,
   ): Promise<boolean> {
-    return this.roomRepository.updatePlayer(roomId, playerId, updates);
+    return this.updatePlayersInRoom(roomId, { [playerId]: updates });
+  }
+
+  async updatePlayersInRoom(
+    roomId: string,
+    updatesByPlayerId: Record<string, Partial<RoomPlayer>>,
+  ): Promise<boolean> {
+    const room = await this.getRoom(roomId);
+    if (!room) {
+      return false;
+    }
+
+    const gameState = await this.getRoomGameState(roomId);
+    const state = gameState.getState();
+
+    for (const [playerId, updates] of Object.entries(updatesByPlayerId)) {
+      const roomPlayer = room.players.find(
+        (player) => player.playerId === playerId,
+      );
+      if (!roomPlayer) {
+        return false;
+      }
+
+      Object.assign(roomPlayer, updates);
+      if (updates.isHost === true) {
+        room.hostId = playerId;
+      }
+
+      const statePlayerIndex = state.players.findIndex(
+        (player) => player.playerId === playerId,
+      );
+      if (statePlayerIndex === -1) {
+        state.players.push(toDomainPlayer(roomPlayer));
+      } else {
+        const statePlayer = state.players[statePlayerIndex];
+        state.players[statePlayerIndex] = toDomainPlayer({
+          ...statePlayer,
+          ...(updates.name !== undefined && { name: updates.name }),
+          ...(updates.team !== undefined && { team: updates.team }),
+          ...(updates.isCOM !== undefined && { isCOM: updates.isCOM }),
+          ...(updates.hand !== undefined && { hand: [...updates.hand] }),
+          ...(updates.isPasser !== undefined && {
+            isPasser: updates.isPasser,
+          }),
+          ...(updates.hasBroken !== undefined && {
+            hasBroken: updates.hasBroken,
+          }),
+          ...(updates.hasRequiredBroken !== undefined && {
+            hasRequiredBroken: updates.hasRequiredBroken,
+          }),
+        });
+      }
+      state.teamAssignments[playerId] = roomPlayer.team;
+    }
+
+    room.players.forEach((player) => {
+      player.isHost = player.playerId === room.hostId;
+    });
+    await gameState.persistRoster(room.players, room.hostId);
+    return true;
   }
 
   private isValidStatusTransition(
@@ -699,7 +738,14 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       roomPlayerUpdates.isAuthenticated = connectionState.isAuthenticated;
     }
 
-    await this.roomRepository.updatePlayer(roomId, playerId, roomPlayerUpdates);
+    const updated = await this.updatePlayerInRoom(
+      roomId,
+      playerId,
+      roomPlayerUpdates,
+    );
+    if (!updated) {
+      return { success: false, error: 'Failed to persist player connection' };
+    }
 
     return { success: true };
   }

--- a/mei-tra-backend/src/services/seat-restoration.service.ts
+++ b/mei-tra-backend/src/services/seat-restoration.service.ts
@@ -1,5 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
-import { IRoomRepository } from '../repositories/interfaces/room.repository.interface';
+import { Injectable } from '@nestjs/common';
 import { DomainPlayer } from '../types/game.types';
 import { toDomainPlayer } from '../types/player-adapters';
 import { Room, RoomPlayer } from '../types/room.types';
@@ -10,8 +9,6 @@ import { VacantSeats } from './com-session.service';
 @Injectable()
 export class SeatRestorationService {
   constructor(
-    @Inject('IRoomRepository')
-    private readonly roomRepository: IRoomRepository,
     private readonly playerReferenceRemapper: PlayerReferenceRemapperService,
   ) {}
 
@@ -67,17 +64,6 @@ export class SeatRestorationService {
     };
 
     room.players[currentSeatIndex] = restoredRoomPlayer;
-
-    await this.roomRepository.removePlayer(roomId, comPlayerId);
-    const addSuccess = await this.roomRepository.addPlayer(
-      roomId,
-      restoredRoomPlayer,
-    );
-    if (!addSuccess) {
-      await this.roomRepository.addPlayer(roomId, currentSeatPlayer);
-      room.players[currentSeatIndex] = currentSeatPlayer;
-      return false;
-    }
 
     const state = gameState.getState();
     const gsIndex = state.players.findIndex(
@@ -139,6 +125,7 @@ export class SeatRestorationService {
       delete vacantSeats[roomId];
     }
 
+    await gameState.persistRoster(room.players, room.hostId);
     return true;
   }
 }

--- a/mei-tra-backend/src/types/database.types.ts
+++ b/mei-tra-backend/src/types/database.types.ts
@@ -68,6 +68,7 @@ export interface Database {
           has_required_broken: boolean;
           is_ready: boolean;
           is_host: boolean;
+          is_com: boolean;
           joined_at: string;
           user_id: string | null;
         };
@@ -84,6 +85,7 @@ export interface Database {
           has_required_broken?: boolean;
           is_ready?: boolean;
           is_host?: boolean;
+          is_com?: boolean;
           joined_at?: string;
           user_id?: string | null;
         };
@@ -100,6 +102,7 @@ export interface Database {
           has_required_broken?: boolean;
           is_ready?: boolean;
           is_host?: boolean;
+          is_com?: boolean;
           joined_at?: string;
           user_id?: string | null;
         };
@@ -124,6 +127,7 @@ export interface Database {
             }>;
           };
           team_assignments: { [key: string]: number };
+          version: number;
           created_at: string;
           updated_at: string;
         };
@@ -146,6 +150,7 @@ export interface Database {
             }>;
           };
           team_assignments?: { [key: string]: number };
+          version?: number;
           created_at?: string;
           updated_at?: string;
         };
@@ -168,6 +173,7 @@ export interface Database {
             }>;
           };
           team_assignments?: { [key: string]: number };
+          version?: number;
           created_at?: string;
           updated_at?: string;
         };

--- a/mei-tra-backend/src/types/game.types.ts
+++ b/mei-tra-backend/src/types/game.types.ts
@@ -125,6 +125,7 @@ export interface ChomboViolation {
 export type GamePhase = 'deal' | 'blow' | 'play' | 'waiting' | null;
 
 export interface GameState {
+  version?: number;
   players: DomainPlayer[];
   currentPlayerIndex: number;
   gamePhase: GamePhase;

--- a/mei-tra-backend/src/types/player-adapters.spec.ts
+++ b/mei-tra-backend/src/types/player-adapters.spec.ts
@@ -1,4 +1,4 @@
-import { toRuntimePlayer } from './player-adapters';
+import { toPersistedPlayerStates, toRuntimePlayer } from './player-adapters';
 
 describe('player-adapters', () => {
   describe('toRuntimePlayer', () => {
@@ -25,6 +25,35 @@ describe('player-adapters', () => {
       });
 
       expect(player).toBeNull();
+    });
+  });
+
+  describe('toPersistedPlayerStates', () => {
+    it('persists gameplay fields without duplicating player identity', () => {
+      const states = toPersistedPlayerStates([
+        {
+          playerId: 'player-1',
+          name: 'Player 1',
+          hand: ['S1'],
+          team: 1,
+          isPasser: true,
+          isCOM: false,
+          hasBroken: true,
+          hasRequiredBroken: false,
+        },
+      ]);
+
+      expect(states).toEqual({
+        'player-1': {
+          hand: ['S1'],
+          isPasser: true,
+          hasBroken: true,
+          hasRequiredBroken: false,
+        },
+      });
+      expect(states['player-1']).not.toHaveProperty('name');
+      expect(states['player-1']).not.toHaveProperty('team');
+      expect(states['player-1']).not.toHaveProperty('isCOM');
     });
   });
 });

--- a/mei-tra-backend/src/types/player-adapters.ts
+++ b/mei-tra-backend/src/types/player-adapters.ts
@@ -10,6 +10,18 @@ export type PersistedGamePlayer = DomainPlayer & {
   id?: string;
 };
 
+export interface PersistedPlayerGameplayState {
+  hand: string[];
+  isPasser: boolean;
+  hasBroken: boolean;
+  hasRequiredBroken: boolean;
+}
+
+export type PersistedPlayerStates = Record<
+  string,
+  PersistedPlayerGameplayState
+>;
+
 export type TransportPlayer = DomainPlayer &
   PlayerConnectionMetadata & {
     isHost?: boolean;
@@ -90,6 +102,22 @@ export function toPersistedGamePlayer(
   return {
     ...toDomainPlayer(player),
   };
+}
+
+export function toPersistedPlayerStates(
+  players: DomainPlayer[],
+): PersistedPlayerStates {
+  return Object.fromEntries(
+    players.map((player) => [
+      player.playerId,
+      {
+        hand: [...player.hand],
+        isPasser: player.isPasser,
+        hasBroken: player.hasBroken ?? false,
+        hasRequiredBroken: player.hasRequiredBroken ?? false,
+      },
+    ]),
+  );
 }
 
 export function toRuntimePlayer(

--- a/mei-tra-backend/src/use-cases/__tests__/create-room-with-chat.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/create-room-with-chat.spec.ts
@@ -63,6 +63,7 @@ describe('CreateRoomUseCase', () => {
       getRoomGameState: jest.fn(),
       updateRoomStatus: jest.fn(),
       updatePlayerInRoom: jest.fn(),
+      updatePlayersInRoom: jest.fn(),
       updateRoom: jest.fn(),
       deleteRoom: jest.fn(),
       releaseRoomResources: jest.fn(),

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -49,6 +49,7 @@ describe('Game Use Cases', () => {
       updateRoomStatus: jest.fn(),
       fillVacantSeatsWithCOM: jest.fn(),
       updatePlayerInRoom: jest.fn(),
+      updatePlayersInRoom: jest.fn().mockResolvedValue(true),
       canStartGame: jest.fn(),
       createNewRoom: jest.fn(),
       leaveRoom: jest.fn(),
@@ -1083,7 +1084,7 @@ describe('Game Use Cases', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Each team must have at most 2 players');
-      expect(roomService.updatePlayerInRoom).not.toHaveBeenCalled();
+      expect(roomService.updatePlayersInRoom).not.toHaveBeenCalled();
     });
 
     it('applies valid team changes', async () => {
@@ -1116,10 +1117,8 @@ describe('Game Use Cases', () => {
 
       expect(result.success).toBe(true);
 
-      const updatePlayerInRoomMock =
-        roomService.updatePlayerInRoom as jest.Mock;
-      expect(updatePlayerInRoomMock).toHaveBeenCalledWith(room.id, 'player-2', {
-        team: 0,
+      expect(roomService.updatePlayersInRoom).toHaveBeenCalledWith(room.id, {
+        'player-2': { team: 0 },
       });
       expect(
         result.updatedRoom?.players.find((p) => p.playerId === 'player-2')

--- a/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
@@ -5,52 +5,79 @@ import { RoomStatus } from '../../types/room.types';
 import { UserProfile } from '../../types/user.types';
 
 describe('ReconnectionUseCase', () => {
-  it('returns active game payload for authenticated reconnection', async () => {
-    const roomService = {
-      getRoomGameState: jest.fn().mockResolvedValue({
-        findSessionUserByUserId: jest.fn().mockReturnValue(null),
-        findSessionUserByPlayerId: jest.fn().mockReturnValue(null),
-        findPlayerByActorId: jest.fn().mockReturnValue({ playerId: 'p1' }),
-        findPlayerByUserId: jest.fn().mockReturnValue({ playerId: 'p1' }),
-        getState: () => ({
-          players: [
-            { playerId: 'p1', hand: ['A♠'], socketId: '', userId: 'user-1' },
-            {
-              playerId: 'p2',
-              hand: ['K♠'],
-              socketId: 'socket-2',
-              userId: 'user-2',
-            },
-          ],
-          gamePhase: 'play',
-          currentPlayerIndex: 0,
-          blowState: {
-            declarations: [],
-            actionHistory: [],
-            currentTrump: null,
-            currentHighestDeclaration: null,
-            lastPasser: null,
-            isRoundCancelled: false,
-            currentBlowIndex: 0,
+  it('uses the persisted room player mapping after an active-game restart', async () => {
+    const roomGameState = {
+      findSessionUserByUserId: jest.fn().mockReturnValue(null),
+      findSessionUserByPlayerId: jest.fn().mockReturnValue(null),
+      findPlayerByActorId: jest.fn().mockReturnValue(null),
+      getState: () => ({
+        players: [
+          {
+            playerId: 'seat-1',
+            name: 'User 1',
+            team: 0,
+            hand: ['A♠'],
+            isPasser: false,
+            hasBroken: false,
+            hasRequiredBroken: false,
           },
-          playState: {
-            currentField: null,
-            negriCard: null,
-            neguri: {},
-            fields: [],
-            lastWinnerId: null,
-            openDeclared: false,
-            openDeclarerId: null,
+          {
+            playerId: 'p2',
+            name: 'User 2',
+            team: 1,
+            hand: ['K♠'],
+            isPasser: false,
+            hasBroken: false,
+            hasRequiredBroken: false,
           },
-          teamScores: { 0: { play: 0, total: 0 }, 1: { play: 0, total: 0 } },
-          pointsToWin: 10,
-        }),
+        ],
+        gamePhase: 'play',
+        currentPlayerIndex: 0,
+        blowState: {
+          declarations: [],
+          actionHistory: [],
+          currentTrump: null,
+          currentHighestDeclaration: null,
+          lastPasser: null,
+          isRoundCancelled: false,
+          currentBlowIndex: 0,
+        },
+        playState: {
+          currentField: null,
+          negriCard: null,
+          neguri: {},
+          fields: [],
+          lastWinnerId: null,
+          openDeclared: false,
+          openDeclarerId: null,
+        },
+        teamScores: { 0: { play: 0, total: 0 }, 1: { play: 0, total: 0 } },
+        pointsToWin: 10,
       }),
+    };
+    const roomService = {
+      getRoomGameState: jest.fn().mockResolvedValue(roomGameState),
       getRoom: jest.fn().mockResolvedValue({
         id: 'room-1',
-        hostId: 'p1',
+        hostId: 'seat-1',
         status: RoomStatus.PLAYING,
-        players: [],
+        players: [
+          {
+            playerId: 'seat-1',
+            socketId: 'stale-socket',
+            userId: 'user-1',
+            isAuthenticated: true,
+            name: 'User 1',
+            hand: ['A♠'],
+            team: 0,
+            isReady: true,
+            isHost: true,
+            isPasser: false,
+            hasBroken: false,
+            hasRequiredBroken: false,
+            joinedAt: new Date(),
+          },
+        ],
       }),
       handlePlayerReconnection: jest.fn().mockResolvedValue({ success: true }),
       listRooms: jest.fn().mockResolvedValue([]),
@@ -92,18 +119,25 @@ describe('ReconnectionUseCase', () => {
       expect.objectContaining({
         success: true,
         mode: 'active-game',
-        reconnectToken: 'p1',
+        reconnectToken: 'seat-1',
       }),
+    );
+    expect(roomGameState.findPlayerByActorId).not.toHaveBeenCalled();
+    expect(roomService.handlePlayerReconnection).toHaveBeenCalledWith(
+      'room-1',
+      'seat-1',
+      'socket-1',
+      'user-1',
     );
   });
 
-  it('uses session mapping first when reconnecting to a waiting room', async () => {
+  it('reconciles persisted players before reconnecting to a waiting room', async () => {
     const roomPlayers = [
       {
         playerId: 'p1',
         socketId: 'stale-socket',
-        userId: undefined,
-        isAuthenticated: false,
+        userId: 'user-1',
+        isAuthenticated: true,
         name: 'User 1',
         hand: [],
         team: 0,
@@ -114,14 +148,9 @@ describe('ReconnectionUseCase', () => {
       },
     ];
     const roomGameState = {
-      findSessionUserByUserId: jest.fn().mockReturnValue({
-        playerId: 'p1',
-        socketId: 'stale-socket',
-        userId: 'user-1',
-        isAuthenticated: true,
-        name: 'User 1',
-      }),
+      findSessionUserByUserId: jest.fn().mockReturnValue(null),
       findSessionUserByPlayerId: jest.fn().mockReturnValue(null),
+      reconcileWaitingRoomPlayers: jest.fn().mockResolvedValue(undefined),
       getState: () => ({
         players: [],
         gamePhase: 'waiting',
@@ -184,6 +213,15 @@ describe('ReconnectionUseCase', () => {
       'p1',
       'socket-1',
       'user-1',
+    );
+    expect(roomGameState.reconcileWaitingRoomPlayers).toHaveBeenCalledWith(
+      roomPlayers,
+    );
+    expect(
+      roomGameState.reconcileWaitingRoomPlayers.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      (roomService.initCOMPlaceholders as jest.Mock).mock
+        .invocationCallOrder[0],
     );
     expect(result).toEqual(
       expect.objectContaining({

--- a/mei-tra-backend/src/use-cases/__tests__/shuffle-teams.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/shuffle-teams.use-case.spec.ts
@@ -29,7 +29,7 @@ describe('ShuffleTeamsUseCase', () => {
         .fn()
         .mockResolvedValueOnce(room)
         .mockResolvedValueOnce(updatedRoom),
-      updatePlayerInRoom: jest.fn().mockResolvedValue(true),
+      updatePlayersInRoom: jest.fn().mockResolvedValue(true),
     } as Partial<IRoomService> as IRoomService;
     const fillWithComUseCase = {
       execute: jest.fn().mockResolvedValue({ success: true, updatedRoom }),
@@ -43,13 +43,13 @@ describe('ShuffleTeamsUseCase', () => {
 
     expect(result.success).toBe(true);
     expect(fillWithComUseCase.execute).toHaveBeenCalled();
-    expect(roomService.updatePlayerInRoom).toHaveBeenCalledTimes(4);
-    const updateCalls = jest.mocked(roomService.updatePlayerInRoom).mock.calls;
-    expect(updateCalls.every(([roomId]) => roomId === 'room-1')).toBe(true);
+    expect(roomService.updatePlayersInRoom).toHaveBeenCalledTimes(1);
+    const [, updates] = jest.mocked(roomService.updatePlayersInRoom).mock
+      .calls[0];
     expect(
-      updateCalls.every(
-        ([, , updates]: [string, string, Partial<RoomPlayer>]) =>
-          updates.team === 0 || updates.team === 1,
+      Object.values(updates).every(
+        (playerUpdates: Partial<RoomPlayer>) =>
+          playerUpdates.team === 0 || playerUpdates.team === 1,
       ),
     ).toBe(true);
   });
@@ -64,7 +64,7 @@ describe('ShuffleTeamsUseCase', () => {
     };
     const roomService = {
       getRoom: jest.fn().mockResolvedValue(room),
-      updatePlayerInRoom: jest.fn(),
+      updatePlayersInRoom: jest.fn(),
     } as Partial<IRoomService> as IRoomService;
     const fillWithComUseCase = {
       execute: jest
@@ -79,7 +79,7 @@ describe('ShuffleTeamsUseCase', () => {
     });
 
     expect(result).toEqual({ success: false, error: 'fill failed' });
-    expect(roomService.updatePlayerInRoom).not.toHaveBeenCalled();
+    expect(roomService.updatePlayersInRoom).not.toHaveBeenCalled();
   });
 
   it('returns failure when any player team update fails', async () => {
@@ -97,12 +97,7 @@ describe('ShuffleTeamsUseCase', () => {
     };
     const roomService = {
       getRoom: jest.fn().mockResolvedValue(room),
-      updatePlayerInRoom: jest
-        .fn()
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(false)
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(true),
+      updatePlayersInRoom: jest.fn().mockResolvedValue(false),
     } as Partial<IRoomService> as IRoomService;
     const fillWithComUseCase = {
       execute: jest.fn(),
@@ -118,7 +113,7 @@ describe('ShuffleTeamsUseCase', () => {
       success: false,
       error: 'Failed to change teams',
     });
-    expect(roomService.updatePlayerInRoom).toHaveBeenCalledTimes(4);
+    expect(roomService.updatePlayersInRoom).toHaveBeenCalledTimes(1);
     expect(roomService.getRoom).toHaveBeenCalledTimes(1);
   });
 });

--- a/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
@@ -179,7 +179,7 @@ describe('UpdateAuthUseCase', () => {
         isAuthenticated: true,
       }),
     );
-    expect(roomGameState.saveState).toHaveBeenCalled();
+    expect(roomGameState.saveState).not.toHaveBeenCalled();
     expect(result.broadcastEvents).toContainEqual(
       expect.objectContaining({
         event: 'update-users',

--- a/mei-tra-backend/src/use-cases/change-player-team.use-case.ts
+++ b/mei-tra-backend/src/use-cases/change-player-team.use-case.ts
@@ -73,13 +73,17 @@ export class ChangePlayerTeamUseCase implements IChangePlayerTeamUseCase {
         };
       }
 
-      // Persist each team change to room_players table via updatePlayerInRoom.
-      // updateRoom() only saves rooms-table columns (name/hostId/status) and would
-      // return stale team values fetched from room_players.
-      for (const [pid, newTeam] of Object.entries(teamChanges)) {
-        await this.roomService.updatePlayerInRoom(roomId, pid, {
-          team: newTeam as Team,
-        });
+      const updated = await this.roomService.updatePlayersInRoom(
+        roomId,
+        Object.fromEntries(
+          Object.entries(teamChanges).map(([pid, newTeam]) => [
+            pid,
+            { team: newTeam as Team },
+          ]),
+        ),
+      );
+      if (!updated) {
+        return { success: false, error: 'Failed to change teams' };
       }
 
       // Re-fetch room so updatedRoom.players reflects the persisted team changes.

--- a/mei-tra-backend/src/use-cases/reconnection.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reconnection.use-case.ts
@@ -1,4 +1,7 @@
-import type { GameStatePayload } from '@contracts/game';
+import type {
+  GameStatePayload,
+  ReconnectionFailureCode,
+} from '@contracts/game';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { IRoomService } from '../services/interfaces/room-service.interface';
 import { IGameStateService } from '../services/interfaces/game-state-service.interface';
@@ -35,6 +38,7 @@ export type ReconnectionResult =
     }
   | {
       success: false;
+      code: ReconnectionFailureCode;
       reason: string;
       roomId?: string;
     };
@@ -62,6 +66,7 @@ export class ReconnectionUseCase {
       if (!room) {
         return {
           success: false,
+          code: 'roomUnavailable',
           roomId,
           reason:
             'Your previous room session is no longer available. Please join or create a room again.',
@@ -75,11 +80,25 @@ export class ReconnectionUseCase {
         state.gamePhase !== 'waiting';
 
       if (!isActiveGame) {
-        await this.roomService.initCOMPlaceholders(roomId);
+        try {
+          await roomGameState.reconcileWaitingRoomPlayers(room.players);
+          await this.roomService.initCOMPlaceholders(roomId);
+        } catch (error) {
+          this.logger.error(
+            `[Reconnection] Failed to reconcile waiting room=${roomId} user=${authenticatedUser.id}: ${String(error)}`,
+          );
+          return {
+            success: false,
+            code: 'stateInconsistent',
+            roomId,
+            reason: 'Failed to reconcile the waiting-room roster',
+          };
+        }
         const updatedRoom = await this.roomService.getRoom(roomId);
         if (!updatedRoom) {
           return {
             success: false,
+            code: 'roomUnavailable',
             roomId,
             reason:
               'Your previous room session is no longer available. Please join or create a room again.',
@@ -95,6 +114,7 @@ export class ReconnectionUseCase {
         if (!existingWaitingPlayer) {
           return {
             success: false,
+            code: 'sessionInvalid',
             roomId,
             reason:
               'Your previous room session is no longer valid. Please join or create a room again.',
@@ -108,8 +128,17 @@ export class ReconnectionUseCase {
           authenticatedUser.id,
         );
         if (!reconnectResult.success) {
+          this.logStateMismatch(
+            roomId,
+            authenticatedUser.id,
+            existingWaitingPlayer.playerId,
+            updatedRoom.players.length,
+            roomGameState.getState().players.length,
+            reconnectResult.error,
+          );
           return {
             success: false,
+            code: 'stateInconsistent',
             roomId,
             reason: 'Failed to reconnect',
           };
@@ -130,13 +159,19 @@ export class ReconnectionUseCase {
         };
       }
 
-      const existingPlayer = resolvePlayerByActorId(
-        roomGameState,
+      const persistedRoomPlayer = this.resolveAuthenticatedRoomPlayer(
+        room.players,
         authenticatedUser.id,
       );
+      const existingPlayer = persistedRoomPlayer
+        ? (state.players.find(
+            (player) => player.playerId === persistedRoomPlayer.playerId,
+          ) ?? null)
+        : resolvePlayerByActorId(roomGameState, authenticatedUser.id);
       if (!existingPlayer) {
         return {
           success: false,
+          code: persistedRoomPlayer ? 'stateInconsistent' : 'sessionInvalid',
           roomId,
           reason:
             'Your previous room session is no longer valid. Please join or create a room again.',
@@ -150,8 +185,17 @@ export class ReconnectionUseCase {
         authenticatedUser.id,
       );
       if (!reconnectResult.success) {
+        this.logStateMismatch(
+          roomId,
+          authenticatedUser.id,
+          existingPlayer.playerId,
+          room.players.length,
+          state.players.length,
+          reconnectResult.error,
+        );
         return {
           success: false,
+          code: 'stateInconsistent',
           roomId,
           reason: 'Failed to reconnect',
         };
@@ -201,6 +245,7 @@ export class ReconnectionUseCase {
       );
       return {
         success: false,
+        code: 'roomUnavailable',
         roomId,
         reason:
           'Your previous room session is no longer available. Please join or create a room again.',
@@ -254,5 +299,30 @@ export class ReconnectionUseCase {
     );
 
     return authenticatedMatches.length === 1 ? authenticatedMatches[0] : null;
+  }
+
+  private resolveAuthenticatedRoomPlayer(
+    roomPlayers: RoomPlayer[],
+    authenticatedUserId: string,
+  ): RoomPlayer | null {
+    const matches = roomPlayers.filter(
+      (player) =>
+        player.isAuthenticated && player.userId === authenticatedUserId,
+    );
+
+    return matches.length === 1 ? matches[0] : null;
+  }
+
+  private logStateMismatch(
+    roomId: string,
+    userId: string,
+    playerId: string,
+    roomPlayerCount: number,
+    statePlayerCount: number,
+    error?: string,
+  ): void {
+    this.logger.error(
+      `[Reconnection] State mismatch room=${roomId} user=${userId} player=${playerId} roomPlayers=${roomPlayerCount} statePlayers=${statePlayerCount} error=${error ?? 'unknown'}`,
+    );
   }
 }

--- a/mei-tra-backend/src/use-cases/shuffle-teams.use-case.ts
+++ b/mei-tra-backend/src/use-cases/shuffle-teams.use-case.ts
@@ -49,14 +49,18 @@ export class ShuffleTeamsUseCase {
       player.team = (idx < half ? 0 : 1) as Team;
     });
 
-    const updateResults = await Promise.all(
-      shuffled.map((player) =>
-        this.roomService.updatePlayerInRoom(request.roomId, player.playerId, {
-          team: player.team,
-        }),
+    const updated = await this.roomService.updatePlayersInRoom(
+      request.roomId,
+      Object.fromEntries(
+        shuffled.map((player) => [
+          player.playerId,
+          {
+            team: player.team,
+          },
+        ]),
       ),
     );
-    if (updateResults.some((updated) => !updated)) {
+    if (!updated) {
       return { success: false, error: 'Failed to change teams' };
     }
 

--- a/mei-tra-backend/src/use-cases/update-auth.use-case.ts
+++ b/mei-tra-backend/src/use-cases/update-auth.use-case.ts
@@ -151,7 +151,6 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
       isAuthenticated: true,
     });
 
-    await roomGameState.saveState();
     await this.roomService.updatePlayerInRoom(
       currentRoomId,
       currentPlayer.playerId,

--- a/mei-tra-backend/supabase/migrations/20260719124824_atomic_room_state_persistence.sql
+++ b/mei-tra-backend/supabase/migrations/20260719124824_atomic_room_state_persistence.sql
@@ -1,0 +1,39 @@
+alter table public.game_states
+  add column if not exists version bigint not null default 0;
+
+update public.game_states as game_state
+set state_data = coalesce(game_state.state_data, '{}'::jsonb) || jsonb_build_object(
+  'playerStates',
+  coalesce(
+    game_state.state_data->'playerStates',
+    (
+      select jsonb_object_agg(
+        player->>'playerId',
+        jsonb_build_object(
+          'hand', coalesce(player->'hand', '[]'::jsonb),
+          'isPasser', coalesce((player->>'isPasser')::boolean, false),
+          'hasBroken', coalesce((player->>'hasBroken')::boolean, false),
+          'hasRequiredBroken',
+            coalesce((player->>'hasRequiredBroken')::boolean, false)
+        )
+      )
+      from jsonb_array_elements(
+        coalesce(game_state.state_data->'players', '[]'::jsonb)
+      ) as player
+      where player ? 'playerId'
+    ),
+    '{}'::jsonb
+  ),
+  'playerOrder',
+  coalesce(
+    game_state.state_data->'playerOrder',
+    (
+      select jsonb_agg(player->>'playerId' order by ordinality)
+      from jsonb_array_elements(
+        coalesce(game_state.state_data->'players', '[]'::jsonb)
+      ) with ordinality as player_entry(player, ordinality)
+      where player ? 'playerId'
+    ),
+    '[]'::jsonb
+  )
+);

--- a/mei-tra-backend/supabase/migrations/20260719131458_atomic_update_game_state_function.sql
+++ b/mei-tra-backend/supabase/migrations/20260719131458_atomic_update_game_state_function.sql
@@ -1,0 +1,80 @@
+create or replace function public.atomic_update_game_state(
+  p_room_id uuid,
+  p_state_patch jsonb default '{}'::jsonb,
+  p_scalar_patch jsonb default '{}'::jsonb,
+  p_expected_version bigint default null
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  current_state public.game_states%rowtype;
+  updated_state public.game_states%rowtype;
+begin
+  select *
+  into current_state
+  from public.game_states
+  where room_id = p_room_id
+  for update;
+
+  if not found then
+    return null;
+  end if;
+
+  if p_expected_version is not null
+    and current_state.version <> p_expected_version then
+    raise exception 'game_state_version_conflict room=% expected=% actual=%',
+      p_room_id,
+      p_expected_version,
+      current_state.version
+      using errcode = 'PT409';
+  end if;
+
+  update public.game_states
+  set
+    state_data = coalesce(current_state.state_data, '{}'::jsonb)
+      || coalesce(p_state_patch, '{}'::jsonb),
+    current_player_index = case
+      when p_scalar_patch ? 'currentPlayerIndex'
+        then (p_scalar_patch->>'currentPlayerIndex')::integer
+      else current_state.current_player_index
+    end,
+    game_phase = case
+      when p_scalar_patch ? 'gamePhase'
+        then (p_scalar_patch->>'gamePhase')::game_phase
+      else current_state.game_phase
+    end,
+    round_number = case
+      when p_scalar_patch ? 'roundNumber'
+        then (p_scalar_patch->>'roundNumber')::integer
+      else current_state.round_number
+    end,
+    points_to_win = case
+      when p_scalar_patch ? 'pointsToWin'
+        then (p_scalar_patch->>'pointsToWin')::integer
+      else current_state.points_to_win
+    end,
+    team_scores = case
+      when p_scalar_patch ? 'teamScores'
+        then p_scalar_patch->'teamScores'
+      else current_state.team_scores
+    end,
+    team_score_records = case
+      when p_scalar_patch ? 'teamScoreRecords'
+        then p_scalar_patch->'teamScoreRecords'
+      else current_state.team_score_records
+    end,
+    team_assignments = case
+      when p_scalar_patch ? 'teamAssignments'
+        then p_scalar_patch->'teamAssignments'
+      else current_state.team_assignments
+    end,
+    version = current_state.version + 1
+  where room_id = p_room_id
+  returning * into updated_state;
+
+  return to_jsonb(updated_state);
+end;
+$$;

--- a/mei-tra-backend/supabase/migrations/20260719131459_persist_room_roster_atomic_function.sql
+++ b/mei-tra-backend/supabase/migrations/20260719131459_persist_room_roster_atomic_function.sql
@@ -1,0 +1,139 @@
+create or replace function public.persist_room_roster_atomic(
+  p_room_id uuid,
+  p_room_players jsonb,
+  p_player_states jsonb,
+  p_player_order jsonb,
+  p_legacy_players jsonb,
+  p_team_assignments jsonb,
+  p_host_id text default null,
+  p_expected_version bigint default null
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  current_state public.game_states%rowtype;
+  updated_state public.game_states%rowtype;
+begin
+  select *
+  into current_state
+  from public.game_states
+  where room_id = p_room_id
+  for update;
+
+  if not found then
+    return null;
+  end if;
+
+  if p_expected_version is not null
+    and current_state.version <> p_expected_version then
+    raise exception 'game_state_version_conflict room=% expected=% actual=%',
+      p_room_id,
+      p_expected_version,
+      current_state.version
+      using errcode = 'PT409';
+  end if;
+
+  delete from public.room_players as room_player
+  where room_player.room_id = p_room_id
+    and not exists (
+      select 1
+      from jsonb_array_elements(coalesce(p_room_players, '[]'::jsonb)) as entry
+      where entry->>'playerId' = room_player.player_id
+    );
+
+  insert into public.room_players (
+    room_id,
+    player_id,
+    socket_id,
+    user_id,
+    name,
+    hand,
+    team,
+    is_passer,
+    has_broken,
+    has_required_broken,
+    is_ready,
+    is_host,
+    is_com,
+    joined_at
+  )
+  select
+    p_room_id,
+    player."playerId",
+    null,
+    nullif(player."userId", '')::uuid,
+    player.name,
+    coalesce(p_player_states->player."playerId"->'hand', '[]'::jsonb),
+    player.team,
+    coalesce(
+      (p_player_states->player."playerId"->>'isPasser')::boolean,
+      false
+    ),
+    coalesce(
+      (p_player_states->player."playerId"->>'hasBroken')::boolean,
+      false
+    ),
+    coalesce(
+      (p_player_states->player."playerId"->>'hasRequiredBroken')::boolean,
+      false
+    ),
+    coalesce(player."isReady", false),
+    coalesce(player."isHost", false),
+    coalesce(player."isCOM", false),
+    coalesce(player."joinedAt", now())
+  from jsonb_to_recordset(coalesce(p_room_players, '[]'::jsonb)) as player(
+    "playerId" text,
+    "userId" text,
+    name text,
+    team integer,
+    "isReady" boolean,
+    "isHost" boolean,
+    "isCOM" boolean,
+    "joinedAt" timestamptz
+  )
+  on conflict (room_id, player_id) do update
+  set
+    socket_id = null,
+    user_id = excluded.user_id,
+    name = excluded.name,
+    hand = excluded.hand,
+    team = excluded.team,
+    is_passer = excluded.is_passer,
+    has_broken = excluded.has_broken,
+    has_required_broken = excluded.has_required_broken,
+    is_ready = excluded.is_ready,
+    is_host = excluded.is_host,
+    is_com = excluded.is_com,
+    joined_at = excluded.joined_at;
+
+  if p_host_id is not null then
+    update public.rooms
+    set
+      host_id = p_host_id,
+      last_activity_at = now()
+    where id = p_room_id;
+  else
+    update public.rooms
+    set last_activity_at = now()
+    where id = p_room_id;
+  end if;
+
+  update public.game_states
+  set
+    state_data = coalesce(current_state.state_data, '{}'::jsonb)
+      || jsonb_build_object(
+        'playerStates', coalesce(p_player_states, '{}'::jsonb),
+        'playerOrder', coalesce(p_player_order, '[]'::jsonb),
+        'players', coalesce(p_legacy_players, '[]'::jsonb)
+      ),
+    team_assignments = coalesce(p_team_assignments, '{}'::jsonb),
+    version = current_state.version + 1
+  where room_id = p_room_id
+  returning * into updated_state;
+
+  return to_jsonb(updated_state);
+end;
+$$;

--- a/mei-tra-backend/supabase/migrations/20260719131500_load_room_game_state_function.sql
+++ b/mei-tra-backend/supabase/migrations/20260719131500_load_room_game_state_function.sql
@@ -1,0 +1,21 @@
+create or replace function public.load_room_game_state(p_room_id uuid)
+returns jsonb
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  select jsonb_build_object(
+    'gameState', to_jsonb(game_state),
+    'roomPlayers', coalesce(
+      (
+        select jsonb_agg(to_jsonb(room_player) order by room_player.joined_at)
+        from public.room_players as room_player
+        where room_player.room_id = p_room_id
+      ),
+      '[]'::jsonb
+    )
+  )
+  from public.game_states as game_state
+  where game_state.room_id = p_room_id;
+$$;

--- a/mei-tra-backend/supabase/migrations/20260719131501_lock_down_room_state_functions.sql
+++ b/mei-tra-backend/supabase/migrations/20260719131501_lock_down_room_state_functions.sql
@@ -1,0 +1,11 @@
+do $$
+begin
+  execute 'revoke all on function public.atomic_update_game_state(uuid, jsonb, jsonb, bigint) from public, anon, authenticated';
+  execute 'revoke all on function public.persist_room_roster_atomic(uuid, jsonb, jsonb, jsonb, jsonb, jsonb, text, bigint) from public, anon, authenticated';
+  execute 'revoke all on function public.load_room_game_state(uuid) from public, anon, authenticated';
+  execute 'grant execute on function public.atomic_update_game_state(uuid, jsonb, jsonb, bigint) to service_role';
+  execute 'grant execute on function public.persist_room_roster_atomic(uuid, jsonb, jsonb, jsonb, jsonb, jsonb, text, bigint) to service_role';
+  execute 'grant execute on function public.load_room_game_state(uuid) to service_role';
+  perform pg_notify('pgrst', 'reload schema');
+end;
+$$;

--- a/mei-tra-backend/supabase/tests/atomic_room_state_concurrency.mjs
+++ b/mei-tra-backend/supabase/tests/atomic_room_state_concurrency.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL_DEV;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY_DEV;
+
+assert.ok(supabaseUrl, 'SUPABASE_URL_DEV is required');
+assert.ok(serviceRoleKey, 'SUPABASE_SERVICE_ROLE_KEY_DEV is required');
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false },
+});
+const roomId = randomUUID();
+
+try {
+  const { error: roomError } = await supabase.from('rooms').insert({
+    id: roomId,
+    name: 'Atomic concurrency test',
+    host_id: 'concurrency-host',
+  });
+  assert.ifError(roomError);
+
+  const { error: stateError } = await supabase.from('game_states').insert({
+    room_id: roomId,
+    state_data: { players: [], playerStates: {}, playerOrder: [] },
+    team_assignments: {},
+  });
+  assert.ifError(stateError);
+
+  const updateRound = (roundNumber) =>
+    supabase.rpc('atomic_update_game_state', {
+      p_room_id: roomId,
+      p_state_patch: {},
+      p_scalar_patch: { roundNumber },
+      p_expected_version: 0,
+    });
+
+  const results = await Promise.all([updateRound(2), updateRound(3)]);
+  const successfulResults = results.filter((result) => !result.error);
+  const failedResults = results.filter((result) => result.error);
+
+  assert.equal(successfulResults.length, 1, 'exactly one update must succeed');
+  assert.equal(failedResults.length, 1, 'exactly one update must conflict');
+  console.log(
+    JSON.stringify({
+      failedUpdate: failedResults[0].error,
+    }),
+  );
+  assert.equal(failedResults[0].error.code, 'PT409');
+
+  const { data: persistedState, error: readError } = await supabase
+    .from('game_states')
+    .select('version, round_number')
+    .eq('room_id', roomId)
+    .single();
+  assert.ifError(readError);
+  assert.equal(persistedState.version, 1);
+  assert.ok(
+    persistedState.round_number === 2 || persistedState.round_number === 3,
+    `unexpected round number: ${persistedState.round_number}`,
+  );
+
+  console.log(
+    JSON.stringify({
+      roomId,
+      successfulRound: persistedState.round_number,
+      conflictCode: failedResults[0].error.code,
+      version: persistedState.version,
+    }),
+  );
+} finally {
+  await supabase.from('rooms').delete().eq('id', roomId);
+}

--- a/mei-tra-backend/supabase/tests/atomic_room_state_persistence.sql
+++ b/mei-tra-backend/supabase/tests/atomic_room_state_persistence.sql
@@ -1,0 +1,168 @@
+begin;
+
+do $$
+begin
+  if has_function_privilege(
+    'anon',
+    'public.atomic_update_game_state(uuid,jsonb,jsonb,bigint)',
+    'execute'
+  ) then
+    raise exception 'anon can execute atomic_update_game_state';
+  end if;
+
+  if not has_function_privilege(
+    'service_role',
+    'public.persist_room_roster_atomic(uuid,jsonb,jsonb,jsonb,jsonb,jsonb,text,bigint)',
+    'execute'
+  ) then
+    raise exception 'service_role cannot execute persist_room_roster_atomic';
+  end if;
+end;
+$$;
+
+insert into public.rooms (id, name, host_id)
+values (
+  '00000000-0000-0000-0000-000000000901',
+  'Atomic persistence test',
+  'player-old'
+);
+
+insert into public.game_states (room_id, state_data, team_assignments)
+values (
+  '00000000-0000-0000-0000-000000000901',
+  '{"players": [], "playerStates": {}, "playerOrder": []}'::jsonb,
+  '{}'::jsonb
+);
+
+insert into public.room_players (
+  room_id,
+  player_id,
+  name,
+  team,
+  is_host
+)
+values (
+  '00000000-0000-0000-0000-000000000901',
+  'player-old',
+  'Old player',
+  0,
+  true
+);
+
+do $$
+declare
+  persisted_version bigint;
+begin
+  begin
+    perform public.persist_room_roster_atomic(
+      '00000000-0000-0000-0000-000000000901',
+      '[{"playerId":"player-new","name":"New player","isReady":true,"isHost":true,"isCOM":false}]'::jsonb,
+      '{"player-new":{"hand":[],"isPasser":false,"hasBroken":false,"hasRequiredBroken":false}}'::jsonb,
+      '["player-new"]'::jsonb,
+      '[]'::jsonb,
+      '{}'::jsonb,
+      'player-new',
+      0
+    );
+    raise exception 'Expected invalid roster write to fail';
+  exception
+    when not_null_violation then null;
+  end;
+
+  if not exists (
+    select 1
+    from public.room_players
+    where room_id = '00000000-0000-0000-0000-000000000901'
+      and player_id = 'player-old'
+  ) then
+    raise exception 'Failed roster write removed the existing player';
+  end if;
+
+  select version
+  into persisted_version
+  from public.game_states
+  where room_id = '00000000-0000-0000-0000-000000000901';
+
+  if persisted_version <> 0 then
+    raise exception 'Failed roster write changed the game state version';
+  end if;
+end;
+$$;
+
+select public.persist_room_roster_atomic(
+  '00000000-0000-0000-0000-000000000901',
+  '[{"playerId":"player-new","name":"New player","team":1,"isReady":true,"isHost":true,"isCOM":false,"joinedAt":"2026-07-19T00:00:00.000Z"}]'::jsonb,
+  '{"player-new":{"hand":["S1"],"isPasser":true,"hasBroken":true,"hasRequiredBroken":false}}'::jsonb,
+  '["player-new"]'::jsonb,
+  '[{"playerId":"player-new","name":"New player","team":1,"hand":["S1"],"isPasser":true,"hasBroken":true,"hasRequiredBroken":false}]'::jsonb,
+  '{"player-new":1}'::jsonb,
+  'player-new',
+  0
+);
+
+do $$
+declare
+  persisted_player public.room_players%rowtype;
+  persisted_state public.game_states%rowtype;
+begin
+  select *
+  into persisted_player
+  from public.room_players
+  where room_id = '00000000-0000-0000-0000-000000000901';
+
+  if persisted_player.player_id <> 'player-new'
+    or persisted_player.socket_id is not null
+    or persisted_player.team <> 1
+    or persisted_player.hand <> '["S1"]'::jsonb then
+    raise exception 'Valid roster write did not persist the expected player';
+  end if;
+
+  select *
+  into persisted_state
+  from public.game_states
+  where room_id = '00000000-0000-0000-0000-000000000901';
+
+  if persisted_state.version <> 1
+    or persisted_state.state_data->'playerOrder' <> '["player-new"]'::jsonb
+    or persisted_state.state_data->'playerStates'->'player-new'->'hand'
+      <> '["S1"]'::jsonb then
+    raise exception 'Valid roster write did not persist the expected game state';
+  end if;
+end;
+$$;
+
+select public.atomic_update_game_state(
+  '00000000-0000-0000-0000-000000000901',
+  '{}'::jsonb,
+  '{"roundNumber":2}'::jsonb,
+  1
+);
+
+do $$
+declare
+  persisted_state public.game_states%rowtype;
+begin
+  begin
+    perform public.atomic_update_game_state(
+      '00000000-0000-0000-0000-000000000901',
+      '{}'::jsonb,
+      '{"roundNumber":3}'::jsonb,
+      1
+    );
+    raise exception 'Expected stale version write to fail';
+  exception
+    when sqlstate 'PT409' then null;
+  end;
+
+  select *
+  into persisted_state
+  from public.game_states
+  where room_id = '00000000-0000-0000-0000-000000000901';
+
+  if persisted_state.version <> 2 or persisted_state.round_number <> 2 then
+    raise exception 'Stale version write changed the game state';
+  end if;
+end;
+$$;
+
+rollback;

--- a/mei-tra-backend/supabase/tests/legacy_player_state_backfill.sql
+++ b/mei-tra-backend/supabase/tests/legacy_player_state_backfill.sql
@@ -1,0 +1,78 @@
+begin;
+
+insert into public.rooms (id, name, host_id)
+values (
+  '00000000-0000-0000-0000-000000000902',
+  'Legacy player backfill test',
+  'legacy-player-1'
+);
+
+insert into public.game_states (room_id, state_data, team_assignments)
+values (
+  '00000000-0000-0000-0000-000000000902',
+  '{
+    "players": [
+      {
+        "playerId": "legacy-player-1",
+        "name": "Legacy Player 1",
+        "team": 0,
+        "hand": ["S1", "H2"],
+        "isPasser": true,
+        "hasBroken": true,
+        "hasRequiredBroken": false
+      },
+      {
+        "playerId": "legacy-player-2",
+        "name": "Legacy Player 2",
+        "team": 1,
+        "hand": ["D3"],
+        "isPasser": false
+      }
+    ]
+  }'::jsonb,
+  '{"legacy-player-1": 0, "legacy-player-2": 1}'::jsonb
+);
+
+\ir ../migrations/20260719124824_atomic_room_state_persistence.sql
+
+do $$
+declare
+  persisted_state public.game_states%rowtype;
+begin
+  select *
+  into persisted_state
+  from public.game_states
+  where room_id = '00000000-0000-0000-0000-000000000902';
+
+  if persisted_state.version <> 0 then
+    raise exception 'Backfill changed the game state version';
+  end if;
+
+  if persisted_state.state_data->'playerOrder'
+    <> '["legacy-player-1", "legacy-player-2"]'::jsonb then
+    raise exception 'Backfill did not preserve legacy player order';
+  end if;
+
+  if persisted_state.state_data->'playerStates'->'legacy-player-1'
+    <> '{
+      "hand": ["S1", "H2"],
+      "isPasser": true,
+      "hasBroken": true,
+      "hasRequiredBroken": false
+    }'::jsonb then
+    raise exception 'Backfill did not preserve the first player gameplay state';
+  end if;
+
+  if persisted_state.state_data->'playerStates'->'legacy-player-2'
+    <> '{
+      "hand": ["D3"],
+      "isPasser": false,
+      "hasBroken": false,
+      "hasRequiredBroken": false
+    }'::jsonb then
+    raise exception 'Backfill did not supply defaults for legacy flags';
+  end if;
+end;
+$$;
+
+rollback;

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import type {
+  BackToLobbyPayload,
   BlowStartedPayload,
   BrokenPayload,
   CardPlayedPayload,
@@ -13,6 +14,7 @@ import type {
   NewRoundStartedPayload,
   PlayerContract,
   PlayCardPayload,
+  ReconnectionFailureCode,
   RequestAgariPayload,
   RevealAgariPayload,
   RoundCancelledPayload,
@@ -49,6 +51,17 @@ import { clearPlayerProfileCache } from '../lib/utils/profileUtils';
 interface ProfileUpdatedPayload {
   userId: string;
 }
+
+const reconnectRecoveryMessageKeys: Record<
+  ReconnectionFailureCode,
+  | 'reconnectRecovery.roomUnavailable'
+  | 'reconnectRecovery.sessionInvalid'
+  | 'reconnectRecovery.stateInconsistent'
+> = {
+  roomUnavailable: 'reconnectRecovery.roomUnavailable',
+  sessionInvalid: 'reconnectRecovery.sessionInvalid',
+  stateInconsistent: 'reconnectRecovery.stateInconsistent',
+};
 
 const dedupeCompletedFields = (fields: CompletedField[]): CompletedField[] => {
   const seen = new Set<string>();
@@ -894,7 +907,7 @@ export const useGame = () => {
         setCurrentHighestDeclaration(currentHighestDeclaration);
         setBlowDeclarations(blowDeclarations);
       },
-      'back-to-lobby': () => {
+      'back-to-lobby': (payload?: BackToLobbyPayload) => {
         console.warn('[useGame] back-to-lobby received', {
           currentRoomId,
           currentPlayerId,
@@ -904,6 +917,12 @@ export const useGame = () => {
               : null,
         });
         resetRoomState();
+        if (payload?.code) {
+          setNotification({
+            message: t(reconnectRecoveryMessageKeys[payload.code]),
+            type: 'warning',
+          });
+        }
       },
       'game-paused': ({ message }: { message: string }) => {
         setPaused(true);

--- a/mei-tra-frontend/hooks/useRoom.ts
+++ b/mei-tra-frontend/hooks/useRoom.ts
@@ -432,10 +432,6 @@ export const useRoom = (options: UseRoomOptions = {}) => {
             : null,
       });
 
-      if (message === 'Failed to reconnect') {
-        return;
-      }
-
       setError(message);
     };
 

--- a/mei-tra-frontend/messages/en.json
+++ b/mei-tra-frontend/messages/en.json
@@ -297,6 +297,11 @@
     "initializing": "Initializing game...",
     "initializingActions": "Initializing game actions...",
     "paused": "Game is paused. It will resume when 4 players are present.",
+    "reconnectRecovery": {
+      "roomUnavailable": "Your previous room has ended. Please join again from the room list.",
+      "sessionInvalid": "Your previous seat could not be verified. Please join again from the room list.",
+      "stateInconsistent": "The server connection was restored. Please join the room again."
+    },
     "yourTurn": "Your turn",
     "waiting": "Waiting...",
     "orderButton": "Order",

--- a/mei-tra-frontend/messages/ja.json
+++ b/mei-tra-frontend/messages/ja.json
@@ -297,6 +297,11 @@
     "initializing": "ゲームを初期化中...",
     "initializingActions": "ゲームアクションを初期化中...",
     "paused": "ゲームが一時停止しています。4人のプレイヤーが揃うと再開します。",
+    "reconnectRecovery": {
+      "roomUnavailable": "以前のルームは終了しています。ルーム一覧から入り直してください。",
+      "sessionInvalid": "以前の参加情報を確認できませんでした。ルーム一覧から入り直してください。",
+      "stateInconsistent": "サーバーとの接続を復旧しました。ルームにもう一度入室してください。"
+    },
     "yourTurn": "あなたのターンです",
     "waiting": "待機中...",
     "orderButton": "強さ順",

--- a/mei-tra-frontend/playwright/waiting-room.e2e.spec.ts
+++ b/mei-tra-frontend/playwright/waiting-room.e2e.spec.ts
@@ -47,15 +47,10 @@ async function login(page: Page, user: typeof PLAYER1) {
   await page.waitForTimeout(500);
 }
 
-/** Create a room then click join, wait for PreGameTable to appear */
+/** Create a room and wait for the host to enter PreGameTable */
 async function createRoom(page: Page, roomName: string) {
   await page.getByPlaceholder('ルーム名を入力').fill(roomName);
   await page.getByRole('button', { name: 'ルーム作成' }).click();
-
-  // Wait for the room to appear in the list, then join it
-  const row = page.locator('[class*="roomItem"]').filter({ hasText: roomName });
-  await expect(row).toBeVisible({ timeout: 10_000 });
-  await row.getByRole('button', { name: '参加' }).click();
 
   await expect(page.locator('[class*="playerPositions"]')).toBeVisible({ timeout: 15_000 });
 }
@@ -135,6 +130,12 @@ test.describe('Waiting Room', () => {
 
     await expect(team0Seats).toHaveCount(2);
     await expect(team1Seats).toHaveCount(2);
+
+    await page1.getByRole('button', { name: 'シャッフル' }).click();
+    await page1.waitForTimeout(500);
+    await expect(team0Seats).toHaveCount(2);
+    await expect(team1Seats).toHaveCount(2);
+    await expect(page1.locator('[class*="playerSeat"]')).toHaveCount(4);
   });
 
   // ────────────────────────────────────────────
@@ -162,6 +163,12 @@ test.describe('Waiting Room', () => {
     const names2 = await getRealPlayerNames(page2);
     expect(names1).toHaveLength(2);
     expect(names2).toHaveLength(2);
+    await expect(
+      page1.locator('[class*="playerSeat"]').filter({ hasText: 'COM' }),
+    ).toHaveCount(2);
+    await expect(
+      page2.locator('[class*="playerSeat"]').filter({ hasText: 'COM' }),
+    ).toHaveCount(2);
   });
 
   // ────────────────────────────────────────────
@@ -207,5 +214,8 @@ test.describe('Waiting Room', () => {
 
     // Total seats must still be 4
     await expect(page1.locator('[class*="playerSeat"]')).toHaveCount(4);
+    await expect(
+      page1.locator('[class*="playerSeat"]').filter({ hasText: 'COM' }),
+    ).toHaveCount(3);
   });
 });


### PR DESCRIPTION
## 概要
Fly.io の scale-to-zero 復帰時に、`room_players` と `game_states.players` のロスター不整合や、プロセスメモリ上の接続対応消失によって再接続できない問題を修正します。

## 原因
- 入室・COMプレースホルダー追加時に、ゲーム状態ロスターの永続化が保証されていなかった
- サーバー再起動後、認証ユーザーIDからゲーム内の席IDを引くメモリ上の対応が失われていた
- 満室判定が既存プレイヤー判定より先に実行され、復帰も拒否される場合があった

## 変更内容
- `players` と `teamAssignments` を厳格に保存するロスター専用処理を追加
- 待機室では `room_players` を基準にゲーム状態ロスターを自己修復してからCOMを補充
- プレイ中は永続化された `userId -> playerId` 対応を優先して本人の席を解決
- 既存プレイヤーの復帰を満室判定より先に処理
- 再接続失敗を3種類のコードに分け、フロントで日本語・英語の案内を表示
- コールドスタート、席ID差異、満室復帰の回帰テストを追加

## 影響
- Fly.io の `min_machines_running=0` は維持します
- Supabase のスキーマ変更はありません
- 進行中の手札状態が欠落している場合は推測復元せず、安全にロビーへ戻します

## 確認
- Backend: `npm test -- --runInBand`（35 suites / 200 tests）
- Backend: `npm run build`
- Backend: 変更ファイルの ESLint
- Frontend: `npm test -- --runInBand`（22 suites / 67 tests）
- Frontend: `npm run build`
- Frontend: 変更ファイルの ESLint
