### PR TITLE
チーム赤・黒の得点表示を修正

### DIFF
--- a/.github/workflows/x-auto-label.yml
+++ b/.github/workflows/x-auto-label.yml
@@ -2,10 +2,11 @@ name: Label New PRs for X Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   label:
@@ -13,7 +14,7 @@ jobs:
 
     steps:
       - name: Add the default X share label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const label = {

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -3196,6 +3196,114 @@ describe('Game Use Cases', () => {
         RoomStatus.FINISHED,
       );
     });
+
+    it('awards successful play points to declaring team one', async () => {
+      const roomService = createRoomServiceMock();
+      const playService = createPlayServiceMock('player-2');
+      const scoreService = createScoreServiceMock(2);
+      const useCase = new CompleteFieldUseCase(
+        roomService,
+        playService,
+        scoreService,
+      );
+
+      const state = buildState();
+      state.blowState.currentHighestDeclaration = {
+        ...state.blowState.currentHighestDeclaration,
+        playerId: 'player-2',
+      };
+      state.players[0].hand = [];
+      state.players[1].hand = [];
+      state.playState.fields = [{ winnerTeam: 1 } as unknown as Field];
+
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        completeField: jest.fn(() => ({
+          cards: ['A', 'B', 'C', 'D'],
+          winnerId: 'player-2',
+          winnerTeam: 1,
+          dealerId: 'player-1',
+        })),
+        saveState: jest.fn(),
+        resetRoundState: jest.fn(async () => {}),
+        transitionPhase: jest.fn(async () => {}),
+        updateState: jest.fn(async (updates) => Object.assign(state, updates)),
+      } as unknown as GameStateService;
+
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const result = await useCase.execute({
+        roomId: 'room-1',
+        field: {
+          cards: ['A', 'B', 'C', 'D'],
+          playedBy: ['player-1', 'player-2', 'player-3', 'player-4'],
+          baseCard: 'A',
+          dealerId: 'player-1',
+          isComplete: false,
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(state.teamScores[0].total).toBe(0);
+      expect(state.teamScores[1].total).toBe(2);
+      expect(state.teamScoreRecords[1]).toEqual([
+        expect.objectContaining({ points: 2, reason: 'Play points' }),
+      ]);
+    });
+
+    it('awards failed team one declaration points to team zero', async () => {
+      const roomService = createRoomServiceMock();
+      const playService = createPlayServiceMock('player-1');
+      const scoreService = createScoreServiceMock(-2);
+      const useCase = new CompleteFieldUseCase(
+        roomService,
+        playService,
+        scoreService,
+      );
+
+      const state = buildState();
+      state.blowState.currentHighestDeclaration = {
+        ...state.blowState.currentHighestDeclaration,
+        playerId: 'player-2',
+      };
+      state.players[0].hand = [];
+      state.players[1].hand = [];
+      state.playState.fields = [{ winnerTeam: 0 } as unknown as Field];
+
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        completeField: jest.fn(() => ({
+          cards: ['A', 'B', 'C', 'D'],
+          winnerId: 'player-1',
+          winnerTeam: 0,
+          dealerId: 'player-1',
+        })),
+        saveState: jest.fn(),
+        resetRoundState: jest.fn(async () => {}),
+        transitionPhase: jest.fn(async () => {}),
+        updateState: jest.fn(async (updates) => Object.assign(state, updates)),
+      } as unknown as GameStateService;
+
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const result = await useCase.execute({
+        roomId: 'room-1',
+        field: {
+          cards: ['A', 'B', 'C', 'D'],
+          playedBy: ['player-1', 'player-2', 'player-3', 'player-4'],
+          baseCard: 'A',
+          dealerId: 'player-1',
+          isComplete: false,
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(state.teamScores[0].total).toBe(2);
+      expect(state.teamScores[1].total).toBe(0);
+      expect(state.teamScoreRecords[0]).toEqual([
+        expect.objectContaining({ points: 2, reason: 'Play points' }),
+      ]);
+    });
   });
 
   describe('ProcessGameOverUseCase', () => {

--- a/mei-tra-frontend/__tests__/components/GameHistoryDock.test.tsx
+++ b/mei-tra-frontend/__tests__/components/GameHistoryDock.test.tsx
@@ -206,4 +206,63 @@ describe('GameHistoryDock', () => {
     expect(within(roundTable).getByText('チーム赤')).toBeInTheDocument();
     expect(within(roundTable).getByText('チーム黒')).toBeInTheDocument();
   });
+
+  it('keeps replay score labels attached to backend team indexes', () => {
+    mockUseGameHistory.mockReturnValue({
+      replay: {
+        roomId: 'room-123',
+        totalEntries: 1,
+        rounds: [
+          {
+            roundNumber: 1,
+            startedAt: new Date('2026-07-26T00:00:00.000Z'),
+            endedAt: new Date('2026-07-26T00:03:00.000Z'),
+            actionTypes: ['round_completed'],
+            playerIds: [],
+            entries: [],
+            events: [
+              {
+                id: 'score-1',
+                timestamp: new Date('2026-07-26T00:03:00.000Z'),
+                actionType: 'round_completed',
+                playerId: null,
+                roundNumber: 1,
+                gamePhase: 'score',
+                kind: 'round',
+                summary: '',
+                details: {},
+                actionData: {},
+                detailItems: [
+                  {
+                    labelKey: 'scores',
+                    value: {
+                      kind: 'scores',
+                      scores: {
+                        0: { total: 1 },
+                        1: { total: 4 },
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      summary: null,
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+
+    render(<GameHistoryDock {...baseProps} gameStarted defaultOpen />);
+
+    const redScore = screen.getByText('チーム赤').closest('div');
+    const blackScore = screen.getByText('チーム黒').closest('div');
+
+    expect(redScore).not.toBeNull();
+    expect(blackScore).not.toBeNull();
+    expect(within(redScore as HTMLElement).getByText('+1')).toBeInTheDocument();
+    expect(within(blackScore as HTMLElement).getByText('+4')).toBeInTheDocument();
+  });
 });

--- a/mei-tra-frontend/__tests__/components/GameInfo.test.tsx
+++ b/mei-tra-frontend/__tests__/components/GameInfo.test.tsx
@@ -56,4 +56,20 @@ describe('GameInfo', () => {
     expect(teamMeter).toHaveAttribute('aria-valuetext', '5/5 WIN');
     expect(screen.getByText('WIN')).toBeInTheDocument();
   });
+
+  it('keeps backend team zero red and team one black', () => {
+    renderGameInfo({
+      0: { deal: 0, blow: 0, play: 3, total: 3 },
+      1: { deal: 0, blow: 0, play: 1, total: 1 },
+    });
+
+    expect(screen.getByRole('meter', { name: 'Red team' })).toHaveAttribute(
+      'aria-valuetext',
+      '3/5',
+    );
+    expect(screen.getByRole('meter', { name: 'Black team' })).toHaveAttribute(
+      'aria-valuetext',
+      '1/5',
+    );
+  });
 });

--- a/mei-tra-frontend/components/game/GameDock.tsx
+++ b/mei-tra-frontend/components/game/GameDock.tsx
@@ -14,7 +14,6 @@ interface GameDockProps {
   currentTrump: TrumpType | null;
   gamePhase?: string | null;
   players?: Player[];
-  currentPlayerId?: string | null;
   onLeaveRequest?: () => void;
 }
 
@@ -24,7 +23,6 @@ export function GameDock({
   currentTrump,
   gamePhase,
   players,
-  currentPlayerId,
   onLeaveRequest,
 }: GameDockProps) {
   const tCommon = useTranslations('common');
@@ -33,9 +31,6 @@ export function GameDock({
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
-  const primaryTeam = players?.find(
-    (player) => player.playerId === currentPlayerId,
-  )?.team ?? 0;
 
   useEffect(() => {
     if (typeof window.matchMedia !== 'function') {
@@ -156,7 +151,6 @@ export function GameDock({
               roomId={roomId}
               gameStarted={gameStarted}
               players={players}
-              primaryTeam={primaryTeam}
               defaultOpen
               hideOpenPage
               onClose={() => setIsHistoryOpen(false)}
@@ -176,7 +170,6 @@ export function GameDock({
             roomId={roomId}
             gameStarted={gameStarted}
             players={players}
-            primaryTeam={primaryTeam}
             defaultOpen
             hideOpenPage
             onClose={() => setIsHistoryOpen(false)}

--- a/mei-tra-frontend/components/game/GameHistoryDock.tsx
+++ b/mei-tra-frontend/components/game/GameHistoryDock.tsx
@@ -18,7 +18,6 @@ interface GameHistoryDockProps {
   roomId: string;
   gameStarted: boolean;
   players?: Player[];
-  primaryTeam?: Player['team'];
   variant?: 'dock' | 'page';
   showOverview?: boolean;
   summaryOverride?: GameHistorySummary | null;
@@ -114,7 +113,6 @@ export function GameHistoryDock({
   roomId,
   gameStarted,
   players = [],
-  primaryTeam = 0,
   variant = 'dock',
   showOverview = true,
   summaryOverride = null,
@@ -218,11 +216,11 @@ export function GameHistoryDock({
       return null;
     }
 
-    if (team === primaryTeam) {
+    if (team === 0) {
       return t('teamRed');
     }
 
-    if (team === 0 || team === 1) {
+    if (team === 1) {
       return t('teamBlack');
     }
 
@@ -813,7 +811,7 @@ export function GameHistoryDock({
                               <div
                                 key={team}
                                 className={`${styles.roundTeamScore} ${
-                                  team === primaryTeam ? styles.teamRed : styles.teamBlack
+                                  team === 0 ? styles.teamRed : styles.teamBlack
                                 }`}
                               >
                                 <span className={styles.roundTeamLabel}>

--- a/mei-tra-frontend/components/game/GameInfo/index.tsx
+++ b/mei-tra-frontend/components/game/GameInfo/index.tsx
@@ -1,8 +1,5 @@
 import React, { useState } from 'react';
-import {
-  TeamScores,
-  Player,
-} from '@/types/game.types';
+import { TeamScores } from '@/types/game.types';
 import styles from './index.module.scss';
 import { useTranslations } from 'next-intl';
 import { ConfirmModal } from '@/components/shared/ConfirmModal';
@@ -12,7 +9,6 @@ type ScoreStatus = 'normal' | 'leading' | 'reach' | 'win';
 interface GameInfoProps {
   teamScores: TeamScores;
   pointsToWin: number;
-  primaryTeam?: Player['team'];
   actionSlot?: (onLeaveRequest: () => void) => React.ReactNode;
   onLeave?: () => void;
 }
@@ -20,7 +16,6 @@ interface GameInfoProps {
 export const GameInfo: React.FC<GameInfoProps> = ({
   teamScores,
   pointsToWin,
-  primaryTeam = 0,
   actionSlot,
   onLeave,
 }) => {
@@ -28,7 +23,7 @@ export const GameInfo: React.FC<GameInfoProps> = ({
   const [showConfirmModal, setShowConfirmModal] = useState(false);
 
   const getTeamLabel = (teamNumber: number) =>
-    teamNumber === primaryTeam ? t('gameInfo.teamRed') : t('gameInfo.teamBlack');
+    t(teamNumber === 0 ? 'gameInfo.teamRed' : 'gameInfo.teamBlack');
   const getScoreProgress = (score: number) => {
     if (pointsToWin <= 0) {
       return 0;
@@ -69,7 +64,7 @@ export const GameInfo: React.FC<GameInfoProps> = ({
     return {
       teamNumber,
       teamName: getTeamLabel(teamNumber),
-      teamColor: teamNumber === primaryTeam ? 'red' : 'black',
+      teamColor: teamNumber === 0 ? 'red' : 'black',
       score,
       progress: getScoreProgress(score),
       status,

--- a/mei-tra-frontend/components/game/GameTable/index.tsx
+++ b/mei-tra-frontend/components/game/GameTable/index.tsx
@@ -131,7 +131,6 @@ export const GameTable: React.FC<GameTableProps> = ({
         <GameInfo
           teamScores={teamScores}
           pointsToWin={pointsToWin}
-          primaryTeam={perspectivePlayerTeam}
           actionSlot={
             currentRoomId ? (onLeaveRequest) => (
               <GameDock
@@ -140,7 +139,6 @@ export const GameTable: React.FC<GameTableProps> = ({
                 currentTrump={currentTrump}
                 gamePhase={gamePhase}
                 players={players}
-                currentPlayerId={tablePerspectivePlayerId}
                 onLeaveRequest={onLeaveRequest}
               />
             ) : undefined


### PR DESCRIPTION
## 概要
- 得点メーターと対局ログのチーム表示を、backend の team 0 = チーム赤 / team 1 = チーム黒に統一
- 閲覧プレイヤーの所属チームによって赤黒が反転していた `primaryTeam` 変換を削除
- チーム1の宣言成功・失敗時の加点先を回帰テストで固定

## 原因
得点計算と Socket payload はチーム番号を正しく保持していましたが、#151 で追加された表示変換が「閲覧者のチームを赤」として再ラベル付けしていたため、待機画面・プレイヤーバッジ・ゲーム終了表示と得点表示が不一致になっていました。

## 検証
- `cd mei-tra-frontend && npm test -- --runInBand __tests__/components/GameInfo.test.tsx __tests__/components/GameHistoryDock.test.tsx __tests__/components/GameDock.test.tsx __tests__/components/GameTable.test.tsx`
- `cd mei-tra-frontend && npx eslint components/game/GameInfo/index.tsx components/game/GameTable/index.tsx components/game/GameDock.tsx components/game/GameHistoryDock.tsx __tests__/components/GameInfo.test.tsx __tests__/components/GameHistoryDock.test.tsx`
- `cd mei-tra-frontend && npm run build`
- `cd mei-tra-backend && npm test -- --runInBand use-cases/__tests__/game.use-cases.spec.ts`
- `cd mei-tra-backend && npm run build`

<!-- x-demo:start -->
{
  "route": "/ja",
  "media": "screenshot",
  "steps": [
    { "action": "fill", "placeholder": "ルーム名を入力", "value": "CI Demo {{timestamp}}" },
    { "action": "clickRole", "role": "button", "name": "ルーム作成" },
    { "action": "wait", "ms": 2500 },
    { "action": "clickRole", "role": "button", "name": "ゲーム開始" },
    { "action": "wait", "ms": 4500 },
    { "action": "playDemo", "maxActions": 8, "maxDurationMs": 60000 }
  ],
  "filename": "capture.png"
}
<!-- x-demo:end -->