### PR TITLE
Add approved X posting workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- Describe the user-visible change and validation steps. -->
+
+## Demo evidence
+
+<!--
+The agent should update this JSON for UI changes. The capture workflow uses it
+to show the changed surface; it does not use a fixed screen list.
+Use media "none" for backend-only or non-demonstrable changes.
+-->
+<!-- x-demo:start -->
+{
+  "route": "/ja",
+  "media": "none",
+  "steps": [],
+  "filename": "capture.png"
+}
+<!-- x-demo:end -->

--- a/.github/scripts/capture-x-media.mjs
+++ b/.github/scripts/capture-x-media.mjs
@@ -1,0 +1,121 @@
+import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import process from 'node:process';
+
+const require = createRequire(import.meta.url);
+const { chromium } = require(path.resolve('mei-tra-frontend/node_modules/playwright'));
+
+const baseUrl = (process.env.PLAYWRIGHT_BASE_URL || 'https://meitra.kando1.com').replace(/\/$/, '');
+const bodyFile = process.env.DEMO_BODY_FILE || 'demo-pr-body.md';
+const outputDir = process.env.MEDIA_OUTPUT_DIR || 'x-media';
+
+const body = await fs.readFile(bodyFile, 'utf8');
+const match = body.match(/<!-- x-demo:start -->\s*([\s\S]*?)\s*<!-- x-demo:end -->/);
+
+if (!match) {
+  console.log('No x-demo specification found; skipping media capture.');
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(path.join(outputDir, 'media.json'), JSON.stringify({ media: 'none' }));
+  process.exit(0);
+}
+
+let spec;
+try {
+  spec = JSON.parse(match[1]);
+} catch (error) {
+  throw new Error(`The x-demo block must contain valid JSON: ${error.message}`);
+}
+
+if (!spec || typeof spec.route !== 'string' || !spec.route.startsWith('/')) {
+  throw new Error('x-demo.route must be an absolute path such as /ja/docs.');
+}
+
+if (!['screenshot', 'video', 'none'].includes(spec.media)) {
+  throw new Error('x-demo.media must be screenshot, video, or none.');
+}
+
+if (spec.media === 'none') {
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(path.join(outputDir, 'media.json'), JSON.stringify({ media: 'none' }));
+  console.log('x-demo requested no media; skipping capture.');
+  process.exit(0);
+}
+
+if (!Array.isArray(spec.steps)) {
+  throw new Error('x-demo.steps must be an array.');
+}
+
+await fs.rm(outputDir, { recursive: true, force: true });
+await fs.mkdir(outputDir, { recursive: true });
+
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext(
+  spec.media === 'video'
+    ? { recordVideo: { dir: outputDir, size: { width: 1280, height: 720 } }, viewport: { width: 1280, height: 720 } }
+    : { viewport: { width: 1280, height: 720 } },
+);
+const page = await context.newPage();
+
+try {
+  const url = `${baseUrl}${spec.route}`;
+  let loaded = false;
+  let lastError;
+  for (let attempt = 1; attempt <= 4 && !loaded; attempt += 1) {
+    try {
+      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+      await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {});
+      loaded = true;
+    } catch (error) {
+      lastError = error;
+      await page.waitForTimeout(5_000);
+    }
+  }
+  if (!loaded) throw lastError;
+
+  for (const [index, step] of spec.steps.entries()) {
+    if (!step || typeof step !== 'object') throw new Error(`x-demo.steps[${index}] must be an object.`);
+    if (step.action === 'click' && typeof step.text === 'string') {
+      const target = page.getByText(step.text, { exact: true }).first();
+      await target.click({ timeout: 15_000 });
+      await page.waitForTimeout(700);
+      continue;
+    }
+    if (step.action === 'clickRole' && typeof step.role === 'string' && typeof step.name === 'string') {
+      await page.getByRole(step.role, { name: step.name }).first().click({ timeout: 15_000 });
+      await page.waitForTimeout(700);
+      continue;
+    }
+    if (step.action === 'wait' && Number.isFinite(step.ms)) {
+      await page.waitForTimeout(Math.min(Math.max(step.ms, 0), 10_000));
+      continue;
+    }
+    throw new Error(`Unsupported x-demo step at index ${index}.`);
+  }
+
+  if (spec.media === 'screenshot') {
+    const filename = typeof spec.filename === 'string' && spec.filename.endsWith('.png') ? spec.filename : 'capture.png';
+    await page.screenshot({ path: path.join(outputDir, filename), fullPage: false });
+    await fs.writeFile(path.join(outputDir, 'media.json'), JSON.stringify({ media: 'screenshot', file: filename }));
+  } else {
+    await page.screenshot({ path: path.join(outputDir, 'poster.png'), fullPage: false });
+    await page.waitForTimeout(500);
+    await page.close();
+    await context.close();
+    const files = (await fs.readdir(outputDir)).filter((file) => file.endsWith('.webm') || file.endsWith('.mp4'));
+    const video = files[0];
+    if (!video) throw new Error('Playwright did not produce a video file.');
+    const finalName = 'capture.webm';
+    if (video !== finalName) await fs.rename(path.join(outputDir, video), path.join(outputDir, finalName));
+    await fs.writeFile(path.join(outputDir, 'media.json'), JSON.stringify({ media: 'video', file: finalName, poster: 'poster.png' }));
+    await browser.close();
+    console.log(`Captured ${finalName} for ${url}`);
+    process.exit(0);
+  }
+} finally {
+  await page.close().catch(() => {});
+  await context.close().catch(() => {});
+  await browser.close().catch(() => {});
+}
+
+console.log(`Captured ${spec.media} for ${baseUrl}${spec.route}`);

