### PR TITLE
Remove legacy player state and stabilize reconnect

### DIFF
--- a/mei-tra-backend/src/__tests__/game.gateway.com-recovery.spec.ts
+++ b/mei-tra-backend/src/__tests__/game.gateway.com-recovery.spec.ts
@@ -106,6 +106,7 @@ describe('GameGateway COM recovery integration', () => {
       id: 'socket-1',
       handshake: { auth: { token: 'token' } },
       data: { user: authenticatedUser },
+      join: jest.fn().mockResolvedValue(undefined),
       emit: jest.fn(),
     } as unknown as Socket;
 
@@ -118,6 +119,7 @@ describe('GameGateway COM recovery integration', () => {
       authenticatedUser,
     });
     expect(testGateway.reconnectionUseCase.execute).not.toHaveBeenCalled();
+    expect(client.join).toHaveBeenCalledWith('room-1');
     expect(client.emit).toHaveBeenCalledWith('game-state', gameState);
     expect(client.emit).toHaveBeenCalledWith('reconnect-token', 'player-1');
     expect(testGateway.startTurnAckMonitor).not.toHaveBeenCalled();

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -1097,6 +1097,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       return;
     }
 
+    this.playerRooms.set(client.id, roomId);
+    await client.join(roomId);
     client.emit('game-state', snapshot.gameState);
     client.emit('reconnect-token', snapshot.reconnectToken);
   }

