### PR TITLE
ラウンド遷移の保存競合を防ぐ

### DIFF
--- a/mei-tra-backend/src/services/__tests__/game-state-phase.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/game-state-phase.spec.ts
@@ -70,6 +70,37 @@ describe('GameStateService phase transitions', () => {
     expect(service.getState().version).toBe(2);
   });
 
+  it('keeps the persisted version when resetting a round', async () => {
+    const state = service.getState();
+    state.version = 96;
+    state.teamAssignments = { 'player-1': 0 };
+
+    await service.resetRoundState();
+    expect(service.getState().version).toBe(96);
+    expect(service.getState().teamAssignments).toEqual({ 'player-1': 0 });
+
+    await service.saveState();
+
+    expect(repository.update).toHaveBeenCalledWith(
+      'room-1',
+      expect.any(Object),
+      96,
+    );
+  });
+
+  it('persists round changes through an explicit state update', async () => {
+    const state = service.getState();
+    state.version = 96;
+
+    await service.updateState({ roundNumber: 2 });
+
+    expect(repository.update).toHaveBeenCalledWith(
+      'room-1',
+      { roundNumber: 2 },
+      96,
+    );
+  });
+
   it('records a completed field without persisting an intermediate snapshot', () => {
     const state = service.getState();
     state.players = [

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -640,18 +640,22 @@ export class GameStateService implements IGameStateService {
 
   async resetRoundState(): Promise<void> {
     // Keep the current players, scores, and game settings
+    const version = this.state.version;
     const players = [...this.state.players];
     const teamScores = { ...this.state.teamScores };
     const teamScoreRecords = { ...this.state.teamScoreRecords };
+    const teamAssignments = { ...this.state.teamAssignments };
     const pointsToWin = this.state.pointsToWin;
 
     // Initialize new state with preserved pointsToWin
     this.initializeState(pointsToWin);
 
     // Restore players and scores
+    this.state.version = version;
     this.state.players = players;
     this.state.teamScores = teamScores;
     this.state.teamScoreRecords = teamScoreRecords;
+    this.state.teamAssignments = teamAssignments;
 
     // Generate new deck and deal cards
     this.state.deck = this.cardService.generateDeck();
@@ -664,15 +668,6 @@ export class GameStateService implements IGameStateService {
 
   set roundNumber(value: number) {
     this.state.roundNumber = value;
-    void this.enqueuePersistence(() =>
-      this.stateManager.persistRoundNumber(this.roomId, this.state, value),
-    )
-      .then((version) => {
-        this.state.version = version;
-      })
-      .catch((error) => {
-        this.logger.error('Failed to persist round number:', error);
-      });
   }
 
   get currentTurn(): string | null {

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -3025,6 +3025,55 @@ describe('Game Use Cases', () => {
       expect(result.gameOver).toBeUndefined();
     });
 
+    it('persists the next round number before starting the next round', async () => {
+      const roomService = createRoomServiceMock();
+      const playService = createPlayServiceMock('player-1');
+      const scoreService = createScoreServiceMock(2);
+      const useCase = new CompleteFieldUseCase(
+        roomService,
+        playService,
+        scoreService,
+      );
+
+      const state = buildState();
+      state.players[0].hand = ['A', 'C'];
+      state.players[1].hand = ['E', 'F'];
+      const updateState = jest.fn(async (updates) => {
+        Object.assign(state, updates);
+      });
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        completeField: jest.fn(() => ({
+          cards: ['A', 'C', 'E', 'F'],
+          winnerId: 'player-1',
+          winnerTeam: 0,
+          dealerId: 'player-1',
+        })),
+        saveState: jest.fn(),
+        resetRoundState: jest.fn(async () => {}),
+        transitionPhase: jest.fn(async () => {}),
+        updateState,
+      } as unknown as GameStateService;
+
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const result = await useCase.execute({
+        roomId: 'room-1',
+        field: {
+          cards: ['A', 'C', 'E', 'F'],
+          playedBy: ['player-1', 'player-2', 'player-3', 'player-4'],
+          baseCard: 'A',
+          dealerId: 'player-1',
+          isComplete: true,
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(updateState).toHaveBeenNthCalledWith(1, { roundNumber: 2 });
+      expect(roomGameState.transitionPhase).toHaveBeenCalledWith('blow');
+      expect(roomGameState.saveState).toHaveBeenCalled();
+    });
+
     it('produces game over instruction when team reaches target', async () => {
       const roomService = createRoomServiceMock();
       const playService = createPlayServiceMock('player-1');

--- a/mei-tra-backend/src/use-cases/complete-field.use-case.ts
+++ b/mei-tra-backend/src/use-cases/complete-field.use-case.ts
@@ -314,7 +314,9 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
     state: GameState,
   ): Promise<GatewayEvent[]> {
     await roomGameState.resetRoundState();
-    roomGameState.roundNumber = state.roundNumber + 1;
+    await roomGameState.updateState({
+      roundNumber: state.roundNumber + 1,
+    });
 
     const updatedState = roomGameState.getState();
     const nextBlowIndex =


### PR DESCRIPTION
## 概要

- ラウンドリセット時に永続化用の `version` を保持する
- 次ラウンド番号を明示的な状態更新として保存し、非同期setterによる保存順序の曖昧さをなくす
- チーム割当をラウンドリセット後も保持する

## 原因

ラウンド終了時に `GameStateService.resetRoundState()` がゲーム状態を初期化し、DBの楽観ロック用 `version` まで `0` に戻していました。次の保存が既存のDB versionと競合し、`Internal server error` になっていました。

## 確認

- `npm test -- --runInBand` (38 suites / 218 tests)
- `npm run build`
- `npx eslint` の変更対象ファイル確認（既存の `complete-field.use-case.ts:59` の lint エラーを除く）
