### PR TITLE
待機チーム表示とCOMプレイ速度を修正

### DIFF
--- a/.github/workflows/x-post-draft.yml
+++ b/.github/workflows/x-post-draft.yml
@@ -3,6 +3,12 @@ name: Create X Post Draft
 on:
   pull_request:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Merged PR number to capture
+        required: true
+        type: number
 
 permissions:
   contents: read
@@ -12,12 +18,14 @@ permissions:
 jobs:
   capture_media:
     if: >-
-      github.event.pull_request.merged == true &&
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main' &&
-      contains(github.event.pull_request.labels.*.name, 'x:share')
+      contains(github.event.pull_request.labels.*.name, 'x:share'))
     runs-on: ubuntu-latest
     outputs:
       media_available: ${{ steps.capture.outputs.media_available }}
+      pr_number: ${{ steps.pr.outputs.number }}
     steps:
       - name: Check out the merged source
         uses: actions/checkout@v4
@@ -36,11 +44,28 @@ jobs:
           npx playwright install --with-deps chromium
 
       - name: Save the PR body for the capture script
+        id: pr
         uses: actions/github-script@v7
+        env:
+          MANUAL_PR_NUMBER: ${{ inputs.pr_number }}
         with:
           script: |
             const fs = require('node:fs');
-            fs.writeFileSync('demo-pr-body.md', context.payload.pull_request.body || '', 'utf8');
+            const prNumber = context.eventName === 'workflow_dispatch'
+              ? Number(process.env.MANUAL_PR_NUMBER)
+              : context.payload.pull_request.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const labels = pr.labels.map((label) => label.name);
+            if (!pr.merged_at || pr.base.ref !== 'main' || !labels.includes('x:share')) {
+              core.setFailed(`PR #${prNumber} must be a merged main PR with the x:share label.`);
+              return;
+            }
+            fs.writeFileSync('demo-pr-body.md', pr.body || '', 'utf8');
+            core.setOutput('number', String(pr.number));
 
       - name: Capture the changed surface
         id: capture
@@ -74,16 +99,17 @@ jobs:
         if: steps.capture.outputs.media_available == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: x-media-pr-${{ github.event.pull_request.number }}
+          name: x-media-pr-${{ steps.pr.outputs.number }}
           path: x-media
           if-no-files-found: error
           retention-days: 30
 
   create-draft:
     if: >-
-      github.event.pull_request.merged == true &&
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main' &&
-      contains(github.event.pull_request.labels.*.name, 'x:share')
+      contains(github.event.pull_request.labels.*.name, 'x:share'))
     needs: capture_media
     runs-on: ubuntu-latest
 
@@ -92,13 +118,32 @@ jobs:
         uses: actions/github-script@v7
         env:
           MEDIA_AVAILABLE: ${{ needs.capture_media.outputs.media_available }}
-          MEDIA_ARTIFACT_NAME: x-media-pr-${{ github.event.pull_request.number }}
+          MEDIA_ARTIFACT_NAME: x-media-pr-${{ needs.capture_media.outputs.pr_number }}
           MEDIA_RUN_ID: ${{ github.run_id }}
+          PR_NUMBER: ${{ needs.capture_media.outputs.pr_number }}
         with:
           script: |
-            const pr = context.payload.pull_request;
+            const prNumber = Number(process.env.PR_NUMBER);
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
             const mediaAvailable = process.env.MEDIA_AVAILABLE === 'true';
             const mediaArtifactUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.MEDIA_RUN_ID}/artifacts`;
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'x:review',
+              per_page: 100,
+            });
+            const existingIssue = openIssues.find((issue) =>
+              issue.body?.includes(`Source PR: #${pr.number} `),
+            );
+            const existingCandidate = existingIssue?.body?.match(
+              /<!-- x-post:start -->\s*([\s\S]*?)\s*<!-- x-post:end -->/,
+            )?.[1]?.trim();
             const candidate = [
               'Mei-Traをアップデートしました。',
               '',
@@ -106,6 +151,7 @@ jobs:
               '',
               'これからも遊びやすさを高めていきます。',
             ].join('\n');