--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
@@ -8,15 +8,6 @@ describe('SupabaseGameStateRepository', () => {
     id: 'game-state-1',
     room_id: '00000000-0000-0000-0000-000000000001',
     state_data: {
-      players: [
-        {
-          playerId: 'player-1',
-          name: 'Legacy name',
-          hand: ['legacy-card'],
-          team: 0,
-          isPasser: false,
-        },
-      ],
       playerStates: {
         'player-1': {
           hand: ['S1'],
@@ -55,7 +46,6 @@ describe('SupabaseGameStateRepository', () => {
       1: { play: 0, total: 0 },
     },
     team_score_records: { 0: [], 1: [] },
-    team_assignments: { 'player-1': 1 },
     version: 4,
     created_at: '2026-07-19T00:00:00.000Z',
     updated_at: '2026-07-19T00:00:00.000Z',
@@ -68,15 +58,12 @@ describe('SupabaseGameStateRepository', () => {
     socket_id: null,
     user_id: '00000000-0000-0000-0000-000000000101',
     name: 'Current name',
-    hand: ['room-card'],
     team: 1,
-    is_passer: false,
-    has_broken: false,
-    has_required_broken: false,
     is_ready: true,
     is_host: true,
     is_com: false,
     joined_at: '2026-07-19T00:00:00.000Z',
+    seat_index: 0,
   };
 
   function createState(): GameState {
@@ -156,7 +143,7 @@ describe('SupabaseGameStateRepository', () => {
     ]);
   });
 
-  it('does not revive legacy players missing from the authoritative roster', async () => {
+  it('ignores player order entries missing from the authoritative roster', async () => {
     const rpc = jest.fn().mockResolvedValue({
       data: {
         gameState: gameStateRow,
@@ -251,6 +238,12 @@ describe('SupabaseGameStateRepository', () => {
         ],
       }),
     );
+    const [, rosterPayload] = rpc.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(rosterPayload).not.toHaveProperty('p_legacy_players');
+    expect(rosterPayload).not.toHaveProperty('p_team_assignments');
     expect(state?.version).toBe(5);
   });
 
@@ -271,22 +264,23 @@ describe('SupabaseGameStateRepository', () => {
 
     await repository.persistRoomRoster(
       gameStateRow.room_id,
-      [
-        { ...createRoomPlayer(), seatIndex: 7 },
-        secondPlayer,
-      ],
+      [{ ...createRoomPlayer(), seatIndex: 7 }, secondPlayer],
       createState(),
       'player-1',
     );
 
-    expect(rpc).toHaveBeenCalledWith(
-      'persist_room_roster_atomic',
-      expect.objectContaining({
-        p_room_players: expect.arrayContaining([
-          expect.objectContaining({ playerId: 'player-1', seatIndex: 0 }),
-          expect.objectContaining({ playerId: 'player-2', seatIndex: 1 }),
-        ]),
-      }),
-    );
+    const [, rosterPayload] = rpc.mock.calls[0] as [
+      string,
+      { p_room_players: Array<{ playerId: string; seatIndex: number }> },
+    ];
+    expect(
+      rosterPayload.p_room_players.map((player) => ({
+        playerId: player.playerId,
+        seatIndex: player.seatIndex,
+      })),
+    ).toEqual([
+      { playerId: 'player-1', seatIndex: 0 },
+      { playerId: 'player-2', seatIndex: 1 },
+    ]);
   });
 });

--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts
@@ -9,10 +9,8 @@ import {
   ScoreRecord,
 } from '../../types/game.types';
 import {
-  PersistedGamePlayer,
   PersistedPlayerGameplayState,
   PersistedPlayerStates,
-  toPersistedGamePlayer,
   toPersistedPlayerStates,
   toRuntimePlayer,
 } from '../../types/player-adapters';
@@ -33,10 +31,6 @@ interface RosterPlayerSnapshot {
   name: string;
   team: number;
   isCOM?: boolean;
-  hand: string[];
-  isPasser: boolean;
-  hasBroken: boolean;
-  hasRequiredBroken: boolean;
 }
 
 @Injectable()
@@ -57,9 +51,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
         .insert({
           room_id: roomId,
           state_data: {
-            players: gameState.players.map((player) =>
-              toPersistedGamePlayer(player),
-            ),
             playerStates: toPersistedPlayerStates(gameState.players),
             playerOrder: gameState.players.map((player) => player.playerId),
             deck: gameState.deck,
@@ -73,7 +64,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
           points_to_win: gameState.pointsToWin,
           team_scores: gameState.teamScores,
           team_score_records: gameState.teamScoreRecords,
-          team_assignments: gameState.teamAssignments,
         })
         .select()
         .single();
@@ -83,7 +73,7 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
         throw new Error(`Failed to create game state: ${error.message}`);
       }
 
-      return this.mapDatabaseToGameState(data);
+      return { ...gameState, version: data.version };
     } catch (error) {
       this.logger.error('Error creating game state:', error);
       throw error;
@@ -183,9 +173,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
   ): Promise<GameState | null> {
     const playerStates = toPersistedPlayerStates(gameState.players);
     const playerOrder = gameState.players.map((player) => player.playerId);
-    const legacyPlayers = gameState.players.map((player) =>
-      toPersistedGamePlayer(player),
-    );
     const persistedRoomPlayers = roomPlayers.map((player, seatIndex) => ({
       playerId: player.playerId,
       userId: player.userId ?? null,
@@ -206,8 +193,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
           p_room_players: persistedRoomPlayers,
           p_player_states: playerStates,
           p_player_order: playerOrder,
-          p_legacy_players: legacyPlayers,
-          p_team_assignments: gameState.teamAssignments,
           p_host_id: hostId ?? null,
           p_expected_version: gameState.version ?? null,
         },
@@ -244,9 +229,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
     const patch: Record<string, unknown> = {};
 
     if (gameState.players) {
-      patch.players = gameState.players.map((player) =>
-        toPersistedGamePlayer(player),
-      );
       patch.playerStates = toPersistedPlayerStates(gameState.players);
       patch.playerOrder = gameState.players.map((player) => player.playerId);
     }
@@ -284,10 +266,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
         gameState.teamScoreRecords,
       );
     }
-    if (gameState.teamAssignments) {
-      patch.teamAssignments = gameState.teamAssignments;
-    }
-
     return patch;
   }
 
@@ -346,10 +324,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
         gameState.teamScoreRecords,
       );
     }
-    if (gameState.teamAssignments) {
-      updateData.team_assignments = gameState.teamAssignments;
-    }
-
     const { data, error } = await this.supabase
       .from('game_states')
       .update(updateData)
@@ -386,29 +360,19 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
         ),
     );
 
-    const statePlayers = new Map(
-      gameState.players.map((player) => [player.playerId, player]),
-    );
-    const rows = roomPlayers.map((player, seatIndex) => {
-      const statePlayer = statePlayers.get(player.playerId);
-      return {
-        room_id: roomId,
-        player_id: player.playerId,
-        socket_id: null,
-        user_id: player.userId ?? null,
-        name: player.name,
-        hand: [...(statePlayer?.hand ?? [])],
-        team: player.team,
-        is_passer: statePlayer?.isPasser ?? false,
-        has_broken: statePlayer?.hasBroken ?? false,
-        has_required_broken: statePlayer?.hasRequiredBroken ?? false,
-        is_ready: player.isReady,
-        is_host: player.isHost,
-        is_com: player.isCOM ?? false,
-        joined_at: player.joinedAt.toISOString(),
-        seat_index: seatIndex,
-      };
-    });
+    const rows = roomPlayers.map((player, seatIndex) => ({
+      room_id: roomId,
+      player_id: player.playerId,
+      socket_id: null,
+      user_id: player.userId ?? null,
+      name: player.name,
+      team: player.team,
+      is_ready: player.isReady,
+      is_host: player.isHost,
+      is_com: player.isCOM ?? false,
+      joined_at: player.joinedAt.toISOString(),
+      seat_index: seatIndex,
+    }));
 
     if (rows.length > 0) {
       const { error } = await this.supabase
@@ -437,7 +401,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
 
     const persistedState = await this.updateLegacy(roomId, {
       players: gameState.players,
-      teamAssignments: gameState.teamAssignments,
     });
     if (!persistedState) {
       throw new Error(`Game state not found for room ${roomId}`);
@@ -609,19 +572,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
     roomPlayers?: Array<RoomPlayerRow | RoomPlayer>,
   ): GameState {
     const stateData = dbGameState.state_data || {};
-    const teamAssignments = dbGameState.team_assignments as {
-      [playerId: string]: 0 | 1;
-    };
-    const legacyPlayers = new Map<string, Partial<PersistedGamePlayer>>(
-      Array.isArray(stateData.players)
-        ? stateData.players
-            .filter(
-              (player): player is PersistedGamePlayer =>
-                typeof (player as PersistedGamePlayer)?.playerId === 'string',
-            )
-            .map((player) => [player.playerId, player])
-        : [],
-    );
     const playerStates =
       stateData.playerStates && typeof stateData.playerStates === 'object'
         ? (stateData.playerStates as PersistedPlayerStates)
@@ -647,44 +597,24 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
       ...rosterPlayers
         .map((player) => player.playerId)
         .filter((playerId) => !persistedOrder.includes(playerId)),
-      ...(!hasAuthoritativeRoster
-        ? Array.from(legacyPlayers.keys()).filter(
-            (playerId) => !persistedOrder.includes(playerId),
-          )
-        : []),
     ];
     const players = playerOrder
       .map((playerId) => {
         const roomPlayer = roomPlayersById.get(playerId);
-        const legacyPlayer = legacyPlayers.get(playerId);
         const gameplay = playerStates[playerId] as
           | PersistedPlayerGameplayState
           | undefined;
-        const fallbackTeam = teamAssignments[playerId];
 
-        return toRuntimePlayer(
-          {
-            ...legacyPlayer,
-            playerId,
-            name: roomPlayer?.name ?? legacyPlayer?.name,
-            team: roomPlayer?.team as 0 | 1 | undefined,
-            isCOM: roomPlayer?.isCOM ?? legacyPlayer?.isCOM,
-            hand: gameplay?.hand ?? roomPlayer?.hand ?? legacyPlayer?.hand,
-            isPasser:
-              gameplay?.isPasser ??
-              roomPlayer?.isPasser ??
-              legacyPlayer?.isPasser,
-            hasBroken:
-              gameplay?.hasBroken ??
-              roomPlayer?.hasBroken ??
-              legacyPlayer?.hasBroken,
-            hasRequiredBroken:
-              gameplay?.hasRequiredBroken ??
-              roomPlayer?.hasRequiredBroken ??
-              legacyPlayer?.hasRequiredBroken,
-          },
-          fallbackTeam,
-        );
+        return toRuntimePlayer({
+          playerId,
+          name: roomPlayer?.name,
+          team: roomPlayer?.team as 0 | 1 | undefined,
+          isCOM: roomPlayer?.isCOM,
+          hand: gameplay?.hand,
+          isPasser: gameplay?.isPasser,
+          hasBroken: gameplay?.hasBroken,
+          hasRequiredBroken: gameplay?.hasRequiredBroken,
+        });
       })
       .filter((player): player is DomainPlayer => Boolean(player));
 
@@ -707,7 +637,9 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
       agari: stateData.agari,
       roundNumber: dbGameState.round_number,
       pointsToWin: dbGameState.points_to_win,
-      teamAssignments,
+      teamAssignments: Object.fromEntries(
+        players.map((player) => [player.playerId, player.team]),
+      ),
     };
   }
 
@@ -720,10 +652,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
         name: player.name,
         team: player.team,
         isCOM: player.is_com,
-        hand: [...player.hand],
-        isPasser: player.is_passer,
-        hasBroken: player.has_broken,
-        hasRequiredBroken: player.has_required_broken,
       };
     }
 
@@ -732,10 +660,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
       name: player.name,
       team: player.team,
       isCOM: player.isCOM,