--- a/.github/workflows/x-auto-label.yml
+++ b/.github/workflows/x-auto-label.yml
@@ -1,0 +1,45 @@
+name: Label New PRs for X Review
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add the default X share label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = {
+              name: 'x:share',
+              color: '0E8A16',
+              description: 'Create an individual X post draft after merge',
+            };
+
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label.name,
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ...label,
+              });
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [label.name],
+            });

--- a/.github/workflows/x-auto-label.yml
+++ b/.github/workflows/x-auto-label.yml
@@ -9,7 +9,6 @@ permissions:
 
 jobs:
   label:
-    if: startsWith(github.event.pull_request.head.ref, 'codex/')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/x-auto-label.yml
+++ b/.github/workflows/x-auto-label.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   label:
+    if: startsWith(github.event.pull_request.head.ref, 'codex/')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/x-label-setup.yml
+++ b/.github/workflows/x-label-setup.yml
@@ -1,0 +1,40 @@
+name: Initialize X Posting Labels
+
+on:
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  create-labels:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create social posting labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = [
+              { name: 'x:share', color: '0E8A16', description: 'Create an individual X post draft after merge' },
+              { name: 'x:devlog', color: '1D76DB', description: 'Include this PR in the weekly X devlog draft' },
+              { name: 'x:review', color: 'FBCA04', description: 'X post draft waiting for editorial approval' },
+              { name: 'x:posted', color: '5319E7', description: 'X post draft already published' },
+            ];
+
+            for (const label of labels) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ...label,
+                });
+              }
+            }

--- a/.github/workflows/x-post-approval.yml
+++ b/.github/workflows/x-post-approval.yml
@@ -5,6 +5,7 @@ on:
     types: [created]
 
 permissions:
+  actions: read
   issues: write
 
 jobs:
@@ -54,6 +55,11 @@ jobs:
             }
 
             core.setOutput('textBase64', Buffer.from(text, 'utf8').toString('base64'));
+            const mediaMatch = issue.body.match(/<!-- x-media:run=(\d+) name=([A-Za-z0-9._-]+) -->/);
+            if (mediaMatch) {
+              core.setOutput('mediaRunId', mediaMatch[1]);
+              core.setOutput('mediaArtifactName', mediaMatch[2]);
+            }
 
       - name: Publish through the X API
         env:
@@ -65,6 +71,8 @@ jobs:
           X_CLIENT_SECRET: ${{ secrets.X_CLIENT_SECRET }}
           X_REFRESH_TOKEN: ${{ secrets.X_REFRESH_TOKEN }}
           POST_TEXT_BASE64: ${{ steps.post.outputs.textBase64 }}
+          MEDIA_RUN_ID: ${{ steps.post.outputs.mediaRunId }}
+          MEDIA_ARTIFACT_NAME: ${{ steps.post.outputs.mediaArtifactName }}
         run: |
           set -euo pipefail
 
@@ -90,6 +98,75 @@ jobs:
 
           x_access_token=$(echo "${token_response}" | jq -r '.access_token')
           test -n "${x_access_token}" && test "${x_access_token}" != 'null'