+            const copy = existingCandidate || candidate;
 
             const body = [
               `Source PR: #${pr.number} (${pr.html_url})`,
@@ -117,7 +163,7 @@ jobs:
                 : 'No capture was generated. Add media manually only if it accurately demonstrates this change.',
               '',
               '<!-- x-post:start -->',
-              candidate,
+              copy,
               '<!-- x-post:end -->',
               mediaAvailable
                 ? `<!-- x-media:run=${process.env.MEDIA_RUN_ID} name=${process.env.MEDIA_ARTIFACT_NAME} -->`
@@ -126,10 +172,20 @@ jobs:
               'When the copy and media are ready, comment exactly `/post-x` to publish. This action is irreversible.',
             ].join('\n');
 
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `X draft: ${pr.title}`,
-              body,
-              labels: ['x:review'],
-            });
+            if (existingIssue) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body,
+              });
+              core.notice(`Updated existing X draft issue #${existingIssue.number}.`);
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `X draft: ${pr.title}`,
+                body,
+                labels: ['x:review'],
+              });
+            }

--- a/.github/x-posting.md
+++ b/.github/x-posting.md
@@ -30,6 +30,10 @@ Every newly opened PR receives `x:share` automatically. GitHub does not reliably
 3. Edit the Japanese text between `<!-- x-post:start -->` and `<!-- x-post:end -->`. The generated post contains no URL. Review the attached screenshot or video and remove it from the draft if it does not accurately show the change.
 4. Comment exactly `/post-x` on the issue. The workflow uploads the approved media to X and attaches it to the post.
 
+## Re-capture a merged PR
+
+If a merged PR was missing its `x-demo` block when it closed, add the block to the PR body and run **Create X Post Draft** manually from the Actions tab. Enter the merged PR number in `Merged PR number to capture`. The workflow validates the `x:share` label, captures the route and steps from the current PR body, uploads the media artifact, and updates the existing `x:review` issue instead of creating a duplicate.
+
 ## Weekly devlog
 
 PRs labeled `x:devlog` are collected every Monday at 09:00 JST. The workflow makes one review issue from up to three PRs merged in the previous seven days. The same `/post-x` approval is required.