-      hand: [...player.hand],
-      isPasser: player.isPasser,
-      hasBroken: player.hasBroken ?? false,
-      hasRequiredBroken: player.hasRequiredBroken ?? false,
     };
   }
 

--- a/mei-tra-backend/src/repositories/implementations/supabase-room.repository.spec.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-room.repository.spec.ts
@@ -35,10 +35,7 @@ describe('SupabaseRoomRepository', () => {
       is_host: boolean;
       is_ready: boolean;
       is_com: boolean;
-      hand: string[];
-      is_passer: boolean;
-      has_broken: boolean;
-      has_required_broken: boolean;
+      seat_index: number;
     }> = {},
   ) {
     return {
@@ -48,15 +45,12 @@ describe('SupabaseRoomRepository', () => {
       socket_id: overrides.socket_id ?? `${playerId}-socket`,
       user_id: overrides.user_id ?? playerId,
       name: overrides.name ?? playerId,
-      hand: overrides.hand ?? [],
       team: overrides.team ?? 0,
-      is_passer: overrides.is_passer ?? false,
-      has_broken: overrides.has_broken ?? false,
-      has_required_broken: overrides.has_required_broken ?? false,
       is_ready: overrides.is_ready ?? false,
       is_host: overrides.is_host ?? false,
       is_com: overrides.is_com ?? false,
       joined_at: joinedAt,
+      seat_index: overrides.seat_index ?? 0,
     };
   }
 
@@ -68,9 +62,14 @@ describe('SupabaseRoomRepository', () => {
     const roomPlayersData = [
       createPlayerRow('room-1', 'player-1', '2026-04-16T00:00:30.000Z', {
         is_host: true,
+        seat_index: 0,
       }),
-      createPlayerRow('room-1', 'player-2', '2026-04-16T00:01:00.000Z'),
-      createPlayerRow('room-2', 'player-3', '2026-04-16T01:00:30.000Z'),
+      createPlayerRow('room-1', 'player-2', '2026-04-16T00:01:00.000Z', {
+        seat_index: 1,
+      }),
+      createPlayerRow('room-2', 'player-3', '2026-04-16T01:00:30.000Z', {
+        seat_index: 0,
+      }),
     ];
 
     const roomsOrder = jest

--- a/mei-tra-backend/src/repositories/implementations/supabase-room.repository.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-room.repository.ts
@@ -269,11 +269,7 @@ export class SupabaseRoomRepository implements IRoomRepository {
         socket_id: player.socketId,
         user_id: player.userId ?? null,
         name: player.name,
-        hand: player.hand,
         team: player.team,
-        is_passer: player.isPasser,
-        has_broken: player.hasBroken,
-        has_required_broken: player.hasRequiredBroken,
         is_ready: player.isReady,
         is_host: player.isHost,
         is_com: player.isCOM ?? false,
@@ -328,14 +324,7 @@ export class SupabaseRoomRepository implements IRoomRepository {
       }
       if (updates.userId !== undefined) updateData.user_id = updates.userId;
       if (updates.name) updateData.name = updates.name;
-      if (updates.hand) updateData.hand = updates.hand;
       if (updates.team !== undefined) updateData.team = updates.team;
-      if (updates.isPasser !== undefined)
-        updateData.is_passer = updates.isPasser;
-      if (updates.hasBroken !== undefined)
-        updateData.has_broken = updates.hasBroken;
-      if (updates.hasRequiredBroken !== undefined)
-        updateData.has_required_broken = updates.hasRequiredBroken;
       if (updates.isReady !== undefined) updateData.is_ready = updates.isReady;
       if (updates.isHost !== undefined) updateData.is_host = updates.isHost;
 
@@ -407,11 +396,7 @@ export class SupabaseRoomRepository implements IRoomRepository {
       socket_id: player.socketId,
       user_id: player.userId ?? null,
       name: player.name,
-      hand: player.hand,
       team: player.team,
-      is_passer: player.isPasser,
-      has_broken: player.hasBroken,
-      has_required_broken: player.hasRequiredBroken,
       is_ready: player.isReady,
       is_host: player.isHost,
       is_com: player.isCOM ?? false,
@@ -493,11 +478,11 @@ export class SupabaseRoomRepository implements IRoomRepository {
       userId: dbPlayer.user_id ?? undefined,
       isAuthenticated: Boolean(dbPlayer.user_id),
       name: dbPlayer.name,
-      hand: dbPlayer.hand,
+      hand: [],
       team: dbPlayer.team as 0 | 1,
-      isPasser: dbPlayer.is_passer,
-      hasBroken: dbPlayer.has_broken,
-      hasRequiredBroken: dbPlayer.has_required_broken,
+      isPasser: false,
+      hasBroken: false,
+      hasRequiredBroken: false,
       isReady: dbPlayer.is_ready,
       isHost: dbPlayer.is_host,
       isCOM: dbPlayer.is_com,

--- a/mei-tra-backend/src/types/database.types.ts
+++ b/mei-tra-backend/src/types/database.types.ts
@@ -61,11 +61,7 @@ export interface Database {
           player_id: string;
           socket_id: string | null;
           name: string;
-          hand: string[];
           team: number;
-          is_passer: boolean;
-          has_broken: boolean;
-          has_required_broken: boolean;
           is_ready: boolean;
           is_host: boolean;
           is_com: boolean;
@@ -79,11 +75,7 @@ export interface Database {
           player_id: string;
           socket_id?: string | null;
           name: string;
-          hand?: string[];
           team?: number;
-          is_passer?: boolean;
-          has_broken?: boolean;
-          has_required_broken?: boolean;
           is_ready?: boolean;
           is_host?: boolean;
           is_com?: boolean;
@@ -97,11 +89,7 @@ export interface Database {
           player_id?: string;
           socket_id?: string | null;
           name?: string;
-          hand?: string[];
           team?: number;
-          is_passer?: boolean;
-          has_broken?: boolean;
-          has_required_broken?: boolean;
           is_ready?: boolean;
           is_host?: boolean;
           is_com?: boolean;
@@ -129,7 +117,6 @@ export interface Database {
               reason: string;
             }>;
           };
-          team_assignments: { [key: string]: number };
           version: number;
           created_at: string;
           updated_at: string;
@@ -152,7 +139,6 @@ export interface Database {
               reason: string;
             }>;
           };
-          team_assignments?: { [key: string]: number };
           version?: number;
           created_at?: string;
           updated_at?: string;
@@ -175,7 +161,6 @@ export interface Database {
               reason: string;
             }>;
           };
-          team_assignments?: { [key: string]: number };
           version?: number;
           created_at?: string;
           updated_at?: string;

--- a/mei-tra-backend/src/use-cases/__tests__/shuffle-teams.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/shuffle-teams.use-case.spec.ts
@@ -40,7 +40,10 @@ describe('ShuffleTeamsUseCase', () => {
     const useCase = new ShuffleTeamsUseCase(roomService, fillWithComUseCase);
 
     const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
-    const result = await useCase.execute({ roomId: 'room-1', playerId: 'host' });
+    const result = await useCase.execute({
+      roomId: 'room-1',
+      playerId: 'host',
+    });
     randomSpy.mockRestore();
 
     expect(result.success).toBe(true);
@@ -51,10 +54,10 @@ describe('ShuffleTeamsUseCase', () => {
       ]),
     );
     const [shuffledPlayers] = roomGameState.reconcileWaitingRoomPlayers.mock
-      .calls[0];
-    expect(shuffledPlayers.map((player: RoomPlayer) => player.seatIndex)).toEqual(
-      [0, 1, 2, 3],
-    );
+      .calls[0] as [RoomPlayer[]];
+    expect(
+      shuffledPlayers.map((player: RoomPlayer) => player.seatIndex),
+    ).toEqual([0, 1, 2, 3]);
   });
 
   it('returns failure when empty seats cannot be filled', async () => {

--- a/mei-tra-backend/src/use-cases/complete-field.use-case.ts
+++ b/mei-tra-backend/src/use-cases/complete-field.use-case.ts
@@ -56,7 +56,7 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
 
       this.removeCardsFromHands(state, field.cards);
 
-      const completedField = await roomGameState.completeField(
+      const completedField = roomGameState.completeField(
         field,
         winner.playerId,
       );

--- a/mei-tra-backend/src/use-cases/shuffle-teams.use-case.ts
+++ b/mei-tra-backend/src/use-cases/shuffle-teams.use-case.ts
@@ -22,7 +22,10 @@ export class ShuffleTeamsUseCase {
     }
 
     if (room.status !== RoomStatus.WAITING) {
-      return { success: false, error: 'Teams can only be shuffled while waiting' };
+      return {
+        success: false,
+        error: 'Teams can only be shuffled while waiting',
+      };
     }
 
     if (room.hostId !== request.playerId) {

--- a/mei-tra-backend/supabase/migrations/20260720173100_remove_legacy_player_state.sql
+++ b/mei-tra-backend/supabase/migrations/20260720173100_remove_legacy_player_state.sql
@@ -1,0 +1,238 @@
+do $migration$
+begin
+  execute $sql$
+    drop function if exists public.persist_room_roster_atomic(
+      uuid,
+      jsonb,
+      jsonb,
+      jsonb,
+      jsonb,
+      jsonb,
+      text,
+      bigint
+    )
+  $sql$;
+
+  execute $sql$
+    create or replace function public.persist_room_roster_atomic(
+      p_room_id uuid,
+      p_room_players jsonb,
+      p_player_states jsonb,
+      p_player_order jsonb,
+      p_host_id text default null,
+      p_expected_version bigint default null
+    )
+    returns jsonb
+    language plpgsql
+    security invoker
+    set search_path = public
+    as $function$
+    declare
+      current_state public.game_states%rowtype;
+      updated_state public.game_states%rowtype;
+    begin
+      select *
+      into current_state
+      from public.game_states
+      where room_id = p_room_id
+      for update;
+
+      if not found then
+        return null;
+      end if;
+
+      if p_expected_version is not null
+        and current_state.version <> p_expected_version then
+        raise exception 'game_state_version_conflict room=% expected=% actual=%',
+          p_room_id,
+          p_expected_version,
+          current_state.version
+          using errcode = 'PT409';
+      end if;
+
+      delete from public.room_players as room_player
+      where room_player.room_id = p_room_id
+        and not exists (
+          select 1
+          from jsonb_array_elements(coalesce(p_room_players, '[]'::jsonb)) as entry
+          where entry->>'playerId' = room_player.player_id
+        );
+
+      insert into public.room_players (
+        room_id,
+        player_id,
+        socket_id,
+        user_id,
+        name,
+        team,
+        is_ready,
+        is_host,
+        is_com,
+        joined_at,
+        seat_index
+      )
+      select
+        p_room_id,
+        player."playerId",
+        null,
+        nullif(player."userId", '')::uuid,
+        player.name,
+        player.team,
+        coalesce(player."isReady", false),
+        coalesce(player."isHost", false),
+        coalesce(player."isCOM", false),
+        coalesce(player."joinedAt", now()),
+        player."seatIndex"
+      from jsonb_to_recordset(coalesce(p_room_players, '[]'::jsonb)) as player(
+        "playerId" text,
+        "userId" text,
+        name text,
+        team integer,
+        "isReady" boolean,
+        "isHost" boolean,
+        "isCOM" boolean,
+        "joinedAt" timestamptz,
+        "seatIndex" integer
+      )
+      on conflict (room_id, player_id) do update
+      set
+        socket_id = null,
+        user_id = excluded.user_id,
+        name = excluded.name,
+        team = excluded.team,
+        is_ready = excluded.is_ready,
+        is_host = excluded.is_host,
+        is_com = excluded.is_com,
+        joined_at = excluded.joined_at,
+        seat_index = excluded.seat_index;
+
+      if p_host_id is not null then
+        update public.rooms
+        set
+          host_id = p_host_id,
+          last_activity_at = now()
+        where id = p_room_id;
+      else
+        update public.rooms
+        set last_activity_at = now()
+        where id = p_room_id;
+      end if;
+
+      update public.game_states
+      set
+        state_data = (coalesce(current_state.state_data, '{}'::jsonb) - 'players')
+          || jsonb_build_object(
+            'playerStates', coalesce(p_player_states, '{}'::jsonb),
+            'playerOrder', coalesce(p_player_order, '[]'::jsonb)
+          ),
+        version = current_state.version + 1
+      where room_id = p_room_id
+      returning * into updated_state;
+
+      return to_jsonb(updated_state);
+    end;
+    $function$
+  $sql$;
+
+  execute $sql$
+    create or replace function public.atomic_update_game_state(
+      p_room_id uuid,
+      p_state_patch jsonb default '{}'::jsonb,
+      p_scalar_patch jsonb default '{}'::jsonb,
+      p_expected_version bigint default null
+    )
+    returns jsonb
+    language plpgsql
+    security invoker
+    set search_path = public
+    as $function$
+    declare
+      current_state public.game_states%rowtype;
+      updated_state public.game_states%rowtype;
+    begin
+      select *
+      into current_state
+      from public.game_states
+      where room_id = p_room_id
+      for update;
+
+      if not found then
+        return null;
+      end if;
+
+      if p_expected_version is not null
+        and current_state.version <> p_expected_version then
+        raise exception 'game_state_version_conflict room=% expected=% actual=%',
+          p_room_id,
+          p_expected_version,
+          current_state.version
+          using errcode = 'PT409';
+      end if;
+
+      update public.game_states
+      set
+        state_data = (coalesce(current_state.state_data, '{}'::jsonb) - 'players')
+          || coalesce(p_state_patch, '{}'::jsonb),
+        current_player_index = case
+          when p_scalar_patch ? 'currentPlayerIndex'
+            then (p_scalar_patch->>'currentPlayerIndex')::integer
+          else current_state.current_player_index
+        end,
+        game_phase = case
+          when p_scalar_patch ? 'gamePhase'
+            then (p_scalar_patch->>'gamePhase')::game_phase
+          else current_state.game_phase
+        end,
+        round_number = case
+          when p_scalar_patch ? 'roundNumber'
+            then (p_scalar_patch->>'roundNumber')::integer
+          else current_state.round_number
+        end,
+        points_to_win = case
+          when p_scalar_patch ? 'pointsToWin'
+            then (p_scalar_patch->>'pointsToWin')::integer
+          else current_state.points_to_win
+        end,
+        team_scores = case
+          when p_scalar_patch ? 'teamScores'
+            then p_scalar_patch->'teamScores'
+          else current_state.team_scores
+        end,
+        team_score_records = case
+          when p_scalar_patch ? 'teamScoreRecords'
+            then p_scalar_patch->'teamScoreRecords'
+          else current_state.team_score_records
+        end,
+        version = current_state.version + 1
+      where room_id = p_room_id
+      returning * into updated_state;
+
+      return to_jsonb(updated_state);
+    end;
+    $function$
+  $sql$;
+
+  update public.game_states
+  set state_data = coalesce(state_data, '{}'::jsonb) - 'players'
+  where state_data ? 'players';
+
+  execute $sql$
+    alter table public.room_players
+      drop column if exists hand,
+      drop column if exists is_passer,
+      drop column if exists has_broken,
+      drop column if exists has_required_broken
+  $sql$;
+
+  execute $sql$
+    alter table public.game_states
+      drop column if exists team_assignments
+  $sql$;
+
+  execute 'revoke all on function public.persist_room_roster_atomic(uuid, jsonb, jsonb, jsonb, text, bigint) from public, anon, authenticated';
+  execute 'grant execute on function public.persist_room_roster_atomic(uuid, jsonb, jsonb, jsonb, text, bigint) to service_role';
+  execute 'revoke all on function public.atomic_update_game_state(uuid, jsonb, jsonb, bigint) from public, anon, authenticated';
+  execute 'grant execute on function public.atomic_update_game_state(uuid, jsonb, jsonb, bigint) to service_role';
+  perform pg_notify('pgrst', 'reload schema');
+end;
+$migration$;

--- a/mei-tra-frontend/__tests__/app/socket.test.ts
+++ b/mei-tra-frontend/__tests__/app/socket.test.ts
@@ -1,0 +1,44 @@
+import { io } from 'socket.io-client';
+import {
+  disconnectSocket,
+  getSocket,
+  setSocketAuthTokenProvider,
+} from '@/app/socket';
+
+type SocketAuthPayload = { roomId: string; token?: string };
+type SocketOptions = {
+  auth: (callback: (data: SocketAuthPayload) => void) => Promise<void>;
+};
+
+const mockedIo = io as jest.Mock;
+
+describe('game socket authentication', () => {
+  beforeEach(() => {
+    disconnectSocket();
+    mockedIo.mockClear();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    disconnectSocket();
+    setSocketAuthTokenProvider(undefined);
+  });
+
+  it('fetches the latest access token for the Socket.IO auth callback', async () => {
+    const getAccessToken = jest.fn().mockResolvedValue('fresh-token');
+
+    sessionStorage.setItem('roomId', 'room-1');
+    setSocketAuthTokenProvider(getAccessToken);
+    getSocket('stale-token');
+
+    const options = mockedIo.mock.calls[0][1] as SocketOptions;
+    const callback = jest.fn();
+    await options.auth(callback);
+
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      token: 'fresh-token',
+    });
+  });
+});

--- a/mei-tra-frontend/__tests__/components/CompletedFields.test.tsx
+++ b/mei-tra-frontend/__tests__/components/CompletedFields.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { CompletedFields } from '@/components/game/CompletedFields';
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: Record<string, number>) => {
+    const labels: Record<string, string> = {
+      takenLabel: 'Taken',
+      takenCount: `${values?.count ?? 0} pairs`,
+      unknown: 'Unknown',
+    };
+
+    return labels[key] ?? key;
+  },
+}));
+
+jest.mock('@/components/game/Card', () => ({
+  Card: ({ card }: { card: string }) => <span>{card}</span>,
+}));
+
+describe('CompletedFields', () => {
+  it('shows zero taken pairs when there are no completed fields', () => {
+    render(<CompletedFields fields={[]} players={[]} />);
+
+    expect(screen.getByText('Taken')).toBeInTheDocument();
+    expect(screen.getByText('0 pairs')).toBeInTheDocument();
+  });
+
+  it('shows the current number of taken pairs', () => {
+    render(
+      <CompletedFields
+        fields={[
+          { cards: ['A♠'], winnerId: 'player-1', winnerTeam: 0 },
+          { cards: ['K♣'], winnerId: 'player-2', winnerTeam: 0 },
+        ]}
+        players={[
+          { playerId: 'player-1', name: 'Player 1' },
+          { playerId: 'player-2', name: 'Player 2' },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('2 pairs')).toBeInTheDocument();
+    expect(screen.getByText('Player 1')).toBeInTheDocument();
+    expect(screen.getByText('Player 2')).toBeInTheDocument();
+  });
+});

--- a/mei-tra-frontend/app/[locale]/page.tsx
+++ b/mei-tra-frontend/app/[locale]/page.tsx
@@ -14,7 +14,6 @@ import { LandingPage } from '@/components/landing/LandingPage';
 import { AuthModal } from '@/components/auth/AuthModal';
 import { ConfirmModal } from '@/components/shared/ConfirmModal';
 import { useAuth } from '@/hooks/useAuth';
-import { useSocket } from '@/hooks/useSocket';
 import styles from './index.module.css';
 
 export const dynamic = 'force-dynamic';
@@ -26,7 +25,6 @@ export default function Home() {
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
   const [authMode, setAuthMode] = useState<'signin' | 'signup'>('signin');
   const gameState = useGame();
-  const { socket } = useSocket();
 
   const openAuthModal = (mode: 'signin' | 'signup') => {
     setAuthMode(mode);
@@ -118,6 +116,7 @@ export default function Home() {
     isConnected = false,
     isConnecting = false,
     users = [],
+    socket = null,
   } = gameState;
 
   // Type guard to ensure gameActions exists
@@ -177,15 +176,17 @@ export default function Home() {
         ) : (
           <>
             {/* ① RoomList: 部屋に入っていない && ゲーム未開始 */}
-            <div style={{ display: (!currentRoomId && !gameStarted) ? 'block' : 'none' }}>
-              <RoomList
-                isConnected={isConnected}
-                isConnecting={isConnecting}
-                users={users}
-                currentPlayerId={currentPlayerId}
-              />
-              <Footer />
-            </div>
+            {!currentRoomId && !gameStarted && (
+              <div>
+                <RoomList
+                  isConnected={isConnected}
+                  isConnecting={isConnecting}
+                  users={users}
+                  currentPlayerId={currentPlayerId}
+                />
+                <Footer />
+              </div>
+            )}
 
             {/* ② PreGameTable: 待機中 / GameTable: ゲーム中 */}
             {currentRoomId && (

--- a/mei-tra-frontend/app/[locale]/rooms/page.tsx
+++ b/mei-tra-frontend/app/[locale]/rooms/page.tsx
@@ -4,13 +4,11 @@ import { Navigation } from '@/components/layout/Navigation';
 import { Footer } from '@/components/layout/Footer';
 import { RoomList } from '@/components/room/RoomList';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
-import { useSocket } from '@/hooks/useSocket';
 import { useRouter } from '@/i18n/routing';
 
 export const dynamic = 'force-dynamic';
 
 export default function RoomsPage() {
-  const { isConnected, isConnecting } = useSocket();
   const router = useRouter();
 
   return (
@@ -18,8 +16,6 @@ export default function RoomsPage() {
       <Navigation />
       <main>
         <RoomList
-          isConnected={isConnected}
-          isConnecting={isConnecting}
           onRoomEntered={() => router.push('/')}
         />
         <Footer />

--- a/mei-tra-frontend/app/socket.ts
+++ b/mei-tra-frontend/app/socket.ts
@@ -3,6 +3,13 @@ import { getSocketBaseUrl } from '@/lib/socket-url';
 
 let socket: Socket | null = null;
 let latestAuthToken: string | undefined;
+let authTokenProvider: (() => Promise<string | null>) | undefined;
+
+export function setSocketAuthTokenProvider(
+  provider: (() => Promise<string | null>) | undefined,
+): void {
+  authTokenProvider = provider;
+}
 
 function detectSafari(): boolean {
   if (typeof window === 'undefined') return false;
@@ -28,9 +35,12 @@ export function getSocket(authToken?: string): Socket {
       // This ensures that after a server restart, the socket reconnects with the correct
       // roomId (set in sessionStorage when the player joined a room), allowing the server
       // to re-add the socket to the correct socket.io room and receive room broadcasts.
-      auth: (cb: (data: { roomId: string; token?: string }) => void) => {
+      auth: async (cb: (data: { roomId: string; token?: string }) => void) => {
         const currentRoomId = sessionStorage.getItem('roomId') || '';
         console.log('[Socket] Auth callback — roomId from sessionStorage:', currentRoomId || 'none');
+        if (authTokenProvider) {
+          latestAuthToken = await authTokenProvider() ?? latestAuthToken;
+        }
         cb({ roomId: currentRoomId, token: latestAuthToken });
       },
       autoConnect: false,
@@ -84,9 +94,12 @@ export function reconnectSocket(authToken?: string): Socket {
   latestAuthToken = authToken ?? latestAuthToken;
 
   if (socket) {
-    socket.auth = (cb: (data: { roomId: string; token?: string }) => void) => {
+    socket.auth = async (cb: (data: { roomId: string; token?: string }) => void) => {
       const currentRoomId = sessionStorage.getItem('roomId') || '';
       console.log('[Socket] Reconnect auth callback — roomId from sessionStorage:', currentRoomId || 'none');
+      if (authTokenProvider) {
+        latestAuthToken = await authTokenProvider() ?? latestAuthToken;
+      }
       cb({ roomId: currentRoomId, token: latestAuthToken });
     };
     socket.disconnect();

--- a/mei-tra-frontend/components/game/CompletedFields/index.module.scss
+++ b/mei-tra-frontend/components/game/CompletedFields/index.module.scss
@@ -1,5 +1,34 @@
 @use '../../../styles/base/typography' as typography;
 
+.completedFieldsPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  width: 100%;
+  max-width: 100%;
+}
+
+.summary {
+  display: inline-flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 0.45rem;
+  align-self: center;
+  padding: 0.15rem 0.65rem;
+  border-radius: var(--mt-radius-pill);
+  background: color-mix(in srgb, var(--mt-surface) 72%, transparent);
+  color: var(--mt-text-secondary);
+  font-size: typography.scale(0.72rem);
+  line-height: 1.2;
+  box-shadow: var(--mt-shadow-soft);
+}
+
+.summary strong {
+  color: var(--mt-text-primary);
+  font-size: typography.scale(0.9rem);
+  font-weight: 800;
+}
+
 .completedFieldsContainer {
   display: flex;
   flex-wrap: nowrap;
@@ -64,6 +93,15 @@
     min-height: 4rem;
     padding: 0;
     width: 100%;
+  }
+
+  .summary {
+    font-size: typography.scale(0.66rem);
+    padding: 0.12rem 0.5rem;
+  }
+
+  .summary strong {
+    font-size: typography.scale(0.82rem);
   }
 
   .completedField {

--- a/mei-tra-frontend/components/game/CompletedFields/index.tsx
+++ b/mei-tra-frontend/components/game/CompletedFields/index.tsx
@@ -13,25 +13,33 @@ export const CompletedFields: React.FC<CompletedFieldsProps> = ({ fields, player
   const t = useTranslations('completedFields');
 
   return (
-    <div className={styles.completedFieldsContainer}>
-      {fields.map((field, index) => {
-        const winnerName = players.find(p => p.playerId === field.winnerId)?.name || t('unknown');
-        return (
-          <div key={index} className={styles.completedField}>
-            <div className={styles.winnerName}>{winnerName}</div>
-            <div className={styles.cards}>
-              {field.cards.map((card: string, cardIndex: number) => {
-                return (
-                  <Card 
-                    key={cardIndex}
-                    card={card}
-                  />
-                );
-              })}
-            </div>
-          </div>
-        );
-      })}
+    <div className={styles.completedFieldsPanel}>
+      <div className={styles.summary}>
+        <span>{t('takenLabel')}</span>
+        <strong>{t('takenCount', { count: fields.length })}</strong>
+      </div>
+      {fields.length > 0 && (
+        <div className={styles.completedFieldsContainer}>
+          {fields.map((field, index) => {
+            const winnerName = players.find(p => p.playerId === field.winnerId)?.name || t('unknown');
+            return (
+              <div key={index} className={styles.completedField}>
+                <div className={styles.winnerName}>{winnerName}</div>
+                <div className={styles.cards}>
+                  {field.cards.map((card: string, cardIndex: number) => {
+                    return (
+                      <Card
+                        key={cardIndex}
+                        card={card}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 };

--- a/mei-tra-frontend/components/game/PlayerHand/index.tsx
+++ b/mei-tra-frontend/components/game/PlayerHand/index.tsx
@@ -369,7 +369,7 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
           )}
         </div>
         {renderPlayerHand(isCurrentPlayer)}
-        {completedFields.length > 0 && (
+        {(completedFields.length > 0 || (position === 'bottom' && gamePhase === 'play')) && (
           <div className={styles.completedFields}>
             <CompletedFields
               fields={completedFields}

--- a/mei-tra-frontend/components/room/RoomList/index.tsx
+++ b/mei-tra-frontend/components/room/RoomList/index.tsx
@@ -51,12 +51,23 @@ export const RoomList: React.FC<RoomListProps> = ({
   const t = useTranslations();
   const { user } = useAuth();
   const memoizedUsers = useMemo(() => users, [users]);
-  const { availableRooms, createRoom, joinRoom, watchRoom, error, currentRoom } = useRoom({ users: memoizedUsers, currentPlayerId: currentPlayerIdProp ?? null });
+  const {
+    availableRooms,
+    createRoom,
+    joinRoom,
+    watchRoom,
+    error,
+    currentRoom,
+    isConnected: roomSocketConnected,
+    isConnecting: roomSocketConnecting,
+  } = useRoom({ users: memoizedUsers, currentPlayerId: currentPlayerIdProp ?? null });
   const [newRoomName, setNewRoomName] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
   const [pointsToWin, setPointsToWin] = useState(5);
   const { backendStatus, isLoading } = useBackendStatus();
-  const isSocketReady = Boolean(isConnected && !isConnecting);
+  const effectiveIsConnected = isConnected ?? roomSocketConnected;
+  const effectiveIsConnecting = isConnecting ?? roomSocketConnecting;
+  const isSocketReady = Boolean(effectiveIsConnected && !effectiveIsConnecting);
   const disableRoomActions = backendStatus.isStarting || !isSocketReady;
 
   const filteredRooms = useMemo(() => {
@@ -140,8 +151,8 @@ export const RoomList: React.FC<RoomListProps> = ({
       )}
 
       {/* 接続状態の表示 */}
-      {isConnecting && <div className={styles.connecting}>{t('room.connecting')}</div>}
-      {!isConnected && !isConnecting && <div className={styles.error}>{t('room.notConnected')}</div>}
+      {effectiveIsConnecting && <div className={styles.connecting}>{t('room.connecting')}</div>}
+      {!effectiveIsConnected && !effectiveIsConnecting && <div className={styles.error}>{t('room.notConnected')}</div>}
       {error && <div className={styles.error}>{error}</div>}
 
       <div className={styles.section}>

--- a/mei-tra-frontend/contexts/AuthContext.tsx
+++ b/mei-tra-frontend/contexts/AuthContext.tsx
@@ -33,6 +33,26 @@ interface AuthContextType {
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
+const TOKEN_REFRESH_SKEW_SECONDS = 60;
+
+function getJwtExpiresAt(token: string): number | null {
+  try {
+    const [, payload] = token.split('.');
+    if (!payload) return null;
+
+    const normalizedPayload = payload
+      .replace(/-/g, '+')
+      .replace(/_/g, '/')
+      .padEnd(Math.ceil(payload.length / 4) * 4, '=');
+    const decodedPayload = JSON.parse(atob(normalizedPayload)) as {
+      exp?: unknown;
+    };
+
+    return typeof decodedPayload.exp === 'number' ? decodedPayload.exp : null;
+  } catch {
+    return null;
+  }
+}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);
@@ -410,7 +430,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const { data, error } = await supabase.auth.getSession();
     if (error || !data.session) return null;
 
-    return data.session.access_token;
+    const expiresAt =
+      data.session.expires_at ?? getJwtExpiresAt(data.session.access_token);
+    const shouldRefresh =
+      typeof expiresAt === 'number' &&
+      expiresAt - TOKEN_REFRESH_SKEW_SECONDS <= Math.floor(Date.now() / 1000);
+
+    if (!shouldRefresh) {
+      return data.session.access_token;
+    }
+
+    const { data: refreshedData, error: refreshError } =
+      await supabase.auth.refreshSession();
+    if (refreshError || !refreshedData.session) {
+      console.warn('[AuthContext] Failed to refresh access token', refreshError);
+      return null;
+    }
+
+    setSession(refreshedData.session);
+    return refreshedData.session.access_token;
   }, []); // No dependencies - always get fresh session
 
   const refreshSession = useCallback(async () => {

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -46,7 +46,6 @@ import {
 } from '../types/game.types';
 import { fromRoomContract, fromRoomSyncPayload } from '../types/room.types';
 import { getTeamDisplayName } from '../lib/utils/teamUtils';
-import { reconnectSocket } from '../app/socket';
 import { clearPlayerProfileCache } from '../lib/utils/profileUtils';
 import { inferNextTurnAfterCardPlayed } from '../lib/utils/turnInference';
 
@@ -159,7 +158,7 @@ export const useGame = () => {
   const tStatus = useTranslations('playerStatus');
   const t = useTranslations('game');
   const { socket, isConnected, isConnecting } = useSocket();
-  const { user, getAccessToken } = useAuth();
+  const { user } = useAuth();
   const gameOverShownRef = useRef<string | null>(null);
   const agariRequestKeyRef = useRef<string | null>(null);
   const roomBootstrapRef = useRef<string | null>(null);
@@ -338,25 +337,9 @@ export const useGame = () => {
 
     roomBootstrapRef.current = storedRoomId;
 
-    let cancelled = false;
-
-    void (async () => {
-      const token = await getAccessToken();
-      if (cancelled || !token) {
-        if (!token) {
-          roomBootstrapRef.current = null;
-        }
-        return;
-      }
-
-      console.log('[useGame] Bootstrapping room state from stored roomId:', storedRoomId);
-      reconnectSocket(token);
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [currentRoomId, getAccessToken, socket, user]);
+    console.log('[useGame] Syncing room state from stored roomId:', storedRoomId);
+    socket.emit('sync-game-state', { roomId: storedRoomId });
+  }, [currentRoomId, socket, user]);
 
   useEffect(() => {
     if (currentRoomId) {
@@ -1215,6 +1198,7 @@ export const useGame = () => {
     return {
       isLoading: true,
       loadingStep: 'クライアントを初期化中...',
+      socket,
       isConnected: false,
       isConnecting: false,
       gameOverModal: null,
@@ -1227,6 +1211,7 @@ export const useGame = () => {
     return {
       isLoading: true,
       loadingStep: loadingState.step,
+      socket,
       isConnected,
       isConnecting,
       gameOverModal: null,
@@ -1275,6 +1260,7 @@ export const useGame = () => {
     pointsToWin,
     users,
     paused,
+    socket,
     isConnected,
     isConnecting,
   };

--- a/mei-tra-frontend/hooks/useRoom.ts
+++ b/mei-tra-frontend/hooks/useRoom.ts
@@ -33,7 +33,11 @@ export const useRoom = (options: UseRoomOptions = {}) => {
   const [error, setError] = useState<string | null>(null);
   const [playerReadyStatus, setPlayerReadyStatus] = useState<Record<string, boolean>>({});
   const [isClient, setIsClient] = useState(false);
-  const { socket } = useSocket();
+  const {
+    socket,
+    isConnected: socketConnected,
+    isConnecting: socketConnecting,
+  } = useSocket();
   const { user } = useAuth();
 
   const users = useMemo(() => options.users ?? [], [options.users]);
@@ -739,6 +743,8 @@ export const useRoom = (options: UseRoomOptions = {}) => {
       playerReadyStatus: {},
       changePlayerTeam: () => {},
       fillWithCOM: () => {},
+      isConnected: false,
+      isConnecting: false,
     };
   }
 
@@ -756,5 +762,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
     playerReadyStatus,
     changePlayerTeam,
     fillWithCOM,
+    isConnected: socketConnected,
+    isConnecting: socketConnecting,
   };
 };

--- a/mei-tra-frontend/hooks/useSocket.ts
+++ b/mei-tra-frontend/hooks/useSocket.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { Socket } from 'socket.io-client';
-import { getSocket } from '../app/socket';
+import {
+  getExistingSocket,
+  getSocket,
+  setSocketAuthTokenProvider,
+} from '../app/socket';
 import { useAuth } from './useAuth';
 
 export interface UseSocketReturn {
@@ -8,6 +12,8 @@ export interface UseSocketReturn {
   isConnected: boolean;
   isConnecting: boolean;
 }
+
+let sharedConnectInFlight = false;
 
 export function useSocket(): UseSocketReturn {
   const { getAccessToken, loading, user } = useAuth();
@@ -28,6 +34,7 @@ export function useSocket(): UseSocketReturn {
 
     const initializeSocket = async () => {
       isInitializingRef.current = true;
+      setSocketAuthTokenProvider(getAccessToken);
 
       // If a socket already exists and is connected, reflect that immediately
       if (socketRef.current?.connected) {
@@ -61,9 +68,11 @@ export function useSocket(): UseSocketReturn {
         console.log('[useSocket] Auth token retrieved, initializing socket with token');
         authTokenRef.current = token;
 
-        // Initialize socket with auth token
+        // Initialize or reuse the shared game socket. Multiple hooks can call
+        // useSocket on the same page, but only one socket connection should be
+        // created and connected.
         if (!socketRef.current) {
-          socketRef.current = getSocket(token);
+          socketRef.current = getExistingSocket() ?? getSocket(token);
         }
         managedSocket = socketRef.current;
 
@@ -74,6 +83,7 @@ export function useSocket(): UseSocketReturn {
             if (!isMounted) return;
             setIsConnected(true);
             setIsConnecting(false);
+            sharedConnectInFlight = false;
             isInitializingRef.current = false;
           };
 
@@ -89,6 +99,7 @@ export function useSocket(): UseSocketReturn {
             if (!isMounted) return;
             setIsConnected(false);
             setIsConnecting(true);
+            sharedConnectInFlight = false;
             isInitializingRef.current = false;
           };
 
@@ -98,6 +109,7 @@ export function useSocket(): UseSocketReturn {
             setIsConnected(false);
             // Backend cold start中も再接続を継続する
             setIsConnecting(true);
+            sharedConnectInFlight = false;
             isInitializingRef.current = false;
           };
 
@@ -132,9 +144,16 @@ export function useSocket(): UseSocketReturn {
           managedSocket.io.on('reconnect_failed', handleReconnectFailed);
 
           // Connect the socket if not already connected
-          if (!managedSocket.connected) {
+          if (!managedSocket.connected && !sharedConnectInFlight) {
             console.log('[useSocket] Attempting to connect socket with auth token...');
+            sharedConnectInFlight = true;
             managedSocket.connect();
+          } else if (!managedSocket.connected) {
+            console.log('[useSocket] Socket connection already in progress');
+            if (isMounted) {
+              setIsConnecting(true);
+            }
+            isInitializingRef.current = false;
           } else {
             // Already connected, update state immediately
             console.log('[useSocket] Socket already connected');

--- a/mei-tra-frontend/messages/en.json
+++ b/mei-tra-frontend/messages/en.json
@@ -382,6 +382,8 @@
     "unknown": "Unknown"
   },
   "completedFields": {
+    "takenLabel": "Taken",
+    "takenCount": "{count} pairs",
     "unknown": "Unknown"
   },
   "chatDock": {

--- a/mei-tra-frontend/messages/ja.json
+++ b/mei-tra-frontend/messages/ja.json
@@ -382,6 +382,8 @@
     "unknown": "不明"
   },
   "completedFields": {
+    "takenLabel": "取得ペア",
+    "takenCount": "{count}ペア",
     "unknown": "不明"
   },
   "chatDock": {


### PR DESCRIPTION
## Summary
- Remove legacy duplicated player state from persisted game JSON and shift reads/writes to the roster-backed shape.
- Rejoin sockets to the room during `sync-game-state` and reuse the shared frontend Socket.IO connection.
- Refresh Socket auth tokens on reconnect so expired JWTs do not leave active games unable to progress.
- Add a completed-fields summary showing how many pairs the current team has taken.

## Why
- Player roster data was duplicated across `room_players` and legacy JSON fields, which made recovery and migration paths harder to reason about.
- Reconnect paths could restore local game state without rejoining the Socket.IO room, or reconnect with a stale JWT.
- During play, players could see completed fields but not the current taken-pair count at a glance.

## Validation
- `cd mei-tra-backend && npm test -- --runInBand src/__tests__/game.gateway.com-recovery.spec.ts src/repositories/implementations/supabase-game-state.repository.spec.ts src/use-cases/__tests__/shuffle-teams.use-case.spec.ts`
- `cd mei-tra-frontend && npm test -- __tests__/components/CompletedFields.test.tsx --runInBand`
- `cd mei-tra-frontend && npm test -- __tests__/app/socket.test.ts --runInBand`
- `cd mei-tra-frontend && npm run lint`
- `cd mei-tra-frontend && npm run build`