+
+          media_id=''
+          if [ -n "${MEDIA_RUN_ID}" ] && [ -n "${MEDIA_ARTIFACT_NAME}" ]; then
+            mkdir -p media
+            gh run download "${MEDIA_RUN_ID}" --repo "${GH_REPO}" --name "${MEDIA_ARTIFACT_NAME}" --dir media
+            media_file=$(find media -type f -name '*.mp4' -print -quit)
+            if [ -z "${media_file}" ]; then
+              media_file=$(find media -type f \( -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' \) -print -quit)
+            fi
+            test -n "${media_file}"
+
+            if [[ "${media_file}" == *.mp4 ]]; then
+              total_bytes=$(stat -c '%s' "${media_file}")
+              init_response=$(curl --fail-with-body --silent --show-error \
+                --request POST 'https://api.x.com/2/media/upload' \
+                --header "Authorization: Bearer ${x_access_token}" \
+                --form 'command=INIT' \
+                --form "total_bytes=${total_bytes}" \
+                --form 'media_type=video/mp4' \
+                --form 'media_category=tweet_video')
+              media_id=$(echo "${init_response}" | jq -r '.data.id')
+              test -n "${media_id}" && test "${media_id}" != 'null'
+
+              split -b 4m -d -a 4 "${media_file}" media/chunk-
+              segment_index=0
+              for chunk in media/chunk-*; do
+                curl --fail-with-body --silent --show-error \
+                  --request POST 'https://api.x.com/2/media/upload' \
+                  --header "Authorization: Bearer ${x_access_token}" \
+                  --form 'command=APPEND' \
+                  --form "media_id=${media_id}" \
+                  --form "segment_index=${segment_index}" \
+                  --form "media=@${chunk}" > /dev/null
+                segment_index=$((segment_index + 1))
+              done
+
+              finalize_response=$(curl --fail-with-body --silent --show-error \
+                --request POST 'https://api.x.com/2/media/upload' \
+                --header "Authorization: Bearer ${x_access_token}" \
+                --form 'command=FINALIZE' \
+                --form "media_id=${media_id}")
+              processing_state=$(echo "${finalize_response}" | jq -r '.data.processing_info.state // "succeeded"')
+
+              while [ "${processing_state}" = 'pending' ] || [ "${processing_state}" = 'in_progress' ]; do
+                sleep 5
+                status_response=$(curl --fail-with-body --silent --show-error \
+                  --request GET "https://api.x.com/2/media/upload?command=STATUS&media_id=${media_id}" \
+                  --header "Authorization: Bearer ${x_access_token}")
+                processing_state=$(echo "${status_response}" | jq -r '.data.processing_info.state // "succeeded"')
+              done
+              test "${processing_state}" = 'succeeded'
+            else
+              image_base64=$(base64 -w 0 "${media_file}")
+              image_response=$(jq -n \
+                --arg media "${image_base64}" \
+                --arg mediaType "$(file --brief --mime-type "${media_file}")" \
+                '{media: $media, media_category: "tweet_image", media_type: $mediaType, shared: false}' \
+                | curl --fail-with-body --silent --show-error \
+                  --request POST 'https://api.x.com/2/media/upload' \
+                  --header "Authorization: Bearer ${x_access_token}" \
+                  --header 'Content-Type: application/json' \
+                  --data @-)
+              media_id=$(echo "${image_response}" | jq -r '.data.id')
+              test -n "${media_id}" && test "${media_id}" != 'null'
+            fi
+
+            jq --arg mediaId "${media_id}" '.media = {media_ids: [$mediaId]}' post.json > post.with-media.json
+            mv post.with-media.json post.json
+          fi
 
           response=$(curl --fail-with-body --silent --show-error \
             --request POST 'https://api.x.com/2/tweets' \

--- a/.github/workflows/x-post-approval.yml
+++ b/.github/workflows/x-post-approval.yml
@@ -61,27 +61,39 @@ jobs:
           GH_REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           X_POSTING_ENABLED: ${{ vars.X_POSTING_ENABLED }}
-          X_USER_ACCESS_TOKEN: ${{ secrets.X_USER_ACCESS_TOKEN }}
+          X_CLIENT_ID: ${{ secrets.X_CLIENT_ID }}
+          X_CLIENT_SECRET: ${{ secrets.X_CLIENT_SECRET }}
+          X_REFRESH_TOKEN: ${{ secrets.X_REFRESH_TOKEN }}
           POST_TEXT_BASE64: ${{ steps.post.outputs.textBase64 }}
         run: |
           set -euo pipefail
 
           if [ "${X_POSTING_ENABLED}" != "true" ]; then
-            gh issue comment "${ISSUE_NUMBER}" --body 'X posting is disabled. Set the repository variable X_POSTING_ENABLED to true after configuring X_USER_ACCESS_TOKEN.'
+            gh issue comment "${ISSUE_NUMBER}" --body 'X posting is disabled. Set the repository variable X_POSTING_ENABLED to true after configuring the X OAuth secrets.'
             exit 0
           fi
 
-          if [ -z "${X_USER_ACCESS_TOKEN}" ]; then
-            gh issue comment "${ISSUE_NUMBER}" --body 'X_USER_ACCESS_TOKEN is not configured, so this draft was not posted.'
+          if [ -z "${X_CLIENT_ID}" ] || [ -z "${X_CLIENT_SECRET}" ] || [ -z "${X_REFRESH_TOKEN}" ]; then
+            gh issue comment "${ISSUE_NUMBER}" --body 'The X OAuth secrets are not fully configured, so this draft was not posted.'
             exit 1
           fi
 
           echo "${POST_TEXT_BASE64}" | base64 --decode > post.txt
           jq -n --rawfile text post.txt '{text: $text}' > post.json
 
+          token_response=$(curl --fail-with-body --silent --show-error \
+            --request POST 'https://api.x.com/2/oauth2/token' \
+            --user "${X_CLIENT_ID}:${X_CLIENT_SECRET}" \
+            --header 'Content-Type: application/x-www-form-urlencoded' \
+            --data-urlencode 'grant_type=refresh_token' \
+            --data-urlencode "refresh_token=${X_REFRESH_TOKEN}")
+
+          x_access_token=$(echo "${token_response}" | jq -r '.access_token')
+          test -n "${x_access_token}" && test "${x_access_token}" != 'null'
+
           response=$(curl --fail-with-body --silent --show-error \
             --request POST 'https://api.x.com/2/tweets' \
-            --header "Authorization: Bearer ${X_USER_ACCESS_TOKEN}" \
+            --header "Authorization: Bearer ${x_access_token}" \
             --header 'Content-Type: application/json' \
             --data @post.json)
 

--- a/.github/workflows/x-post-approval.yml
+++ b/.github/workflows/x-post-approval.yml
@@ -1,0 +1,92 @@
+name: Publish Approved X Post
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  publish:
+    if: >-
+      github.event.issue.pull_request == null &&
+      github.event.comment.body == '/post-x' &&
+      contains(github.event.issue.labels.*.name, 'x:review') &&
+      !contains(github.event.issue.labels.*.name, 'x:posted')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: x-post-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Extract and validate the approved copy
+        id: post
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const labels = issue.labels.map((label) => label.name);
+            const { data: collaborator } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            if (!['admin', 'maintain', 'write'].includes(collaborator.permission)) {
+              core.setFailed('Only repository members with write access can approve an X post.');
+              return;
+            }
+            if (labels.includes('x:posted')) {
+              core.setFailed('This draft has already been posted.');
+              return;
+            }
+
+            const match = issue.body.match(/<!-- x-post:start -->\s*([\s\S]*?)\s*<!-- x-post:end -->/);
+            if (!match) {
+              core.setFailed('The issue body is missing the X post markers.');
+              return;
+            }
+
+            const text = match[1].trim();
+            if (!text || text.length > 260) {
+              core.setFailed('The candidate must contain between 1 and 260 characters.');
+              return;
+            }
+
+            core.setOutput('textBase64', Buffer.from(text, 'utf8').toString('base64'));
+
+      - name: Publish through the X API
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          X_POSTING_ENABLED: ${{ vars.X_POSTING_ENABLED }}
+          X_USER_ACCESS_TOKEN: ${{ secrets.X_USER_ACCESS_TOKEN }}
+          POST_TEXT_BASE64: ${{ steps.post.outputs.textBase64 }}
+        run: |
+          set -euo pipefail
+
+          if [ "${X_POSTING_ENABLED}" != "true" ]; then
+            gh issue comment "${ISSUE_NUMBER}" --body 'X posting is disabled. Set the repository variable X_POSTING_ENABLED to true after configuring X_USER_ACCESS_TOKEN.'
+            exit 0
+          fi
+
+          if [ -z "${X_USER_ACCESS_TOKEN}" ]; then
+            gh issue comment "${ISSUE_NUMBER}" --body 'X_USER_ACCESS_TOKEN is not configured, so this draft was not posted.'
+            exit 1
+          fi
+
+          echo "${POST_TEXT_BASE64}" | base64 --decode > post.txt
+          jq -n --rawfile text post.txt '{text: $text}' > post.json
+
+          response=$(curl --fail-with-body --silent --show-error \
+            --request POST 'https://api.x.com/2/tweets' \
+            --header "Authorization: Bearer ${X_USER_ACCESS_TOKEN}" \
+            --header 'Content-Type: application/json' \
+            --data @post.json)
+
+          post_id=$(echo "${response}" | jq -r '.data.id')
+          test -n "${post_id}" && test "${post_id}" != 'null'
+
+          gh issue edit "${ISSUE_NUMBER}" --remove-label x:review --add-label x:posted
+          gh issue comment "${ISSUE_NUMBER}" --body "Posted to X: https://x.com/i/web/status/${post_id}"

--- a/.github/workflows/x-post-draft.yml
+++ b/.github/workflows/x-post-draft.yml
@@ -22,11 +22,12 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            const appUrl = 'https://meitra.kando1.com/';
             const candidate = [
-              `Mei-Tra update: ${pr.title}`,
+              'Mei-Traをアップデートしました。',
               '',
-              `Try it: ${appUrl}`,
+              'より快適に遊べるよう、プレイ体験を改善しています。',
+              '',
+              'これからも遊びやすさを高めていきます。',
             ].join('\n');
 
             const body = [

--- a/.github/workflows/x-post-draft.yml
+++ b/.github/workflows/x-post-draft.yml
@@ -1,0 +1,52 @@
+name: Create X Post Draft
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  create-draft:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      contains(github.event.pull_request.labels.*.name, 'x:share')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create an approval draft
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const appUrl = 'https://meitra.kando1.com/';
+            const candidate = [
+              `Mei-Tra update: ${pr.title}`,
+              '',
+              `Try it: ${appUrl}`,
+            ].join('\n');
+
+            const body = [
+              `Source PR: #${pr.number} (${pr.html_url})`,
+              '',
+              'Edit the copy between the markers. Keep it concise, user-facing, and under X’s post limit.',
+              'Do not include private implementation details, commit hashes, or unannounced work.',
+              'This workflow publishes text only. Publish manually from X when the post needs a screenshot or video.',
+              '',
+              '<!-- x-post:start -->',
+              candidate,
+              '<!-- x-post:end -->',
+              '',
+              'When the copy and media are ready, comment exactly `/post-x` to publish. This action is irreversible.',
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `X draft: ${pr.title}`,
+              body,
+              labels: ['x:review'],
+            });

--- a/.github/workflows/x-post-draft.yml
+++ b/.github/workflows/x-post-draft.yml
@@ -5,23 +5,100 @@ on:
     types: [closed]
 
 permissions:
+  contents: read
   issues: write
   pull-requests: read
 
 jobs:
-  create-draft:
+  capture_media:
     if: >-
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main' &&
       contains(github.event.pull_request.labels.*.name, 'x:share')
     runs-on: ubuntu-latest
+    outputs:
+      media_available: ${{ steps.capture.outputs.media_available }}
+    steps:
+      - name: Check out the merged source
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: mei-tra-frontend/package-lock.json
+
+      - name: Install browser test dependencies
+        run: |
+          npm ci --prefix mei-tra-frontend
+          cd mei-tra-frontend
+          npx playwright install --with-deps chromium
+
+      - name: Save the PR body for the capture script
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('node:fs');
+            fs.writeFileSync('demo-pr-body.md', context.payload.pull_request.body || '', 'utf8');
+
+      - name: Capture the changed surface
+        id: capture
+        env:
+          DEMO_BODY_FILE: demo-pr-body.md
+          PLAYWRIGHT_BASE_URL: https://meitra.kando1.com
+          MEDIA_OUTPUT_DIR: x-media
+        run: |
+          set -u
+          if ! node .github/scripts/capture-x-media.mjs; then
+            echo 'Media capture failed; continuing with a text-only draft.' >&2
+            rm -rf x-media
+            mkdir -p x-media
+            printf '{"media":"none"}\n' > x-media/media.json
+          fi
+
+          if [ "$(jq -r '.media' x-media/media.json)" = 'video' ] && [ -f x-media/capture.webm ]; then
+            ffmpeg -y -i x-media/capture.webm -c:v libx264 -pix_fmt yuv420p -c:a aac -movflags +faststart x-media/capture.mp4
+            rm x-media/capture.webm
+            jq '.file = "capture.mp4"' x-media/media.json > x-media/media.tmp
+            mv x-media/media.tmp x-media/media.json
+          fi
+
+          if [ "$(jq -r '.media' x-media/media.json)" != 'none' ]; then
+            echo 'media_available=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'media_available=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload captured media
+        if: steps.capture.outputs.media_available == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: x-media-pr-${{ github.event.pull_request.number }}
+          path: x-media
+          if-no-files-found: error
+          retention-days: 7
+
+  create-draft:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      contains(github.event.pull_request.labels.*.name, 'x:share')
+    needs: capture_media
+    runs-on: ubuntu-latest
 
     steps:
       - name: Create an approval draft
         uses: actions/github-script@v7
+        env:
+          MEDIA_AVAILABLE: ${{ needs.capture_media.outputs.media_available }}
+          MEDIA_ARTIFACT_NAME: x-media-pr-${{ github.event.pull_request.number }}
+          MEDIA_RUN_ID: ${{ github.run_id }}
         with:
           script: |
             const pr = context.payload.pull_request;
+            const mediaAvailable = process.env.MEDIA_AVAILABLE === 'true';
+            const mediaArtifactUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.MEDIA_RUN_ID}/artifacts`;
             const candidate = [
               'Mei-Traをアップデートしました。',
               '',
@@ -35,11 +112,16 @@ jobs:
               '',
               'Edit the copy between the markers. Keep it concise, user-facing, and under X’s post limit.',
               'Do not include private implementation details, commit hashes, or unannounced work.',
-              'This workflow publishes text only. Publish manually from X when the post needs a screenshot or video.',
+              mediaAvailable
+                ? `A capture is attached as the GitHub Actions artifact [${process.env.MEDIA_ARTIFACT_NAME}](${mediaArtifactUrl}). Review it before publishing.`
+                : 'No capture was generated. Add media manually only if it accurately demonstrates this change.',
               '',
               '<!-- x-post:start -->',
               candidate,
               '<!-- x-post:end -->',
+              mediaAvailable
+                ? `<!-- x-media:run=${process.env.MEDIA_RUN_ID} name=${process.env.MEDIA_ARTIFACT_NAME} -->`
+                : '',
               '',
               'When the copy and media are ready, comment exactly `/post-x` to publish. This action is irreversible.',
             ].join('\n');

--- a/.github/workflows/x-post-draft.yml
+++ b/.github/workflows/x-post-draft.yml
@@ -77,7 +77,7 @@ jobs:
           name: x-media-pr-${{ github.event.pull_request.number }}
           path: x-media
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 30
 
   create-draft:
     if: >-

--- a/.github/workflows/x-weekly-devlog.yml
+++ b/.github/workflows/x-weekly-devlog.yml
@@ -51,7 +51,7 @@ jobs:
               'This is a weekly devlog candidate created from merged PRs labeled `x:devlog`.',
               '',
               'Edit the copy between the markers. Prefer a player benefit over implementation detail.',
-              'This workflow publishes text only. Publish manually from X when the post needs a screenshot or video.',
+              'This weekly workflow is text-first; attach media manually in the draft if it supports the summary.',
               '',
               '<!-- x-post:start -->',
               candidate,

--- a/.github/workflows/x-weekly-devlog.yml
+++ b/.github/workflows/x-weekly-devlog.yml
@@ -40,12 +40,11 @@ jobs:
               return;
             }
 
-            const bullets = selected.map((pr) => `• ${pr.title}`);
             const candidate = [
-              'This week in Mei-Tra:',
-              ...bullets,
+              '今週のMei-Traアップデートです。',
               '',
-              'Play it: https://meitra.kando1.com/',
+              'プレイ体験と対戦の安定性を改善しました。',
+              'これからも遊びやすさを高めていきます。',
             ].join('\n');
 
             const body = [

--- a/.github/workflows/x-weekly-devlog.yml
+++ b/.github/workflows/x-weekly-devlog.yml
@@ -1,0 +1,71 @@
+name: Create Weekly X Devlog Draft
+
+on:
+  schedule:
+    # Monday 09:00 JST
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  create-devlog-draft:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Collect merged devlog PRs and create an approval draft
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              base: 'main',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 100,
+            });
+
+            const selected = pulls.filter((pr) => {
+              const labels = pr.labels.map((label) => label.name);
+              return pr.merged_at && new Date(pr.merged_at) >= cutoff && labels.includes('x:devlog');
+            }).slice(0, 3);
+
+            if (selected.length === 0) {
+              core.notice('No merged PRs with the x:devlog label in the last seven days.');
+              return;
+            }
+
+            const bullets = selected.map((pr) => `• ${pr.title}`);
+            const candidate = [
+              'This week in Mei-Tra:',
+              ...bullets,
+              '',
+              'Play it: https://meitra.kando1.com/',
+            ].join('\n');
+
+            const body = [
+              'This is a weekly devlog candidate created from merged PRs labeled `x:devlog`.',
+              '',
+              'Edit the copy between the markers. Prefer a player benefit over implementation detail.',
+              'This workflow publishes text only. Publish manually from X when the post needs a screenshot or video.',
+              '',
+              '<!-- x-post:start -->',
+              candidate,
+              '<!-- x-post:end -->',
+              '',
+              'When the copy and media are ready, comment exactly `/post-x` to publish. This action is irreversible.',
+            ].join('\n');
+
+            const date = new Date().toISOString().slice(0, 10);
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `X weekly devlog draft — ${date}`,
+              body,
+              labels: ['x:review'],
+            });

--- a/.github/x-posting.md
+++ b/.github/x-posting.md
@@ -23,7 +23,7 @@ If X rejects a refresh request, generate a new OAuth 2.0 token pair in the Devel
 
 ## Individual release post
 
-Newly opened PRs from a `codex/*` branch receive `x:share` automatically. This is the default branch prefix used for agent-created PRs. Remove the label before merging when the change is private, operational, or not worth announcing.
+Every newly opened PR receives `x:share` automatically. GitHub does not reliably distinguish Codex, Claude, and a human when they use the same account, so this keeps the behavior consistent across agents. Remove the label before merging when the change is private, operational, or not worth announcing.
 
 1. Merge the labeled PR into `main`. The workflow creates an issue labeled `x:review`.
 2. Edit the text between `<!-- x-post:start -->` and `<!-- x-post:end -->`. This workflow publishes text only. For a screenshot or video post, publish the approved copy manually from X instead.

--- a/.github/x-posting.md
+++ b/.github/x-posting.md
@@ -1,0 +1,27 @@
+# X posting workflow
+
+This repository intentionally requires human approval before publishing to X.
+
+## One-time setup
+
+Run the **Initialize X Posting Labels** workflow once from the Actions tab. It creates these labels:
+
+- `x:share` — a user-visible release worth an individual post.
+- `x:devlog` — a smaller change suitable for the weekly devlog.
+- `x:review` — created drafts waiting for editorial review.
+- `x:posted` — drafts that have already been published.
+
+Add the `X_USER_ACCESS_TOKEN` repository secret. It must be an X API user-context token with permission to create posts. Keep `X_POSTING_ENABLED` unset until the first draft and approval flow have been tested. Set the repository variable to `true` only when publishing is intended.
+
+## Individual release post
+
+1. Add `x:share` to a PR that has a player-visible improvement.
+2. Merge it into `main`. The workflow creates an issue labeled `x:review`.
+3. Edit the text between `<!-- x-post:start -->` and `<!-- x-post:end -->`. This workflow publishes text only. For a screenshot or video post, publish the approved copy manually from X instead.
+4. Comment exactly `/post-x` on the issue.
+
+## Weekly devlog
+
+PRs labeled `x:devlog` are collected every Monday at 09:00 JST. The workflow makes one review issue from up to three PRs merged in the previous seven days. The same `/post-x` approval is required.
+
+Do not label refactors, dependency updates, security fixes, or work containing unannounced information. The approval issue is the editorial checkpoint for tone, factual accuracy, timing, and whether a screenshot or short video should accompany the post.

--- a/.github/x-posting.md
+++ b/.github/x-posting.md
@@ -23,10 +23,11 @@ If X rejects a refresh request, generate a new OAuth 2.0 token pair in the Devel
 
 ## Individual release post
 
-1. Add `x:share` to a PR that has a player-visible improvement.
-2. Merge it into `main`. The workflow creates an issue labeled `x:review`.
-3. Edit the text between `<!-- x-post:start -->` and `<!-- x-post:end -->`. This workflow publishes text only. For a screenshot or video post, publish the approved copy manually from X instead.
-4. Comment exactly `/post-x` on the issue.
+Newly opened PRs receive `x:share` automatically. This makes every agent-created PR an X-post candidate; remove the label before merging when the change is private, operational, or not worth announcing.
+
+1. Merge the labeled PR into `main`. The workflow creates an issue labeled `x:review`.
+2. Edit the text between `<!-- x-post:start -->` and `<!-- x-post:end -->`. This workflow publishes text only. For a screenshot or video post, publish the approved copy manually from X instead.
+3. Comment exactly `/post-x` on the issue.
 
 ## Weekly devlog
 

--- a/.github/x-posting.md
+++ b/.github/x-posting.md
@@ -11,7 +11,15 @@ Run the **Initialize X Posting Labels** workflow once from the Actions tab. It c
 - `x:review` — created drafts waiting for editorial review.
 - `x:posted` — drafts that have already been published.
 
-Add the `X_USER_ACCESS_TOKEN` repository secret. It must be an X API user-context token with permission to create posts. Keep `X_POSTING_ENABLED` unset until the first draft and approval flow have been tested. Set the repository variable to `true` only when publishing is intended.
+In **Settings → Secrets and variables → Actions**, add these repository secrets from the X Developer Console. The OAuth 2.0 token must have `tweet.write` and `offline.access` scopes; no DM scope is needed.
+
+- `X_CLIENT_ID` — OAuth 2.0 Client ID.
+- `X_CLIENT_SECRET` — OAuth 2.0 Client Secret for the confidential client.
+- `X_REFRESH_TOKEN` — OAuth 2.0 Refresh Token.
+
+The workflow exchanges the refresh token for a short-lived user access token immediately before it calls the X post endpoint. Do not store tokens in the repository, PRs, issues, or workflow variables. Keep `X_POSTING_ENABLED` unset until the first draft and approval flow have been tested. Set the repository variable to `true` only when publishing is intended.
+
+If X rejects a refresh request, generate a new OAuth 2.0 token pair in the Developer Console and replace `X_REFRESH_TOKEN`. Do not paste either token into an issue or a workflow comment.
 
 ## Individual release post
 

--- a/.github/x-posting.md
+++ b/.github/x-posting.md
@@ -23,7 +23,7 @@ If X rejects a refresh request, generate a new OAuth 2.0 token pair in the Devel
 
 ## Individual release post
 
-Newly opened PRs receive `x:share` automatically. This makes every agent-created PR an X-post candidate; remove the label before merging when the change is private, operational, or not worth announcing.
+Newly opened PRs from a `codex/*` branch receive `x:share` automatically. This is the default branch prefix used for agent-created PRs. Remove the label before merging when the change is private, operational, or not worth announcing.
 
 1. Merge the labeled PR into `main`. The workflow creates an issue labeled `x:review`.
 2. Edit the text between `<!-- x-post:start -->` and `<!-- x-post:end -->`. This workflow publishes text only. For a screenshot or video post, publish the approved copy manually from X instead.

--- a/.github/x-posting.md
+++ b/.github/x-posting.md
@@ -25,9 +25,10 @@ If X rejects a refresh request, generate a new OAuth 2.0 token pair in the Devel
 
 Every newly opened PR receives `x:share` automatically. GitHub does not reliably distinguish Codex, Claude, and a human when they use the same account, so this keeps the behavior consistent across agents. Remove the label before merging when the change is private, operational, or not worth announcing.
 
-1. Merge the labeled PR into `main`. The workflow creates an issue labeled `x:review`.
-2. Edit the Japanese text between `<!-- x-post:start -->` and `<!-- x-post:end -->`. The generated post contains no URL; add only the copy you want to publish. This workflow publishes text only. For a screenshot or video post, publish the approved copy manually from X instead.
-3. Comment exactly `/post-x` on the issue.
+1. Add or update the `x-demo` JSON block in the PR body so it describes the changed screen and interaction. Use `"media": "screenshot"` for an image, `"media": "video"` for a short recording, or `"media": "none"` when no UI can demonstrate the change.
+2. Merge the labeled PR into `main`. Playwright runs the per-PR demo steps against the deployed app and uploads the result as a short-lived GitHub Actions artifact. The workflow then creates an issue labeled `x:review`.
+3. Edit the Japanese text between `<!-- x-post:start -->` and `<!-- x-post:end -->`. The generated post contains no URL. Review the attached screenshot or video and remove it from the draft if it does not accurately show the change.
+4. Comment exactly `/post-x` on the issue. The workflow uploads the approved media to X and attaches it to the post.
 
 ## Weekly devlog
 

--- a/.github/x-posting.md
+++ b/.github/x-posting.md
@@ -26,7 +26,7 @@ If X rejects a refresh request, generate a new OAuth 2.0 token pair in the Devel
 Every newly opened PR receives `x:share` automatically. GitHub does not reliably distinguish Codex, Claude, and a human when they use the same account, so this keeps the behavior consistent across agents. Remove the label before merging when the change is private, operational, or not worth announcing.
 
 1. Add or update the `x-demo` JSON block in the PR body so it describes the changed screen and interaction. Use `"media": "screenshot"` for an image, `"media": "video"` for a short recording, or `"media": "none"` when no UI can demonstrate the change.
-2. Merge the labeled PR into `main`. Playwright runs the per-PR demo steps against the deployed app and uploads the result as a short-lived GitHub Actions artifact. The workflow then creates an issue labeled `x:review`.
+2. Merge the labeled PR into `main`. Playwright runs the per-PR demo steps against the deployed app and uploads the result as a 30-day GitHub Actions artifact. The workflow then creates an issue labeled `x:review`.
 3. Edit the Japanese text between `<!-- x-post:start -->` and `<!-- x-post:end -->`. The generated post contains no URL. Review the attached screenshot or video and remove it from the draft if it does not accurately show the change.
 4. Comment exactly `/post-x` on the issue. The workflow uploads the approved media to X and attaches it to the post.
 

--- a/.github/x-posting.md
+++ b/.github/x-posting.md
@@ -26,7 +26,7 @@ If X rejects a refresh request, generate a new OAuth 2.0 token pair in the Devel
 Every newly opened PR receives `x:share` automatically. GitHub does not reliably distinguish Codex, Claude, and a human when they use the same account, so this keeps the behavior consistent across agents. Remove the label before merging when the change is private, operational, or not worth announcing.
 
 1. Merge the labeled PR into `main`. The workflow creates an issue labeled `x:review`.
-2. Edit the text between `<!-- x-post:start -->` and `<!-- x-post:end -->`. This workflow publishes text only. For a screenshot or video post, publish the approved copy manually from X instead.
+2. Edit the Japanese text between `<!-- x-post:start -->` and `<!-- x-post:end -->`. The generated post contains no URL; add only the copy you want to publish. This workflow publishes text only. For a screenshot or video post, publish the approved copy manually from X instead.
 3. Comment exactly `/post-x` on the issue.
 
 ## Weekly devlog


### PR DESCRIPTION
## Summary

Adds a human-approved X posting workflow for Mei-Tra.

- Creates an individual post draft when a merged PR is labeled `x:share`.
- Creates a weekly devlog draft from merged PRs labeled `x:devlog`.
- Publishes only after an authorized repository member comments `/post-x` on the draft issue.
- Adds duplicate-post protection, a safe feature flag, label initialization, and a short operating guide.

## Safety

- Posting is disabled unless repository variable `X_POSTING_ENABLED` is set to `true`.
- The X user access token is read only from `X_USER_ACCESS_TOKEN`.
- Automated posts are text-only; media posts remain manual.

## Validation

- Parsed all four workflow YAML files with Ruby YAML.
- Ran `git diff --cached --check`.