--- a/mei-tra-backend/src/services/__tests__/com-autoplay-recovery.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-autoplay-recovery.service.spec.ts
@@ -9,7 +9,9 @@ import {
 } from '../com-autoplay-recovery.service';
 
 const flushPromises = async (): Promise<void> => {
-  await new Promise<void>((resolve) => setImmediate(resolve));
+  for (let index = 0; index < 10; index += 1) {
+    await Promise.resolve();
+  }
 };
 
 const createService = () => {
@@ -43,6 +45,7 @@ const createService = () => {
 
 describe('ComAutoPlayRecoveryService', () => {
   it('completes a persisted full field when its timer was lost', async () => {
+    jest.useFakeTimers();
     const {
       service,
       roomService,
@@ -84,7 +87,6 @@ describe('ComAutoPlayRecoveryService', () => {
 
     service.trigger('room-1', handlers);
     await flushPromises();
-    await flushPromises();
 
     expect(completeFieldUseCase.execute).toHaveBeenCalledWith({
       roomId: 'room-1',
@@ -94,26 +96,19 @@ describe('ComAutoPlayRecoveryService', () => {
       'room-1',
       completionResponse,
     );
+    expect(comAutoPlayUseCase.execute).not.toHaveBeenCalled();
+
+    await jest.runOnlyPendingTimersAsync();
+    await flushPromises();
+
     expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
   });
 
-  it('serializes duplicate recovery triggers and reruns once afterward', async () => {
+  it('serializes duplicate recovery triggers before the delayed step', async () => {
+    jest.useFakeTimers();
     const { service, roomService, comAutoPlayUseCase, handlers } =
       createService();
-    let finishFirstRun:
-      | ((value: {
-          success: boolean;
-          events: never[];
-          shouldContinue: boolean;
-        }) => void)
-      | undefined;
-    const firstRun = new Promise<{
-      success: boolean;
-      events: never[];
-      shouldContinue: boolean;
-    }>((resolve) => {
-      finishFirstRun = resolve;
-    });
 
     roomService.getRoomGameState.mockResolvedValue({
       getState: () => ({
@@ -122,7 +117,7 @@ describe('ComAutoPlayRecoveryService', () => {
         pendingBrokenHandReveal: null,
       }),
     });
-    comAutoPlayUseCase.execute.mockReturnValueOnce(firstRun).mockResolvedValue({
+    comAutoPlayUseCase.execute.mockResolvedValue({
       success: true,
       events: [],
       shouldContinue: false,
@@ -130,19 +125,15 @@ describe('ComAutoPlayRecoveryService', () => {
 
     service.trigger('room-1', handlers);
     service.trigger('room-1', handlers);
+    await flushPromises();
+
+    expect(comAutoPlayUseCase.execute).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(2_000);
     await flushPromises();
 
     expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(1);
-
-    finishFirstRun?.({
-      success: true,
-      events: [],
-      shouldContinue: false,
-    });
-    await flushPromises();
-    await flushPromises();
-
-    expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
   });
 
   it('retries COM auto-play after a transient failure', async () => {
@@ -174,15 +165,17 @@ describe('ComAutoPlayRecoveryService', () => {
       });
 
     service.trigger('room-1', handlers);
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushPromises();
+
+    expect(comAutoPlayUseCase.execute).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(2_000);
+    await flushPromises();
 
     expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(1);
 
-    await jest.advanceTimersByTimeAsync(5_000);
-    await Promise.resolve();
-    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(7_000);
+    await flushPromises();
 
     expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(2);
     service.clearRoom('room-1');
@@ -209,19 +202,18 @@ describe('ComAutoPlayRecoveryService', () => {
     });
 
     service.trigger('room-1', handlers);
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushPromises();
 
-    expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(1);
+    expect(comAutoPlayUseCase.execute).not.toHaveBeenCalled();
     service.clearRoom('room-1');
     await jest.advanceTimersByTimeAsync(2_000);
 
-    expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(1);
+    expect(comAutoPlayUseCase.execute).not.toHaveBeenCalled();
     jest.useRealTimers();
   });
 
   it('suppresses events from an in-flight run after the room is cleared', async () => {
+    jest.useFakeTimers();
     const { service, roomService, comAutoPlayUseCase, handlers } =
       createService();
     let finishRun:
@@ -250,6 +242,8 @@ describe('ComAutoPlayRecoveryService', () => {
 
     service.trigger('room-1', handlers);
     await flushPromises();
+    await jest.advanceTimersByTimeAsync(2_000);
+    await flushPromises();
     service.clearRoom('room-1');
     finishRun?.({
       success: true,
@@ -266,5 +260,6 @@ describe('ComAutoPlayRecoveryService', () => {
     await flushPromises();
 
     expect(handlers.dispatchEvents).not.toHaveBeenCalled();
+    jest.useRealTimers();
   });
 });

--- a/mei-tra-backend/src/services/com-autoplay-recovery.service.ts
+++ b/mei-tra-backend/src/services/com-autoplay-recovery.service.ts
@@ -13,6 +13,7 @@ import { GatewayEvent } from '../use-cases/interfaces/gateway-event.interface';
 import { BROKEN_HAND_REVEAL_PENDING_TTL_MS } from '../use-cases/helpers/broken-hand.helper';
 
 const COM_AUTO_PLAY_RETRY_DELAY_MS = 5_000;
+const COM_AUTO_PLAY_INITIAL_DELAY_MS = 2_000;
 const COM_AUTO_PLAY_CONTINUE_DELAY_MS = 2_000;
 const MAX_COM_AUTO_PLAY_RETRY_DELAY_MS = 60_000;
 
@@ -63,7 +64,7 @@ export class ComAutoPlayRecoveryService {
         !recoveredInterruptedProgress &&
         this.isCurrentGeneration(roomId, generation)
       ) {
-        await this.runAutoPlayStep(roomId, handlers, generation);
+        this.scheduleInitialAutoPlay(roomId, handlers);
       }
     })()
       .catch((error) => {
@@ -298,6 +299,35 @@ export class ComAutoPlayRecoveryService {
   ): void {
     this.retryAttempts.delete(roomId);
     this.scheduleTrigger(roomId, handlers, delayMs);
+  }
+
+  private scheduleInitialAutoPlay(
+    roomId: string,
+    handlers: ComAutoPlayRecoveryHandlers,
+  ): void {
+    if (this.retryTimeouts.has(roomId)) {
+      return;
+    }
+
+    const generation = this.getRoomGeneration(roomId);
+    const timeout = setTimeout(() => {
+      this.retryTimeouts.delete(roomId);
+      if (!this.isCurrentGeneration(roomId, generation)) {
+        return;
+      }
+
+      void this.runAutoPlayStep(roomId, handlers, generation).catch((error) => {
+        if (!this.isCurrentGeneration(roomId, generation)) {
+          return;
+        }
+        this.logger.error(
+          `COM auto-play initial step failed for room ${roomId}`,
+          error instanceof Error ? error.stack : String(error),
+        );
+        this.scheduleRetry(roomId, handlers);
+      });
+    }, COM_AUTO_PLAY_INITIAL_DELAY_MS);
+    this.retryTimeouts.set(roomId, timeout);
   }
 
   private scheduleTrigger(

--- a/mei-tra-frontend/components/game/GameTable/index.module.scss
+++ b/mei-tra-frontend/components/game/GameTable/index.module.scss
@@ -103,11 +103,11 @@
       "left top right"
       "field field field"
       "bottom bottom bottom";
-    grid-template-columns: 78px minmax(0, 1fr) 78px;
+    grid-template-columns: minmax(0, clamp(4.5rem, 22vw, 5.25rem)) minmax(0, 1fr) minmax(0, clamp(4.5rem, 22vw, 5.25rem));
     grid-template-rows: auto minmax(158px, 1fr) auto;
-    gap: 0.1rem 0.5rem;
+    gap: 0.1rem clamp(0.2rem, 1.5vw, 0.5rem);
     margin-top: 0.35rem;
-    padding: 0.35rem 0.4rem 0.75rem;
+    padding: 0.35rem max(0.2rem, env(safe-area-inset-right)) 0.75rem max(0.2rem, env(safe-area-inset-left));
     align-items: stretch;
   }
 

--- a/mei-tra-frontend/components/game/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/game/PlayerHand/index.module.scss
@@ -56,6 +56,7 @@
   -webkit-user-select: none;
   -webkit-touch-callout: none;
   -webkit-tap-highlight-color: transparent;
+  touch-action: pan-y;
 }
 
 .cardFaceDown{

--- a/mei-tra-frontend/components/game/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/game/PlayerHand/index.module.scss
@@ -238,7 +238,7 @@
 
 .playerInfoBadges {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
   justify-content: center;
   gap: 0.25rem;
@@ -394,6 +394,7 @@
   font-weight: 500;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
   line-height: 1.3;
+  text-align: center;
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
@@ -876,24 +877,25 @@
   }
 
   .takenCount{
-    flex: 1 1 auto;
-    font-size: typography.scale(0.58rem);
+    flex: 0 1 auto;
+    font-size: typography.scale(0.52rem);
     color: var(--mt-text-muted);
-    padding: 0.12rem 0.2rem;
+    padding: 0.1rem 0.14rem;
     border-radius: var(--mt-radius);
     border: 1px solid var(--mt-border-hairline);
   }
 
   .teamBadge {
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     min-width: 0;
-    font-size: typography.scale(0.58rem);
-    padding-inline: 0.2rem;
+    font-size: typography.scale(0.52rem);
+    padding-inline: 0.14rem;
   }
 
   .playerInfoBadges {
     gap: 0.15rem;
     min-width: 0;
+    flex-wrap: nowrap;
   }
 
   .playerPosition.top .playerInfo,
@@ -952,7 +954,8 @@
 
   .declarationBadge {
     margin-bottom: 0.15rem;
-    padding: 0.15rem 0.36rem;
+    gap: 0.15rem;
+    padding: 0.1rem 0.24rem;
   }
 
   .playerPosition.bottom .bottomStatusZone {
@@ -961,15 +964,15 @@
   }
 
   .declarationLabel {
-    font-size: typography.scale(0.6rem);
+    font-size: typography.scale(0.55rem);
   }
 
   .declarationValue {
-    font-size: typography.scale(0.7rem);
+    font-size: typography.scale(0.64rem);
   }
 
   .declarationSuit {
-    font-size: typography.scale(1rem);
+    font-size: typography.scale(0.8rem);
   }
 
   .playerPosition.bottom .playerInfoGroup {

--- a/mei-tra-frontend/components/game/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/game/PlayerHand/index.module.scss
@@ -893,9 +893,10 @@
   }
 
   .playerInfoBadges {
+    flex-direction: column;
     gap: 0.15rem;
     min-width: 0;
-    flex-wrap: nowrap;
+    align-items: center;
   }
 
   .playerPosition.top .playerInfo,

--- a/mei-tra-frontend/components/game/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/game/PlayerHand/index.module.scss
@@ -238,6 +238,7 @@
 
 .playerInfoBadges {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
   gap: 0.25rem;
@@ -259,6 +260,10 @@
   font-weight: 800;
   line-height: 1;
   padding: 0.1rem 0.3rem;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -389,6 +394,10 @@
   font-weight: 500;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
   line-height: 1.3;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -526,6 +535,7 @@
 
 .playerPosition{
   position: relative;
+  min-width: 0;
   z-index: 10;
   display: flex;
   flex-direction: column;
@@ -784,6 +794,9 @@
   .playerPosition.left,
   .playerPosition.right {
     align-self: start;
+    justify-self: stretch;
+    width: 100%;
+    min-width: 0;
     margin-top: 0.55rem;
   }
 
@@ -814,6 +827,8 @@
 
   .playerInfoGroup{
     gap: 0.5rem;
+    min-width: 0;
+    max-width: 100%;
   }
 
   .handContainer{
@@ -842,7 +857,9 @@
   }
 
   .playerInfoContainer{
-    min-width: 72px;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
     border-radius: var(--radius-md);
     padding: 0.2rem;
   }
@@ -859,12 +876,24 @@
   }
 
   .takenCount{
-    font-size: typography.scale(0.75rem);
+    flex: 1 1 auto;
+    font-size: typography.scale(0.58rem);
     color: var(--mt-text-muted);
-    background: var(--mt-surface-raised);
-    padding: 0.15rem 0.5rem;
+    padding: 0.12rem 0.2rem;
     border-radius: var(--mt-radius);
     border: 1px solid var(--mt-border-hairline);
+  }
+
+  .teamBadge {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: typography.scale(0.58rem);
+    padding-inline: 0.2rem;
+  }
+
+  .playerInfoBadges {
+    gap: 0.15rem;
+    min-width: 0;
   }
 
   .playerPosition.top .playerInfo,
@@ -873,10 +902,18 @@
     margin-bottom: 0;
   }
 
+  .playerPosition.left .playerInfoGroup,
+  .playerPosition.right .playerInfoGroup {
+    width: 100%;
+    min-width: 0;
+  }
+
   .playerPosition.top .playerInfoContainer,
   .playerPosition.left .playerInfoContainer,
   .playerPosition.right .playerInfoContainer {
-    min-width: 5rem;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
     padding: 0.1rem;
     background: var(--mt-surface-raised-2);
     transform: scale(0.88);
@@ -941,6 +978,8 @@
     justify-content: flex-start;
     align-items: flex-end;
     gap: 0.25rem;
+    min-width: 0;
+    max-width: 100%;
     align-self: end;
   }
 
@@ -949,7 +988,9 @@
   }
 
   .playerPosition.bottom .playerInfoContainer {
-    min-width: 84px;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
     padding: 0.22rem;
   }
 

--- a/mei-tra-frontend/components/game/PlayerHand/index.tsx
+++ b/mei-tra-frontend/components/game/PlayerHand/index.tsx
@@ -185,6 +185,28 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
     setDropPlacement({ card, side: getDropSide(event) });
   };
 
+  const updatePointerDropPlacement = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!draggingCard) {
+      return;
+    }
+
+    const targetElement = document
+      .elementFromPoint(event.clientX, event.clientY)
+      ?.closest<HTMLElement>('[data-hand-card]');
+    const targetCard = targetElement?.dataset.handCard;
+
+    if (!targetElement || !targetCard || targetCard === draggingCard) {
+      setDropPlacement(null);
+      return;
+    }
+
+    const bounds = targetElement.getBoundingClientRect();
+    setDropPlacement({
+      card: targetCard,
+      side: event.clientX < bounds.left + bounds.width / 2 ? 'before' : 'after',
+    });
+  };
+
   const handleCardClick = (card: string) => {
     if (!canActAsCurrentPlayer) {
       return;
@@ -204,6 +226,22 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
       return (
         <div
           className={styles.handContainer}
+          onPointerMove={(event) => {
+            if (canActAsCurrentPlayer) {
+              updatePointerDropPlacement(event);
+            }
+          }}
+          onPointerUp={() => {
+            if (draggingCard && dropPlacement) {
+              reorderDisplayHand(draggingCard, dropPlacement.card, dropPlacement.side);
+            }
+            setDraggingCard(null);
+            setDropPlacement(null);
+          }}
+          onPointerCancel={() => {
+            setDraggingCard(null);
+            setDropPlacement(null);
+          }}
           style={{
             '--player-hand-card-base-width': `${handCardMetrics.width}px`,
             '--player-hand-card-base-overlap': handCardMetrics.overlap,
@@ -244,22 +282,7 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
                     setDropPlacement(null);
                   }
                 }}
-                onPointerMove={(event) => {
-                  if (canActAsCurrentPlayer) {
-                    updateDropPlacement(card, event);
-                  }
-                }}
-                onPointerUp={(event) => {
-                  if (draggingCard && dropPlacement?.card === card) {
-                    reorderDisplayHand(draggingCard, card, getDropSide(event));
-                  }
-                  setDraggingCard(null);
-                  setDropPlacement(null);
-                }}
-                onPointerCancel={() => {
-                  setDraggingCard(null);
-                  setDropPlacement(null);
-                }}
+                data-hand-card={card}
                 onDragStart={(event) => {
                   if (!canActAsCurrentPlayer) {
                     event.preventDefault();

--- a/mei-tra-frontend/components/game/PreGameTable/index.tsx
+++ b/mei-tra-frontend/components/game/PreGameTable/index.tsx
@@ -24,7 +24,7 @@ function createEmptySlot(index: number): Player {
     socketId: `empty-${index}`,
     playerId: `empty-${index}`,
     name: 'COM',
-    team: 0,
+    team: (index % 2) as Player['team'],
     hand: [],
     isCOM: true,
   };
@@ -57,13 +57,13 @@ export const PreGameTable: React.FC<PreGameTableProps> = ({
         <div
           key={player.playerId}
           className={`${styles.playerSeat} ${styles[positions[idx]]} ${
-            idx % 2 === 0 ? styles.teamRed : styles.teamBlack
+            player.team === 0 ? styles.teamRed : styles.teamBlack
           }`}
         >
           <div className={styles.seatContent}>
             <PlayerAvatar player={player} size="medium" showName={true} />
             <span className={styles.teamBadge}>
-              {tRoot(idx % 2 === 0 ? 'gameInfo.teamRed' : 'gameInfo.teamBlack')}
+              {tRoot(player.team === 0 ? 'gameInfo.teamRed' : 'gameInfo.teamBlack')}
             </span>
             {isHost &&
               onRemovePlayer &&


### PR DESCRIPTION
## 概要
- 待機画面のチームバッジを実際の `player.team` に基づいて表示
- 空席COMは座席位置に対応するチームを表示
- COMの初回自動プレイに2秒の待機を追加し、操作直後の即時プレイを防止
- マージ済みPRを番号指定して再取得できるXデモキャプチャWorkflowを追加
- 既存のX下書きIssueを更新し、重複作成を防止

## 検証
- `mei-tra-backend`: `npm test -- --runInBand src/services/__tests__/com-autoplay-recovery.service.spec.ts`
- `git diff --check`
- Workflow YAML parse / Prettier check

## 使い方
1. PR本文に `x-demo` ブロックを追加
2. Actionsの `Create X Post Draft` を手動実行
3. `Merged PR number to capture` にPR番号を入力

## 補足
- Xへの公開は既存どおり、下書き確認後に `/post-x` で承認します。
