### PR TITLE
Customize team names and polish game UI

### DIFF
--- a/contracts/game.ts
+++ b/contracts/game.ts
@@ -1,5 +1,7 @@
 export type Team = 0 | 1;
 
+export type TeamNames = Partial<Record<Team, string>>;
+
 export type TransportGamePhase = 'deal' | 'blow' | 'play' | 'waiting' | null;
 
 export type TrumpType = 'tra' | 'herz' | 'daiya' | 'club' | 'zuppe';
@@ -87,6 +89,7 @@ export interface GameStatePayload {
   roomId: string;
   hostId?: string;
   pointsToWin: number;
+  teamNames?: TeamNames;
 }
 
 export interface SyncGameStatePayload {
@@ -192,4 +195,5 @@ export interface GameStartedPayload {
   roomId: string;
   players: PlayerContract[];
   pointsToWin: number;
+  teamNames?: TeamNames;
 }

--- a/contracts/room.ts
+++ b/contracts/room.ts
@@ -1,4 +1,4 @@
-import type { PlayerContract, Team } from './game';
+import type { PlayerContract, Team, TeamNames } from './game';
 
 export type RoomStatusContract =
   | 'waiting'
@@ -20,6 +20,13 @@ export interface RoomSettingsContract {
   teamAssignmentMethod: 'random' | 'host-choice';
   pointsToWin: number;
   allowSpectators: boolean;
+  teamNames?: TeamNames;
+}
+
+export interface UpdateTeamNamesPayload {
+  roomId: string;
+  playerId: string;
+  teamNames: TeamNames;
 }
 
 export interface RoomContract {

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -15,6 +15,7 @@ import type {
   RevealAgariPayload,
   SyncGameStatePayload,
 } from '@contracts/game';
+import type { UpdateTeamNamesPayload } from '@contracts/room';
 import { IGameStateService } from './services/interfaces/game-state-service.interface';
 import { IRoomService } from './services/interfaces/room-service.interface';
 import { TrumpType } from './types/game.types';
@@ -54,6 +55,7 @@ import { TurnMonitorService } from './services/turn-monitor.service';
 import { ReconnectionUseCase } from './use-cases/reconnection.use-case';
 import { ModeratePlayerUseCase } from './use-cases/moderate-player.use-case';
 import { ShuffleTeamsUseCase } from './use-cases/shuffle-teams.use-case';
+import { UpdateTeamNamesUseCase } from './use-cases/update-team-names.use-case';
 import { Room } from './types/room.types';
 import { toRoomContract, toRoomContracts } from './types/room-adapters';
 import {
@@ -128,6 +130,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     private readonly reconnectionUseCase: ReconnectionUseCase,
     private readonly moderatePlayerUseCase: ModeratePlayerUseCase,
     private readonly shuffleTeamsUseCase: ShuffleTeamsUseCase,
+    private readonly updateTeamNamesUseCase: UpdateTeamNamesUseCase,
     private readonly joinRoomGatewayEffectsService: JoinRoomGatewayEffectsService,
     private readonly disconnectGatewayEffectsService: DisconnectGatewayEffectsService,
     private readonly roomUpdateGatewayEffectsService: RoomUpdateGatewayEffectsService,
@@ -1180,6 +1183,45 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       return { success: true };
     } catch (error) {
       console.error('Error in handleShuffleTeams:', error);
+      client.emit('error-message', 'Internal server error');
+      return { success: false };
+    }
+  }
+
+  @SubscribeMessage('update-team-names')
+  async handleUpdateTeamNames(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() data: UpdateTeamNamesPayload,
+  ): Promise<{ success: boolean }> {
+    if (
+      this.spectatorGatewayEffectsService.rejectAction(
+        client,
+        'update team names',
+      )
+    ) {
+      return { success: false };
+    }
+
+    try {
+      const result = await this.updateTeamNamesUseCase.execute(data);
+      if (!result.success || !result.updatedRoom) {
+        client.emit(
+          'error-message',
+          result.error || 'Failed to update team names',
+        );
+        return { success: false };
+      }
+
+      this.dispatchEvents(
+        await this.roomUpdateGatewayEffectsService.buildRoomEvents({
+          room: result.updatedRoom,
+          scope: 'room',
+          roomId: data.roomId,
+        }),
+      );
+      return { success: true };
+    } catch (error) {
+      console.error('Error in handleUpdateTeamNames:', error);
       client.emit('error-message', 'Internal server error');
       return { success: false };
     }

--- a/mei-tra-backend/src/game.module.ts
+++ b/mei-tra-backend/src/game.module.ts
@@ -47,6 +47,7 @@ import { SpectatorGatewayEffectsService } from './services/spectator-gateway-eff
 import { ReconnectionUseCase } from './use-cases/reconnection.use-case';
 import { ModeratePlayerUseCase } from './use-cases/moderate-player.use-case';
 import { ShuffleTeamsUseCase } from './use-cases/shuffle-teams.use-case';
+import { UpdateTeamNamesUseCase } from './use-cases/update-team-names.use-case';
 import { GameEventLogService } from './services/game-event-log.service';
 import { GameHistoryController } from './controllers/game-history.controller';
 import { GetGameHistoryUseCase } from './use-cases/get-game-history.use-case';
@@ -214,6 +215,7 @@ import { ComAutoPlayRecoveryService } from './services/com-autoplay-recovery.ser
     ReconnectionUseCase,
     ModeratePlayerUseCase,
     ShuffleTeamsUseCase,
+    UpdateTeamNamesUseCase,
   ],
   exports: ['IActivityTrackerService', 'IGetUserRecentGameHistoryUseCase'],
 })

--- a/mei-tra-backend/src/main.ts
+++ b/mei-tra-backend/src/main.ts
@@ -1,6 +1,8 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import * as Sentry from '@sentry/nestjs';
+import { IoAdapter } from '@nestjs/platform-socket.io';
+import { isAllowedFrontendOrigin } from './config/frontend-origins';
 
 async function bootstrap() {
   if (process.env.SENTRY_DSN) {
@@ -13,12 +15,17 @@ async function bootstrap() {
   }
 
   const app = await NestFactory.create(AppModule);
+  app.useWebSocketAdapter(new IoAdapter(app));
 
   app.enableCors({
-    origin:
-      process.env.NODE_ENV === 'development'
-        ? process.env.FRONTEND_URL_DEV
-        : process.env.FRONTEND_URL_PROD,
+    origin: (origin, callback) => {
+      if (!origin || isAllowedFrontendOrigin(origin)) {
+        callback(null, true);
+        return;
+      }
+
+      callback(new Error('Origin not allowed by CORS'));
+    },
     credentials: true,
   });
 

--- a/mei-tra-backend/src/services/start-game-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/start-game-gateway-effects.service.ts
@@ -45,6 +45,7 @@ export class StartGameGatewayEffectsService {
       roomId,
       players: transportPlayers,
       pointsToWin,
+      teamNames: room?.settings.teamNames,
     };
     const roomEvents = room
       ? await this.roomUpdateGatewayEffectsService.buildRoomEvents({

--- a/mei-tra-backend/src/types/database.types.ts
+++ b/mei-tra-backend/src/types/database.types.ts
@@ -14,6 +14,10 @@ export interface Database {
             teamAssignmentMethod: 'random' | 'host-choice';
             pointsToWin: number;
             allowSpectators: boolean;
+            teamNames?: {
+              0?: string;
+              1?: string;
+            };
           };
           created_at: string;
           updated_at: string;
@@ -31,6 +35,10 @@ export interface Database {
             teamAssignmentMethod?: 'random' | 'host-choice';
             pointsToWin?: number;
             allowSpectators?: boolean;
+            teamNames?: {
+              0?: string;
+              1?: string;
+            };
           };
           created_at?: string;
           updated_at?: string;
@@ -48,6 +56,10 @@ export interface Database {
             teamAssignmentMethod?: 'random' | 'host-choice';
             pointsToWin?: number;
             allowSpectators?: boolean;
+            teamNames?: {
+              0?: string;
+              1?: string;
+            };
           };
           created_at?: string;
           updated_at?: string;

--- a/mei-tra-backend/src/types/game.types.ts
+++ b/mei-tra-backend/src/types/game.types.ts
@@ -1,5 +1,7 @@
 export type Team = 0 | 1;
 
+export type TeamNames = Partial<Record<Team, string>>;
+
 export interface PlayerIdentity {
   playerId: string; // Table participant identifier (future participantId equivalent)
   name: string;

--- a/mei-tra-backend/src/types/room.types.ts
+++ b/mei-tra-backend/src/types/room.types.ts
@@ -1,4 +1,4 @@
-import { PlayerGameplayState } from './game.types';
+import { PlayerGameplayState, TeamNames } from './game.types';
 import { SessionUser } from './session.types';
 
 export enum RoomStatus {
@@ -35,6 +35,7 @@ export interface RoomSettings {
   teamAssignmentMethod: 'random' | 'host-choice';
   pointsToWin: number;
   allowSpectators: boolean;
+  teamNames?: TeamNames;
 }
 
 export interface RoomRepository {

--- a/mei-tra-backend/src/use-cases/__tests__/update-team-names.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/update-team-names.use-case.spec.ts
@@ -1,0 +1,98 @@
+import { UpdateTeamNamesUseCase } from '../update-team-names.use-case';
+import { IRoomService } from '../../services/interfaces/room-service.interface';
+import { RoomStatus } from '../../types/room.types';
+
+describe('UpdateTeamNamesUseCase', () => {
+  const waitingRoom = {
+    id: 'room-1',
+    hostId: 'host',
+    status: RoomStatus.WAITING,
+    settings: {
+      maxPlayers: 4,
+      isPrivate: false,
+      password: null,
+      teamAssignmentMethod: 'random',
+      pointsToWin: 5,
+      allowSpectators: true,
+    },
+    players: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastActivityAt: new Date(),
+  };
+
+  it('updates normalized team names while waiting', async () => {
+    const updatedRoom = {
+      ...waitingRoom,
+      settings: {
+        ...waitingRoom.settings,
+        teamNames: { 0: '東軍', 1: '西軍' },
+      },
+    };
+    const roomService = {
+      getRoom: jest.fn().mockResolvedValue(waitingRoom),
+      updateRoom: jest.fn().mockResolvedValue(updatedRoom),
+    } as Partial<IRoomService> as IRoomService;
+    const useCase = new UpdateTeamNamesUseCase(roomService);
+
+    const result = await useCase.execute({
+      roomId: 'room-1',
+      playerId: 'host',
+      teamNames: {
+        0: '  東軍  ',
+        1: '西軍',
+      },
+    });
+
+    expect(result).toEqual({ success: true, updatedRoom });
+    expect(roomService.updateRoom).toHaveBeenCalledWith('room-1', {
+      settings: {
+        ...waitingRoom.settings,
+        teamNames: { 0: '東軍', 1: '西軍' },
+      },
+    });
+  });
+
+  it('rejects non-host updates', async () => {
+    const roomService = {
+      getRoom: jest.fn().mockResolvedValue(waitingRoom),
+      updateRoom: jest.fn(),
+    } as Partial<IRoomService> as IRoomService;
+    const useCase = new UpdateTeamNamesUseCase(roomService);
+
+    const result = await useCase.execute({
+      roomId: 'room-1',
+      playerId: 'guest',
+      teamNames: { 0: '東軍', 1: '西軍' },
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Only the host can change team names',
+    });
+    expect(roomService.updateRoom).not.toHaveBeenCalled();
+  });
+
+  it('rejects updates after the game starts', async () => {
+    const roomService = {
+      getRoom: jest.fn().mockResolvedValue({
+        ...waitingRoom,
+        status: RoomStatus.PLAYING,
+      }),
+      updateRoom: jest.fn(),
+    } as Partial<IRoomService> as IRoomService;
+    const useCase = new UpdateTeamNamesUseCase(roomService);
+
+    const result = await useCase.execute({
+      roomId: 'room-1',
+      playerId: 'host',
+      teamNames: { 0: '東軍', 1: '西軍' },
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Team names can only be changed while waiting',
+    });
+    expect(roomService.updateRoom).not.toHaveBeenCalled();
+  });
+});

--- a/mei-tra-backend/src/use-cases/interfaces/join-room.use-case.interface.ts
+++ b/mei-tra-backend/src/use-cases/interfaces/join-room.use-case.interface.ts
@@ -6,6 +6,7 @@ import {
   GamePhase,
   BlowState,
   CompletedField,
+  TeamNames,
 } from '../../types/game.types';
 import { Room, RoomStatus } from '../../types/room.types';
 import { SessionUser } from '../../types/session.types';
@@ -38,6 +39,7 @@ export interface ResumeGamePayload {
     fields: CompletedField[] | undefined;
     roomId: string;
     pointsToWin: number;
+    teamNames?: TeamNames;
   };
 }
 

--- a/mei-tra-backend/src/use-cases/join-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/join-room.use-case.ts
@@ -143,6 +143,7 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
         fields: state.playState?.fields,
         roomId,
         pointsToWin: room.settings.pointsToWin,
+        teamNames: room.settings.teamNames,
       },
     };
   }

--- a/mei-tra-backend/src/use-cases/reconnection.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reconnection.use-case.ts
@@ -342,6 +342,7 @@ export class ReconnectionUseCase {
         roomId,
         hostId: room.hostId,
         pointsToWin: state.pointsToWin,
+        teamNames: room.settings.teamNames,
       },
     };
   }

--- a/mei-tra-backend/src/use-cases/update-team-names.use-case.ts
+++ b/mei-tra-backend/src/use-cases/update-team-names.use-case.ts
@@ -1,0 +1,68 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { TeamNames } from '@contracts/game';
+import { IRoomService } from '../services/interfaces/room-service.interface';
+import { Room, RoomStatus } from '../types/room.types';
+
+const MAX_TEAM_NAME_LENGTH = 16;
+
+function normalizeTeamName(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim().replace(/\s+/g, ' ');
+  if (!normalized) {
+    return undefined;
+  }
+
+  return normalized.slice(0, MAX_TEAM_NAME_LENGTH);
+}
+
+@Injectable()
+export class UpdateTeamNamesUseCase {
+  constructor(
+    @Inject('IRoomService') private readonly roomService: IRoomService,
+  ) {}
+
+  async execute(request: {
+    roomId: string;
+    playerId: string;
+    teamNames: TeamNames;
+  }): Promise<{ success: boolean; updatedRoom?: Room; error?: string }> {
+    const room = await this.roomService.getRoom(request.roomId);
+    if (!room) {
+      return { success: false, error: 'Room not found' };
+    }
+
+    if (room.status !== RoomStatus.WAITING) {
+      return {
+        success: false,
+        error: 'Team names can only be changed while waiting',
+      };
+    }
+
+    if (room.hostId !== request.playerId) {
+      return { success: false, error: 'Only the host can change team names' };
+    }
+
+    const redTeamName = normalizeTeamName(request.teamNames[0]);
+    const blackTeamName = normalizeTeamName(request.teamNames[1]);
+    const teamNames: TeamNames = {
+      ...(redTeamName ? { 0: redTeamName } : {}),
+      ...(blackTeamName ? { 1: blackTeamName } : {}),
+    };
+
+    const updatedRoom = await this.roomService.updateRoom(room.id, {
+      settings: {
+        ...room.settings,
+        teamNames,
+      },
+    });
+
+    if (!updatedRoom) {
+      return { success: false, error: 'Failed to update team names' };
+    }
+
+    return { success: true, updatedRoom };
+  }
+}

--- a/mei-tra-backend/src/use-cases/watch-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/watch-room.use-case.ts
@@ -97,6 +97,7 @@ export class WatchRoomUseCase implements IWatchRoomUseCase {
       roomId: room.id,
       hostId: room.hostId,
       pointsToWin: room.settings.pointsToWin,
+      teamNames: room.settings.teamNames,
     };
   }
 }

--- a/mei-tra-frontend/__tests__/components/BlowControls.test.tsx
+++ b/mei-tra-frontend/__tests__/components/BlowControls.test.tsx
@@ -80,4 +80,15 @@ describe('BlowControls', () => {
     expect(historyTrumpLabel as HTMLElement).toBeInTheDocument();
     expect(historyTrumpLabel as HTMLElement).toHaveAttribute('data-trump', 'daiya');
   });
+
+  it('separates long player names from declaration text', () => {
+    renderBlowControls();
+
+    const playerName = screen.getByText('Player 1');
+    const historyItem = playerName.closest('div');
+
+    expect(playerName.className).toContain('declarationPlayerName');
+    expect(historyItem).toHaveAttribute('title', 'Player 1: Daiya 6 sets');
+    expect(screen.getByText(/6 sets/).className).toContain('declarationText');
+  });
 });

--- a/mei-tra-frontend/__tests__/components/BlowSpectatorPanel.test.tsx
+++ b/mei-tra-frontend/__tests__/components/BlowSpectatorPanel.test.tsx
@@ -88,6 +88,17 @@ describe('BlowSpectatorPanel', () => {
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
   });
 
+  it('puts player names in truncatable spans', () => {
+    renderPanel();
+
+    const historyName = screen.getAllByText('Player 1').find((element) =>
+      element.className.includes('playerName'),
+    );
+
+    expect(historyName).toBeDefined();
+    expect(historyName).toHaveAttribute('title', 'Player 1');
+  });
+
   it('updates from a later socket snapshot without exposing controls', () => {
     const { rerender } = renderPanel({
       blowActionHistory: [],

--- a/mei-tra-frontend/__tests__/components/GameHistoryDock.test.tsx
+++ b/mei-tra-frontend/__tests__/components/GameHistoryDock.test.tsx
@@ -34,6 +34,7 @@ jest.mock('next-intl', () => ({
       roundTableBlower: '吹き手',
       roundTableBid: '宣言',
       roundTableScore: '得点',
+      'actionTypes.card_played': 'カードプレイ',
       teamRed: 'チーム赤',
       teamBlack: 'チーム黒',
       roundInProgress: '進行中',
@@ -264,5 +265,74 @@ describe('GameHistoryDock', () => {
     expect(blackScore).not.toBeNull();
     expect(within(redScore as HTMLElement).getByText('+1')).toBeInTheDocument();
     expect(within(blackScore as HTMLElement).getByText('+4')).toBeInTheDocument();
+  });
+
+  it('shows detailed replay events on the profile history page', () => {
+    mockUseGameHistory.mockReturnValue({
+      replay: {
+        roomId: 'room-123',
+        totalEntries: 3,
+        rounds: [
+          {
+            roundNumber: 1,
+            startedAt: new Date('2026-07-26T00:00:00.000Z'),
+            endedAt: new Date('2026-07-26T00:03:00.000Z'),
+            actionTypes: ['play_phase_started', 'card_played', 'round_completed'],
+            playerIds: ['player-1'],
+            entries: [],
+            events: [
+              {
+                id: 'play-started-1',
+                timestamp: new Date('2026-07-26T00:01:00.000Z'),
+                actionType: 'play_phase_started',
+                playerId: 'player-1',
+                roundNumber: 1,
+                gamePhase: 'play',
+                kind: 'blow',
+                summary: '',
+                details: {},
+                actionData: {},
+                detailItems: [],
+              },
+              {
+                id: 'card-played-1',
+                timestamp: new Date('2026-07-26T00:02:00.000Z'),
+                actionType: 'card_played',
+                playerId: 'player-1',
+                roundNumber: 1,
+                gamePhase: 'play',
+                kind: 'card',
+                summary: '',
+                details: {},
+                actionData: {},
+                detailItems: [],
+              },
+              {
+                id: 'score-1',
+                timestamp: new Date('2026-07-26T00:03:00.000Z'),
+                actionType: 'round_completed',
+                playerId: null,
+                roundNumber: 1,
+                gamePhase: 'score',
+                kind: 'round',
+                summary: '',
+                details: {},
+                actionData: {},
+                detailItems: [],
+              },
+            ],
+          },
+        ],
+      },
+      summary: null,
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+
+    render(<GameHistoryDock {...baseProps} gameStarted={false} variant="page" />);
+
+    expect(screen.getByText('カードプレイ')).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 });

--- a/mei-tra-frontend/__tests__/components/GameInfo.test.tsx
+++ b/mei-tra-frontend/__tests__/components/GameInfo.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { GameInfo } from '@/components/game/GameInfo';
+import type React from 'react';
 import type { TeamScores } from '@/types/game.types';
 
 jest.mock('next-intl', () => ({
@@ -23,11 +24,15 @@ jest.mock('@/components/shared/ConfirmModal', () => ({
   ConfirmModal: () => null,
 }));
 
-const renderGameInfo = (teamScores: TeamScores) =>
+const renderGameInfo = (
+  teamScores: TeamScores,
+  props: Partial<React.ComponentProps<typeof GameInfo>> = {},
+) =>
   render(
     <GameInfo
       pointsToWin={5}
       teamScores={teamScores}
+      {...props}
     />,
   );
 
@@ -68,6 +73,30 @@ describe('GameInfo', () => {
       '3/5',
     );
     expect(screen.getByRole('meter', { name: 'Black team' })).toHaveAttribute(
+      'aria-valuetext',
+      '1/5',
+    );
+  });
+
+  it('uses custom team names without changing backend team order', () => {
+    renderGameInfo(
+      {
+        0: { deal: 0, blow: 0, play: 3, total: 3 },
+        1: { deal: 0, blow: 0, play: 1, total: 1 },
+      },
+      {
+        teamNames: {
+          0: '東軍',
+          1: '西軍',
+        },
+      },
+    );
+
+    expect(screen.getByRole('meter', { name: '東軍' })).toHaveAttribute(
+      'aria-valuetext',
+      '3/5',
+    );
+    expect(screen.getByRole('meter', { name: '西軍' })).toHaveAttribute(
       'aria-valuetext',
       '1/5',
     );

--- a/mei-tra-frontend/__tests__/components/PlayerHand.test.tsx
+++ b/mei-tra-frontend/__tests__/components/PlayerHand.test.tsx
@@ -25,6 +25,7 @@ jest.mock('next-intl', () => ({
       },
       blowControls: {
         tra: 'No Tra',
+        daiya: 'Daiya (♦)',
       },
     };
 
@@ -212,6 +213,19 @@ describe('PlayerHand', () => {
     });
 
     expect(screen.getByText('No Tra')).toHaveClass('declarationSuit');
+  });
+
+  it('omits the suit symbol from the declaration badge', () => {
+    renderPlayerHand({
+      currentHighestDeclaration: {
+        playerId: 'player-2',
+        trumpType: 'daiya',
+        numberOfPairs: 7,
+      },
+    });
+
+    expect(screen.getByText('Daiya')).toHaveClass('declarationSuit');
+    expect(screen.queryByText('Daiya (♦)')).not.toBeInTheDocument();
   });
 
   it('shows a black team badge for team one', () => {

--- a/mei-tra-frontend/app/[locale]/page.tsx
+++ b/mei-tra-frontend/app/[locale]/page.tsx
@@ -104,8 +104,10 @@ export default function Home() {
     currentRoomId = null,
     isHost = false,
     isSpectator = false,
+    teamNames,
     startGame,
     shuffleTeams,
+    updateTeamNames,
     removePlayerFromRoom,
     replacePlayerWithCOM,
     idlePlayerIds = [],
@@ -198,6 +200,8 @@ export default function Home() {
                     onStart={startGame}
                     onLeave={handleLeaveRoom}
                     shuffleTeams={shuffleTeams}
+                    teamNames={teamNames}
+                    onUpdateTeamNames={updateTeamNames}
                     onRemovePlayer={removePlayerFromRoom}
                   />
                 ) : (
@@ -223,6 +227,7 @@ export default function Home() {
                   currentRoomId={currentRoomId}
                   isHost={isHost}
                   isSpectator={isSpectator}
+                  teamNames={teamNames}
                   idlePlayerIds={idlePlayerIds}
                   disconnectedPlayerIds={disconnectedPlayerIds}
                   pointsToWin={pointsToWin}

--- a/mei-tra-frontend/components/game/BlowControls/index.module.scss
+++ b/mei-tra-frontend/components/game/BlowControls/index.module.scss
@@ -30,11 +30,16 @@
 }
 
 .currentTurn {
-  display: inline-block;
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
   padding: 0.5rem 1rem;
   border-radius: var(--mt-radius);
+  overflow: hidden;
   font-size: typography.scale(0.875rem);
   line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .currentTurn.active {
@@ -161,12 +166,32 @@
 }
 
 .declarationItem {
+  display: flex;
+  align-items: baseline;
+  gap: 0.18rem;
   background-color: var(--mt-surface-raised-2);
   color: var(--mt-text-primary);
   padding: 0.35rem 0.5rem;
   border-radius: var(--mt-radius);
   font-size: typography.scale(0.875rem);
   line-height: 1.4;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.declarationPlayerName {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.declarationSeparator,
+.declarationText {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 .declarationItem.pass {

--- a/mei-tra-frontend/components/game/BlowControls/index.tsx
+++ b/mei-tra-frontend/components/game/BlowControls/index.tsx
@@ -218,7 +218,10 @@ export function BlowControls({
     <div className={styles.blowControlsContainer}>
       <div className={styles.content}>
         <div className={styles.title}>
-          <div className={`${styles.currentTurn} ${isCurrentPlayer ? styles.active : styles.inactive}`}>
+          <div
+            className={`${styles.currentTurn} ${isCurrentPlayer ? styles.active : styles.inactive}`}
+            title={currentPlayerName ?? undefined}
+          >
             {t('currentTurn')} {currentPlayerName}
           </div>
         </div>
@@ -289,11 +292,18 @@ export function BlowControls({
 
               if (entry.type === 'pass') {
                 return (
-                  <div 
+                  <div
                     key={`pass-${entry.playerId}-${index}`}
                     className={`${styles.declarationItem} ${styles.pass}`}
+                    title={`${player.name}: ${t('passed')}`}
                   >
-                    {player.name}: {t('passed')}
+                    <span className={styles.declarationPlayerName}>
+                      {player.name}
+                    </span>
+                    <span className={styles.declarationSeparator}>:</span>
+                    <span className={styles.declarationText}>
+                      {t('passed')}
+                    </span>
                   </div>
                 );
               }
@@ -309,14 +319,20 @@ export function BlowControls({
                 <div
                   key={`${entry.playerId}-${entry.timestamp}`}
                   className={getDeclarationItemClassName(declaration)}
+                  title={`${player.name}: ${entry.trumpType ? t(entry.trumpType) : ''} ${formatSetOption(declaration.numberOfPairs)}`}
                 >
-                  {player.name}:{' '}
-                  {entry.trumpType ? (
-                    <span className={styles.trumpLabel} data-trump={entry.trumpType}>
-                      {t(entry.trumpType)}
-                    </span>
-                  ) : null}{' '}
-                  {formatSetOption(declaration.numberOfPairs)}
+                  <span className={styles.declarationPlayerName}>
+                    {player.name}
+                  </span>
+                  <span className={styles.declarationSeparator}>:</span>
+                  <span className={styles.declarationText}>
+                    {entry.trumpType ? (
+                      <span className={styles.trumpLabel} data-trump={entry.trumpType}>
+                        {t(entry.trumpType)}
+                      </span>
+                    ) : null}{' '}
+                    {formatSetOption(declaration.numberOfPairs)}
+                  </span>
                 </div>
               );
             })}

--- a/mei-tra-frontend/components/game/BlowSpectatorPanel/index.module.scss
+++ b/mei-tra-frontend/components/game/BlowSpectatorPanel/index.module.scss
@@ -101,6 +101,7 @@
 .historyItem {
   justify-content: space-between;
   gap: 0.5rem;
+  min-width: 0;
   padding: 0.25rem 0.4rem;
   border-radius: var(--mt-radius);
   background: var(--mt-surface-raised-2);
@@ -127,8 +128,10 @@
 }
 
 .declarationValue {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
   gap: 0.25rem;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .trump {

--- a/mei-tra-frontend/components/game/BlowSpectatorPanel/index.tsx
+++ b/mei-tra-frontend/components/game/BlowSpectatorPanel/index.tsx
@@ -56,14 +56,19 @@ export function BlowSpectatorPanel({
       <dl className={styles.summary}>
         <div className={styles.summaryRow}>
           <dt>{t('currentTurn')}</dt>
-          <dd>{currentPlayerName}</dd>
+          <dd title={currentPlayerName}>{currentPlayerName}</dd>
         </div>
         <div className={styles.summaryRow}>
           <dt>{t('highestBid')}</dt>
           <dd>
             {currentHighestDeclaration ? (
               <span className={styles.declarationValue}>
-                <span>{getPlayerName(currentHighestDeclaration.playerId)}</span>
+                <span
+                  className={styles.playerName}
+                  title={getPlayerName(currentHighestDeclaration.playerId)}
+                >
+                  {getPlayerName(currentHighestDeclaration.playerId)}
+                </span>
                 <span
                   className={styles.trump}
                   data-trump={currentHighestDeclaration.trumpType}
@@ -88,7 +93,12 @@ export function BlowSpectatorPanel({
                   action.type === 'pass' ? styles.pass : ''
                 } ${isHighestDeclaration(action) ? styles.highest : ''}`}
               >
-                <span className={styles.playerName}>{getPlayerName(action.playerId)}</span>
+                <span
+                  className={styles.playerName}
+                  title={getPlayerName(action.playerId)}
+                >
+                  {getPlayerName(action.playerId)}
+                </span>
                 {action.type === 'pass' ? (
                   <span>{t('pass')}</span>
                 ) : (

--- a/mei-tra-frontend/components/game/GameDock.module.scss
+++ b/mei-tra-frontend/components/game/GameDock.module.scss
@@ -25,15 +25,15 @@
   border-radius: var(--mt-radius);
   background: var(--mt-surface-raised-2);
   color: var(--mt-text-primary);
-  font-size: typography.scale(0.78rem);
+  font-size: typography.scale(0.875rem);
   font-weight: 700;
   cursor: pointer;
 }
 
 .historyButton:hover,
 .historyButton[aria-expanded='true'] {
-  border-color: var(--mt-accent);
-  background: var(--mt-accent-subtle);
+  border-color: var(--mt-text-muted);
+  background: var(--mt-surface-raised);
 }
 
 .historyPanel {
@@ -48,9 +48,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--mt-btn-primary-text);
-  background: var(--mt-btn-primary-bg);
-  border: none;
+  color: var(--mt-text-primary);
+  background: var(--mt-surface-raised-2);
+  border: 1px solid var(--mt-border-hairline);
   padding: 0;
   border-radius: var(--mt-radius);
   min-height: 2.25rem;
@@ -59,7 +59,8 @@
   transition: all 0.2s ease;
 
   &:hover {
-    box-shadow: 0 0 15px var(--mt-accent-subtle);
+    background: var(--mt-surface-raised);
+    border-color: var(--mt-text-muted);
   }
 }
 
@@ -116,12 +117,13 @@
   border-radius: var(--mt-radius);
   background: var(--mt-surface-raised-2);
   color: var(--mt-text-primary);
-  font-size: typography.scale(0.85rem);
+  font-size: typography.scale(0.875rem);
   font-weight: 700;
   cursor: pointer;
 
   &:hover {
-    border-color: var(--mt-accent);
+    background: var(--mt-surface-raised);
+    border-color: var(--mt-text-muted);
   }
 }
 

--- a/mei-tra-frontend/components/game/GameDock.tsx
+++ b/mei-tra-frontend/components/game/GameDock.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import type { Player, TrumpType } from '@/types/game.types';
+import type { Player, TeamNames, TrumpType } from '@/types/game.types';
 import { ChatDock } from '@/components/social/ChatDock';
 import { GameHistoryDock } from '@/components/game/GameHistoryDock';
 import { StrengthOrderDock } from '@/components/game/StrengthOrderDock';
@@ -14,6 +14,7 @@ interface GameDockProps {
   currentTrump: TrumpType | null;
   gamePhase?: string | null;
   players?: Player[];
+  teamNames?: TeamNames;
   onLeaveRequest?: () => void;
 }
 
@@ -23,6 +24,7 @@ export function GameDock({
   currentTrump,
   gamePhase,
   players,
+  teamNames,
   onLeaveRequest,
 }: GameDockProps) {
   const tCommon = useTranslations('common');
@@ -151,6 +153,7 @@ export function GameDock({
               roomId={roomId}
               gameStarted={gameStarted}
               players={players}
+              teamNames={teamNames}
               defaultOpen
               hideOpenPage
               onClose={() => setIsHistoryOpen(false)}
@@ -170,6 +173,7 @@ export function GameDock({
             roomId={roomId}
             gameStarted={gameStarted}
             players={players}
+            teamNames={teamNames}
             defaultOpen
             hideOpenPage
             onClose={() => setIsHistoryOpen(false)}

--- a/mei-tra-frontend/components/game/GameHistoryDock.module.scss
+++ b/mei-tra-frontend/components/game/GameHistoryDock.module.scss
@@ -24,6 +24,11 @@
   gap: 0.75rem;
   padding: 0.9rem 1rem 0.75rem;
   border-bottom: 1px solid var(--mt-border-hairline);
+  min-width: 0;
+}
+
+.header > div:first-child {
+  min-width: 0;
 }
 
 .title {
@@ -36,6 +41,7 @@
   margin: 0.25rem 0 0;
   font-size: 0.75rem;
   color: var(--mt-text-secondary);
+  overflow-wrap: anywhere;
 }
 
 .actions {
@@ -114,7 +120,10 @@
 
 .scoreComparisonLabel,
 .scoreComparisonValue {
+  min-width: 0;
+  overflow: hidden;
   font-size: 0.72rem;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -298,6 +307,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
+  min-width: 0;
 }
 
 .roundSectionTitle {
@@ -314,6 +324,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem;
+  min-width: 0;
 }
 
 .roundSectionBody {
@@ -386,7 +397,10 @@
   border-bottom: 1px solid var(--mt-border-hairline);
   text-align: left;
   vertical-align: top;
+  overflow: hidden;
+  text-overflow: ellipsis;
   word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .roundTable thead th {
@@ -434,7 +448,7 @@
 
 .roundTeamScore {
   display: grid;
-  grid-template-columns: max-content auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: baseline;
   gap: 0.3rem;
   justify-content: start;
@@ -506,6 +520,7 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 0.6rem;
+  min-width: 0;
 }
 
 .eventBadges {
@@ -516,6 +531,7 @@
 }
 
 .eventTimestamp {
+  flex: 0 0 auto;
   font-size: 0.7rem;
   color: var(--mt-text-muted);
 }
@@ -543,6 +559,7 @@
 .eventSummary {
   font-size: 0.78rem;
   line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 
 .eventDetails {
@@ -554,12 +571,14 @@
 .detailChip {
   display: inline-flex;
   align-items: center;
+  max-width: 100%;
   border-radius: 8px;
   border: 1px solid var(--mt-border-hairline);
   background: var(--mt-surface-raised-2);
   padding: 0.24rem 0.45rem;
   font-size: 0.68rem;
   color: var(--mt-text-secondary);
+  overflow-wrap: anywhere;
 }
 
 .state,
@@ -582,7 +601,8 @@
 
 .minimizedButton {
   padding: 0.55rem 0.9rem;
-  font-size: 0.78rem;
+  font-size: typography.scale(0.875rem);
+  font-weight: 700;
   white-space: nowrap;
 }
 
@@ -619,8 +639,7 @@
   }
 
   .breakdownTitle,
-  .eventSummary,
-  .minimizedButton {
+  .eventSummary {
     font-size: typography.scale(0.78rem);
   }
 

--- a/mei-tra-frontend/components/game/GameHistoryDock.tsx
+++ b/mei-tra-frontend/components/game/GameHistoryDock.tsx
@@ -11,13 +11,15 @@ import type {
   GameHistoryReplayRound,
   GameHistorySummary,
 } from '@/types/game-history.types';
-import type { Player } from '@/types/game.types';
+import type { Player, Team, TeamNames } from '@/types/game.types';
+import { getTeamDisplayName } from '@/lib/utils/teamLabels';
 import styles from './GameHistoryDock.module.scss';
 
 interface GameHistoryDockProps {
   roomId: string;
   gameStarted: boolean;
   players?: Player[];
+  teamNames?: TeamNames;
   variant?: 'dock' | 'page';
   showOverview?: boolean;
   summaryOverride?: GameHistorySummary | null;
@@ -41,31 +43,6 @@ const ACTION_TYPE_MESSAGE_KEYS = {
   game_over: 'actionTypes.game_over',
   player_stats_updated: 'actionTypes.player_stats_updated',
 } as const;
-
-function getRoundReplayEvents(round: GameHistoryReplayRound) {
-  const chronologicalEvents = [...round.events].sort(
-    (left, right) => left.timestamp.getTime() - right.timestamp.getTime(),
-  );
-  const blowEvent =
-    chronologicalEvents.find(
-      (event) => event.actionType === 'play_phase_started',
-    ) ??
-    [...chronologicalEvents]
-      .reverse()
-      .find((event) => event.actionType === 'blow_declared');
-  const scoreEvent = [...chronologicalEvents]
-    .reverse()
-    .find(
-      (event) =>
-        event.actionType === 'round_completed' ||
-        event.actionType === 'round_cancelled' ||
-        event.actionType === 'game_over',
-    );
-
-  return [blowEvent, scoreEvent].filter(
-    (event): event is GameHistoryReplayEvent => Boolean(event),
-  );
-}
 
 const extractScoreTotals = (
   value: Record<string, unknown> | null,
@@ -113,6 +90,7 @@ export function GameHistoryDock({
   roomId,
   gameStarted,
   players = [],
+  teamNames,
   variant = 'dock',
   showOverview = true,
   summaryOverride = null,
@@ -216,12 +194,10 @@ export function GameHistoryDock({
       return null;
     }
 
-    if (team === 0) {
-      return t('teamRed');
-    }
-
-    if (team === 1) {
-      return t('teamBlack');
+    if (team === 0 || team === 1) {
+      return getTeamDisplayName(team as Team, teamNames, (fallbackTeam) =>
+        t(fallbackTeam === 0 ? 'teamRed' : 'teamBlack'),
+      );
     }
 
     return t('teamValue', { team: team + 1 });
@@ -775,7 +751,7 @@ export function GameHistoryDock({
                           </div>
                         ) : null}
                         {renderEventList(
-                          getRoundReplayEvents(round).map((event) => ({
+                          chronologicalEvents.map((event) => ({
                             event,
                             roundNumber: round.roundNumber,
                           })),

--- a/mei-tra-frontend/components/game/GameHistoryPageClient.module.scss
+++ b/mei-tra-frontend/components/game/GameHistoryPageClient.module.scss
@@ -20,6 +20,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  min-width: 0;
 }
 
 .eyebrow {
@@ -64,6 +65,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
+  min-width: 0;
   padding: 1rem 1.1rem;
   border: 1px solid var(--mt-border-hairline);
   border-radius: 14px;
@@ -104,6 +106,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.28rem;
+  min-width: 0;
   padding: 0.8rem 0.9rem;
   border-radius: 10px;
   background: var(--mt-surface-raised-2);
@@ -127,11 +130,13 @@
   font-size: 0.98rem;
   font-weight: 700;
   word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .summaryValueSmall {
   font-size: 0.82rem;
   line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .feedSection {

--- a/mei-tra-frontend/components/game/GameInfo/index.module.scss
+++ b/mei-tra-frontend/components/game/GameInfo/index.module.scss
@@ -31,7 +31,7 @@
 
 .gameInfoScoreContent {
   display: grid;
-  grid-template-columns: minmax(0, 5rem) auto;
+  grid-template-columns: minmax(0, 140px) auto;
   height: 100%;
   align-items: center;
   justify-content: flex-start;
@@ -110,16 +110,23 @@
 }
 
 .gameInfoScoreTeam {
+  display: block;
   width: 100%;
   max-width: 100%;
+  min-height: 1.05rem;
+  padding: 0.1rem 0.45rem;
+  border: 1px solid color-mix(in srgb, currentColor 58%, var(--mt-border-hairline));
+  border-radius: 999px;
+  background: var(--mt-surface-raised);
+  box-sizing: border-box;
   min-width: 0;
   justify-self: end;
   overflow: hidden;
   color: var(--mt-text-secondary);
-  font-size: typography.scale(0.82rem);
-  font-weight: 700;
-  line-height: 1.2;
-  text-align: right;
+  font-size: typography.scale(0.62rem);
+  font-weight: 800;
+  line-height: 1;
+  text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -207,7 +214,7 @@
   }
 
   .gameInfoContent {
-    padding-right: 10rem;
+    padding-right: 3.25rem;
     flex-basis: auto;
   }
 
@@ -221,7 +228,7 @@
   }
 
   .gameInfoScoreContent {
-    grid-template-columns: minmax(3.5rem, 4.75rem) auto;
+    grid-template-columns: minmax(0, 8.5rem) auto;
     column-gap: 0.4rem;
   }
 
@@ -292,6 +299,6 @@
 
 @media (max-width: 420px) {
   .gameInfoContent {
-    padding-right: 9.75rem;
+    padding-right: 3rem;
   }
 }

--- a/mei-tra-frontend/components/game/GameInfo/index.tsx
+++ b/mei-tra-frontend/components/game/GameInfo/index.tsx
@@ -1,14 +1,16 @@
 import React, { useState } from 'react';
-import { TeamScores } from '@/types/game.types';
+import { Team, TeamNames, TeamScores } from '@/types/game.types';
 import styles from './index.module.scss';
 import { useTranslations } from 'next-intl';
 import { ConfirmModal } from '@/components/shared/ConfirmModal';
+import { getTeamDisplayName } from '@/lib/utils/teamLabels';
 
 type ScoreStatus = 'normal' | 'leading' | 'reach' | 'win';
 
 interface GameInfoProps {
   teamScores: TeamScores;
   pointsToWin: number;
+  teamNames?: TeamNames;
   actionSlot?: (onLeaveRequest: () => void) => React.ReactNode;
   onLeave?: () => void;
 }
@@ -16,14 +18,17 @@ interface GameInfoProps {
 export const GameInfo: React.FC<GameInfoProps> = ({
   teamScores,
   pointsToWin,
+  teamNames,
   actionSlot,
   onLeave,
 }) => {
   const t = useTranslations();
   const [showConfirmModal, setShowConfirmModal] = useState(false);
 
-  const getTeamLabel = (teamNumber: number) =>
-    t(teamNumber === 0 ? 'gameInfo.teamRed' : 'gameInfo.teamBlack');
+  const getTeamLabel = (teamNumber: Team) =>
+    getTeamDisplayName(teamNumber, teamNames, (team) =>
+      t(team === 0 ? 'gameInfo.teamRed' : 'gameInfo.teamBlack'),
+    );
   const getScoreProgress = (score: number) => {
     if (pointsToWin <= 0) {
       return 0;
@@ -56,7 +61,7 @@ export const GameInfo: React.FC<GameInfoProps> = ({
         return null;
     }
   };
-  const scoreTeams = [0, 1].map((teamNumber) => {
+  const scoreTeams = ([0, 1] as Team[]).map((teamNumber) => {
     const score = teamScores[teamNumber].total;
     const opposingScore = teamScores[teamNumber === 0 ? 1 : 0].total;
     const status = getScoreStatus(score, opposingScore);

--- a/mei-tra-frontend/components/game/GameTable/index.tsx
+++ b/mei-tra-frontend/components/game/GameTable/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Player, GamePhase, TrumpType, Field, CompletedField, BlowAction, BlowDeclaration, TeamScores, GameActions } from '@/types/game.types';
+import { Player, GamePhase, TrumpType, Field, CompletedField, BlowAction, BlowDeclaration, TeamScores, GameActions, TeamNames } from '@/types/game.types';
 import { GameField } from '@/components/game/GameField';
 import { GameInfo } from '@/components/game/GameInfo';
 import { GameDock } from '@/components/game/GameDock';
@@ -35,6 +35,7 @@ interface GameTableProps {
   idlePlayerIds?: string[];
   disconnectedPlayerIds?: string[];
   pointsToWin: number;
+  teamNames?: TeamNames;
   // Waiting-room props (shown before game starts)
   isWaiting?: boolean;
   isHost?: boolean;
@@ -66,6 +67,7 @@ export const GameTable: React.FC<GameTableProps> = ({
   currentPlayerId,
   currentRoomId,
   pointsToWin,
+  teamNames,
   idlePlayerIds = [],
   disconnectedPlayerIds = [],
   isWaiting = false,
@@ -131,6 +133,7 @@ export const GameTable: React.FC<GameTableProps> = ({
         <GameInfo
           teamScores={teamScores}
           pointsToWin={pointsToWin}
+          teamNames={teamNames}
           actionSlot={
             currentRoomId ? (onLeaveRequest) => (
               <GameDock
@@ -139,6 +142,7 @@ export const GameTable: React.FC<GameTableProps> = ({
                 currentTrump={currentTrump}
                 gamePhase={gamePhase}
                 players={players}
+                teamNames={teamNames}
                 onLeaveRequest={onLeaveRequest}
               />
             ) : undefined
@@ -219,6 +223,7 @@ export const GameTable: React.FC<GameTableProps> = ({
               currentField={currentField}
               currentTrump={currentTrump}
               takenCount={takenCount}
+              teamNames={teamNames}
               isHost={isHost}
               isIdle={idlePlayerIds.includes(player_.playerId)}
               isDisconnected={disconnectedPlayerIds.includes(player_.playerId)}

--- a/mei-tra-frontend/components/game/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/game/PlayerHand/index.module.scss
@@ -226,15 +226,22 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-xs);
+  gap: 0.18rem;
   align-items: center;
   justify-content: center;
+  text-align: center;
   background: var(--mt-surface-raised-2);
   border: 1px solid var(--mt-border-hairline);
   border-radius: var(--mt-radius);
-  padding: 4px;
+  box-sizing: border-box;
+  padding: 0.25rem;
   min-width: 132px;
+  max-width: 100%;
   backdrop-filter: blur(2px);
+}
+
+.playerInfoContainer > * {
+  max-width: 100%;
 }
 
 .playerInfoBadges {
@@ -249,32 +256,29 @@
 }
 
 .teamBadge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 1.05rem;
-  border: 1px solid var(--mt-border-hairline);
-  border-radius: 999px;
-  background: var(--mt-surface-raised);
+  display: block;
+  flex: 0 1 auto;
+  border: 0;
+  background: transparent;
+  box-sizing: border-box;
   color: var(--mt-text-primary);
-  font-size: typography.scale(0.62rem);
-  font-weight: 800;
-  line-height: 1;
-  padding: 0.1rem 0.3rem;
+  font-size: typography.scale(0.72rem);
+  font-weight: 700;
+  line-height: 1.2;
+  padding: 0;
   min-width: 0;
-  max-width: 100%;
+  max-width: min(100px, 100%);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-align: center;
 }
 
 .teamRedBadge {
-  border-color: color-mix(in srgb, var(--mt-danger) 60%, var(--mt-border-hairline));
   color: var(--mt-danger);
 }
 
 .teamBlackBadge {
-  border-color: var(--mt-team-black);
   color: var(--mt-team-black);
 }
 
@@ -335,7 +339,10 @@
 
 .playerAvatar{
   position: relative;
-  width: calc(100% - 8px);
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  min-width: 0;
 }
 
 .avatarTurnBadge {
@@ -619,8 +626,9 @@
 .playerPosition.top .playerInfoContainer,
 .playerPosition.left .playerInfoContainer,
 .playerPosition.right .playerInfoContainer {
-  min-width: 5.5rem;
-  padding: 0.16rem;
+  min-width: 4.9rem;
+  max-width: 8.75rem;
+  padding: 0.16rem 0.22rem;
   background: var(--mt-surface-raised-2);
 }
 
@@ -888,7 +896,9 @@
 
   .teamBadge {
     flex: 0 1 auto;
+    width: auto;
     min-width: 0;
+    max-width: 100%;
     font-size: typography.scale(0.52rem);
     padding-inline: 0.14rem;
   }

--- a/mei-tra-frontend/components/game/PlayerHand/index.tsx
+++ b/mei-tra-frontend/components/game/PlayerHand/index.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
-import { Player, GamePhase, GameActions, CompletedField, Field, TrumpType, BlowDeclaration } from '@/types/game.types';
+import { Player, GamePhase, GameActions, CompletedField, Field, TrumpType, BlowDeclaration, TeamNames } from '@/types/game.types';
 import { CardFace } from '@/components/game/CardFace';
 import { CompletedFields, TakenCardPreview } from '@/components/game/CompletedFields';
 import { PlayerAvatar } from '@/components/game/PlayerAvatar';
 import styles from './index.module.scss';
 import { useCardValidation } from './hooks/useCardValidation';
 import { PlayAndCancelBtn } from '@/components/game/PlayAndCancelBtn';
+import { getTeamDisplayName } from '@/lib/utils/teamLabels';
 
 const HAND_CARD_METRICS = {
   width: 80,
@@ -44,6 +45,7 @@ interface PlayerHandProps {
   onSpectatorPerspectiveChange?: (playerId: string) => void;
   onReplaceWithCOM?: (playerId: string) => void;
   takenCount?: number;
+  teamNames?: TeamNames;
 }
 
 export const PlayerHand: React.FC<PlayerHandProps> = ({
@@ -68,6 +70,7 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
   onSpectatorPerspectiveChange,
   onReplaceWithCOM,
   takenCount = 0,
+  teamNames,
 }) => {
   const t = useTranslations('playerHand');
   const tGameInfo = useTranslations('gameInfo');
@@ -109,7 +112,9 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
     : locale === 'ja'
       ? `${takenCount}組`
       : `${takenCount} sets`;
-  const teamLabel = tGameInfo(player.team === 0 ? 'teamRed' : 'teamBlack');
+  const teamLabel = getTeamDisplayName(player.team, teamNames, (team) =>
+    tGameInfo(team === 0 ? 'teamRed' : 'teamBlack'),
+  );
 
   useEffect(() => {
     if (
@@ -190,9 +195,13 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
       return;
     }
 
-    const targetElement = document
-      .elementFromPoint(event.clientX, event.clientY)
-      ?.closest<HTMLElement>('[data-hand-card]');
+    const elementAtPointer =
+      typeof document.elementFromPoint === 'function'
+        ? document.elementFromPoint(event.clientX, event.clientY)
+        : event.target instanceof Element
+          ? event.target
+          : null;
+    const targetElement = elementAtPointer?.closest<HTMLElement>('[data-hand-card]');
     const targetCard = targetElement?.dataset.handCard;
 
     if (!targetElement || !targetCard || targetCard === draggingCard) {
@@ -426,7 +435,7 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
           className={styles.declarationSuit}
           data-trump={playerDeclaration.trumpType}
         >
-          {tBlow(playerDeclaration.trumpType)}
+          {tBlow(playerDeclaration.trumpType).replace(/（[^）]*）|\([^)]*\)/g, '').trim()}
         </span>
         <span className={styles.declarationPairs}>{playerDeclaration.numberOfPairs}</span>
       </span>

--- a/mei-tra-frontend/components/game/PreGameTable/index.module.scss
+++ b/mei-tra-frontend/components/game/PreGameTable/index.module.scss
@@ -8,7 +8,7 @@
     "left center right"
     ".    bottom .";
   grid-template-columns: 280px 240px 280px;
-  grid-template-rows: auto minmax(200px, 240px) auto;
+  grid-template-rows: auto auto auto;
   gap: 0.55rem 1.1rem;
   justify-content: center;
   min-height: calc(100dvh - 6.4rem);
@@ -81,6 +81,133 @@
   margin-top: 0.35rem;
 }
 
+.teamNamePanel {
+  width: min(100%, 240px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.teamNameSummary {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 2.1rem;
+  padding: 0.25rem 0.35rem;
+  border: 1px solid var(--mt-border-hairline);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--mt-surface-raised) 78%, transparent);
+}
+
+.teamNameSummaryLabel {
+  flex: 0 0 auto;
+  color: var(--mt-text-secondary);
+  font-size: typography.scale(0.7rem);
+  font-weight: 800;
+  white-space: nowrap;
+  margin-right: 0.05rem;
+}
+
+.teamNamePill {
+  flex: 0 1 auto;
+  max-width: 4.2rem;
+  padding: 2px 6px;
+  border-radius: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: typography.scale(0.68rem);
+  font-weight: 800;
+}
+
+.teamRedPill {
+  border: 1px solid color-mix(in srgb, var(--mt-card-red) 48%, transparent);
+  background: color-mix(in srgb, var(--mt-card-red) 14%, var(--mt-surface-raised));
+  color: var(--mt-card-red);
+}
+
+.teamBlackPill {
+  border: 1px solid color-mix(in srgb, var(--mt-team-black) 42%, transparent);
+  background: color-mix(in srgb, var(--mt-team-black) 10%, var(--mt-surface-raised));
+  color: var(--mt-team-black);
+}
+
+.teamNameEditButton {
+  flex: 0 0 auto;
+  min-height: 1.6rem;
+  padding: 0 0.45rem;
+  border: 1px solid var(--mt-border-hairline);
+  border-radius: 999px;
+  background: var(--mt-surface);
+  color: var(--mt-text-secondary);
+  font-size: typography.scale(0.7rem);
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.teamNameForm {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0.55rem;
+  border: 1px solid var(--mt-border-hairline);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--mt-surface-raised) 78%, transparent);
+}
+
+.teamNameFields {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.teamNameField {
+  display: grid;
+  grid-template-columns: 4.4rem minmax(0, 1fr);
+  align-items: center;
+  gap: 0.45rem;
+  font-size: typography.scale(0.72rem);
+  font-weight: 800;
+
+  span {
+    white-space: nowrap;
+  }
+
+  input {
+    width: 100%;
+    min-width: 0;
+    height: 1.9rem;
+    padding: 0.25rem 0.45rem;
+    border: 1px solid var(--mt-border-hairline);
+    border-radius: 6px;
+    background: var(--mt-surface);
+    color: var(--mt-text-primary);
+    font: inherit;
+    font-weight: 700;
+  }
+}
+
+.teamRedField {
+  color: var(--mt-card-red);
+}
+
+.teamBlackField {
+  color: var(--mt-team-black);
+}
+
+.teamNameSaveButton {
+  min-height: 2rem;
+  padding: 0.35rem 0.7rem;
+  border: 1px solid var(--mt-border-hairline);
+  border-radius: 6px;
+  background: var(--mt-surface);
+  color: var(--mt-text-primary);
+  font-size: typography.scale(0.78rem);
+  font-weight: 800;
+  cursor: pointer;
+  text-shadow: none;
+}
+
 .startButton,
 .shuffleButton,
 .leaveButton {
@@ -136,11 +263,16 @@
 }
 
 .teamBadge {
+  display: block;
   font-size: typography.scale(0.7rem);
   padding: 2px 7px;
   border-radius: 4px;
   margin-top: 4px;
   font-weight: 600;
+  max-width: min(8rem, 100%);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .teamRed .teamBadge {
@@ -195,6 +327,20 @@
   .center {
     gap: 0.625rem;
     width: 100%;
+  }
+
+  .teamNamePanel,
+  .teamNameForm {
+    width: 100%;
+  }
+
+  .teamNameForm {
+    padding: 0.45rem;
+  }
+
+  .teamNameField {
+    grid-template-columns: 3.8rem minmax(0, 1fr);
+    gap: 0.35rem;
   }
 
   .startButton,

--- a/mei-tra-frontend/components/game/PreGameTable/index.tsx
+++ b/mei-tra-frontend/components/game/PreGameTable/index.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Player } from '@/types/game.types';
+import { Player, TeamNames } from '@/types/game.types';
 import { PlayerAvatar } from '@/components/game/PlayerAvatar';
 import { getConsistentTableOrderWithSelfBottom } from '@/lib/utils/tableOrder';
+import { getTeamDisplayName } from '@/lib/utils/teamLabels';
 import styles from './index.module.scss';
 
 interface PreGameTableProps {
@@ -14,6 +15,8 @@ interface PreGameTableProps {
   onStart: () => void;
   onLeave: () => void;
   shuffleTeams?: () => void;
+  teamNames?: TeamNames;
+  onUpdateTeamNames?: (teamNames: TeamNames) => void;
   onRemovePlayer?: (playerId: string) => void;
 }
 
@@ -37,9 +40,29 @@ export const PreGameTable: React.FC<PreGameTableProps> = ({
   onStart,
   onLeave,
   shuffleTeams,
+  teamNames,
+  onUpdateTeamNames,
   onRemovePlayer,
 }) => {
   const tRoot = useTranslations();
+  const resolvedTeamNames = useMemo<TeamNames>(
+    () => ({
+      0: getTeamDisplayName(0, teamNames, (team) =>
+        tRoot(team === 0 ? 'gameInfo.teamRed' : 'gameInfo.teamBlack'),
+      ),
+      1: getTeamDisplayName(1, teamNames, (team) =>
+        tRoot(team === 0 ? 'gameInfo.teamRed' : 'gameInfo.teamBlack'),
+      ),
+    }),
+    [teamNames, tRoot],
+  );
+  const [draftTeamNames, setDraftTeamNames] =
+    useState<TeamNames>(resolvedTeamNames);
+  const [isEditingTeamNames, setIsEditingTeamNames] = useState(false);
+
+  useEffect(() => {
+    setDraftTeamNames(resolvedTeamNames);
+  }, [resolvedTeamNames]);
 
   const ordered = currentPlayerId
     ? getConsistentTableOrderWithSelfBottom(players, currentPlayerId)
@@ -50,6 +73,17 @@ export const PreGameTable: React.FC<PreGameTableProps> = ({
     if (p.isCOM && !p.isReady) return { ...p, name: 'COM' };
     return p;
   });
+
+  const getTeamLabel = (team: Player['team']) =>
+    getTeamDisplayName(team, teamNames, (fallbackTeam) =>
+      tRoot(fallbackTeam === 0 ? 'gameInfo.teamRed' : 'gameInfo.teamBlack'),
+    );
+
+  const handleTeamNameSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onUpdateTeamNames?.(draftTeamNames);
+    setIsEditingTeamNames(false);
+  };
 
   return (
     <div className={styles.playerPositions}>
@@ -62,8 +96,8 @@ export const PreGameTable: React.FC<PreGameTableProps> = ({
         >
           <div className={styles.seatContent}>
             <PlayerAvatar player={player} size="medium" showName={true} />
-            <span className={styles.teamBadge}>
-              {tRoot(player.team === 0 ? 'gameInfo.teamRed' : 'gameInfo.teamBlack')}
+            <span className={styles.teamBadge} title={getTeamLabel(player.team)}>
+              {getTeamLabel(player.team)}
             </span>
             {isHost &&
               onRemovePlayer &&
@@ -84,6 +118,72 @@ export const PreGameTable: React.FC<PreGameTableProps> = ({
       <div className={styles.center}>
         {isHost ? (
           <>
+            {onUpdateTeamNames && (
+              <div className={styles.teamNamePanel}>
+                <div className={styles.teamNameSummary}>
+                  <span className={styles.teamNameSummaryLabel}>
+                    {tRoot('room.teamNames')}
+                  </span>
+                  <span className={`${styles.teamNamePill} ${styles.teamRedPill}`}>
+                    {resolvedTeamNames[0]}
+                  </span>
+                  <span className={`${styles.teamNamePill} ${styles.teamBlackPill}`}>
+                    {resolvedTeamNames[1]}
+                  </span>
+                  <button
+                    type="button"
+                    className={styles.teamNameEditButton}
+                    onClick={() => setIsEditingTeamNames((current) => !current)}
+                  >
+                    {tRoot(
+                      isEditingTeamNames
+                        ? 'common.close'
+                        : 'room.editTeamNames',
+                    )}
+                  </button>
+                </div>
+                {isEditingTeamNames && (
+                  <form
+                    className={styles.teamNameForm}
+                    onSubmit={handleTeamNameSubmit}
+                  >
+                    <div className={styles.teamNameFields}>
+                      <label className={`${styles.teamNameField} ${styles.teamRedField}`}>
+                        <span>{tRoot('room.teamRedName')}</span>
+                        <input
+                          type="text"
+                          value={draftTeamNames[0] ?? ''}
+                          onChange={(event) =>
+                            setDraftTeamNames((current) => ({
+                              ...current,
+                              0: event.target.value,
+                            }))
+                          }
+                          maxLength={16}
+                        />
+                      </label>
+                      <label className={`${styles.teamNameField} ${styles.teamBlackField}`}>
+                        <span>{tRoot('room.teamBlackName')}</span>
+                        <input
+                          type="text"
+                          value={draftTeamNames[1] ?? ''}
+                          onChange={(event) =>
+                            setDraftTeamNames((current) => ({
+                              ...current,
+                              1: event.target.value,
+                            }))
+                          }
+                          maxLength={16}
+                        />
+                      </label>
+                    </div>
+                    <button type="submit" className={styles.teamNameSaveButton}>
+                      {tRoot('room.saveTeamNames')}
+                    </button>
+                  </form>
+                )}
+              </div>
+            )}
             {shuffleTeams && (
               <button className={styles.shuffleButton} onClick={shuffleTeams}>
                 {tRoot('room.shuffleTeams')}

--- a/mei-tra-frontend/components/game/StrengthOrderDock.module.scss
+++ b/mei-tra-frontend/components/game/StrengthOrderDock.module.scss
@@ -10,21 +10,22 @@
 }
 
 .orderButton {
-  background: var(--mt-btn-primary-bg);
-  color: var(--mt-btn-primary-text);
+  background: var(--mt-surface-raised-2);
+  color: var(--mt-text-primary);
   padding: 0.5rem 1rem;
+  border: 1px solid var(--mt-border-hairline);
   border-radius: var(--mt-radius);
   min-height: 2.25rem;
   min-width: 5.5rem;
   height: 100%;
   font-size: typography.scale(0.875rem);
-  box-shadow: var(--mt-shadow-btn);
-  border: none;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
 
   &:hover {
-    background: var(--mt-btn-primary-bg-hover);
+    background: var(--mt-surface-raised);
+    border-color: var(--mt-text-muted);
   }
 
   @media (max-width: 768px) {

--- a/mei-tra-frontend/components/profile/ProfilePage.module.scss
+++ b/mei-tra-frontend/components/profile/ProfilePage.module.scss
@@ -136,6 +136,7 @@ $transition-button: all 0.3s ease;
   gap: $spacing-lg;
   justify-content: space-between;
   width: 100%;
+  min-width: 0;
 
   @media (max-width: 768px) {
     flex-direction: column;
@@ -145,6 +146,7 @@ $transition-button: all 0.3s ease;
 }
 
 .avatarContainer {
+  flex: 0 0 auto;
   background-color: var(--mt-surface-raised-2);
   padding: 4px;
   border-radius: 50%;
@@ -177,19 +179,29 @@ $transition-button: all 0.3s ease;
 }
 
 .profileInfo {
+  flex: 1 1 auto;
+  min-width: 0;
   color: var(--mt-text-primary);
 }
 
 .profileName {
+  max-width: 100%;
   font-size: $font-size-xxl;
   font-weight: bold;
   font-family: var(--mt-font-heading);
   margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .profileEmail {
+  max-width: 100%;
   color: var(--mt-text-muted);
   font-size: $font-size-sm;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .profileContent {
@@ -220,10 +232,15 @@ $transition-button: all 0.3s ease;
 }
 
 .statValue {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
   font-size: $font-size-xxl;
   font-weight: bold;
   margin-bottom: $spacing-xs;
   color: var(--mt-text-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .statLabel {
@@ -253,6 +270,8 @@ $transition-button: all 0.3s ease;
 .accountRow {
   display: flex;
   justify-content: space-between;
+  gap: $spacing-md;
+  min-width: 0;
   padding: $spacing-sm 0;
   border-bottom: 1px solid var(--mt-border-hairline);
 
@@ -267,11 +286,21 @@ $transition-button: all 0.3s ease;
 }
 
 .accountLabel {
+  flex: 0 0 auto;
   color: var(--mt-text-muted);
 }
 
 .accountValue {
+  min-width: 0;
+  overflow: hidden;
   color: var(--mt-text-primary);
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  @media (max-width: 480px) {
+    text-align: left;
+  }
 }
 
 .accountActions {
@@ -328,6 +357,7 @@ $transition-button: all 0.3s ease;
   display: flex;
   align-items: center;
   gap: $spacing-sm;
+  flex: 0 0 auto;
 
   @media (max-width: 768px) {
     justify-content: center;

--- a/mei-tra-frontend/components/profile/ProfilePage.tsx
+++ b/mei-tra-frontend/components/profile/ProfilePage.tsx
@@ -199,10 +199,10 @@ export function ProfilePage() {
                 )}
               </div>
               <div className={styles.profileInfo}>
-                <h1 className={styles.profileName}>
+                <h1 className={styles.profileName} title={profile?.displayName || user?.email || 'User'}>
                   {profile?.displayName || user?.email || 'User'}
                 </h1>
-                <p className={styles.profileEmail}>
+                <p className={styles.profileEmail} title={user.email ?? undefined}>
                   {user.email}
                 </p>
               </div>

--- a/mei-tra-frontend/components/profile/ProfileRecentMatchesSection.module.scss
+++ b/mei-tra-frontend/components/profile/ProfileRecentMatchesSection.module.scss
@@ -46,6 +46,7 @@
 
 .card {
   display: block;
+  min-width: 0;
   border-radius: var(--mt-radius);
   border: 1px solid var(--mt-border-hairline);
   background: var(--mt-surface-raised);
@@ -67,13 +68,18 @@
   gap: $spacing-md;
   align-items: flex-start;
   margin-bottom: $spacing-sm;
+  min-width: 0;
 }
 
 .roomName {
+  min-width: 0;
   margin: 0;
   font-size: $font-size-lg;
   font-weight: 600;
   color: var(--mt-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .completedAt {
@@ -93,6 +99,7 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+  min-width: 0;
 }
 
 .metaLabel {
@@ -103,9 +110,13 @@
 }
 
 .metaValue {
+  min-width: 0;
+  overflow: hidden;
   color: var(--mt-text-primary);
   font-size: $font-size-sm;
   font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .detailsLink {

--- a/mei-tra-frontend/components/profile/ProfileRecentMatchesSection.tsx
+++ b/mei-tra-frontend/components/profile/ProfileRecentMatchesSection.tsx
@@ -88,7 +88,9 @@ export function ProfileRecentMatchesSection({
               className={styles.card}
             >
               <div className={styles.cardHeader}>
-                <h4 className={styles.roomName}>{item.roomName}</h4>
+                <h4 className={styles.roomName} title={item.roomName}>
+                  {item.roomName}
+                </h4>
                 <p className={styles.completedAt}>
                   {dateFormatter.format(item.completedAt)}
                 </p>

--- a/mei-tra-frontend/components/profile/UserProfile.module.scss
+++ b/mei-tra-frontend/components/profile/UserProfile.module.scss
@@ -131,11 +131,14 @@ $opacity-disabled: 0.5;
 }
 
 .displayName {
+  max-width: 100%;
   font-size: typography.scale(0.9rem);
   font-weight: 700;
   color: var(--mt-text-primary);
   line-height: 1.2;
-  overflow-wrap: anywhere;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .profileEditHint {
@@ -226,6 +229,7 @@ $opacity-disabled: 0.5;
 .compactTrigger .avatarPlaceholder {
   width: 2.5rem;
   height: 2.5rem;
+  border: none;
 }
 
 .compactTriggerOpen {
@@ -262,6 +266,7 @@ $opacity-disabled: 0.5;
   border-radius: 0.8rem;
   text-decoration: none;
   transition: $transition-button;
+  min-width: 0;
 
   &:hover {
     background: var(--mt-surface-raised-2);
@@ -269,18 +274,24 @@ $opacity-disabled: 0.5;
 }
 
 .compactDisplayName {
+  max-width: 100%;
   font-size: typography.scale(0.95rem);
   font-weight: 700;
   color: var(--mt-text-primary);
   line-height: 1.2;
-  overflow-wrap: anywhere;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .compactMeta {
+  max-width: 100%;
   font-size: typography.scale(0.78rem);
   color: var(--mt-text-secondary);
   line-height: 1.25;
-  overflow-wrap: anywhere;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .compactActions {

--- a/mei-tra-frontend/components/profile/UserProfile.tsx
+++ b/mei-tra-frontend/components/profile/UserProfile.tsx
@@ -90,7 +90,7 @@ export function UserProfile({ variant = 'default', isGameInProgress = false }: U
 
   const compactSummaryContent = (
     <>
-      <span className={styles.compactDisplayName}>{displayName}</span>
+      <span className={styles.compactDisplayName} title={displayName}>{displayName}</span>
       {secondaryEmail ? (
         <span className={styles.compactMeta}>{secondaryEmail}</span>
       ) : null}
@@ -103,7 +103,7 @@ export function UserProfile({ variant = 'default', isGameInProgress = false }: U
         {renderAvatar(styles.avatar, styles.avatarPlaceholder)}
       </div>
       <div className={styles.userInfo}>
-        <span className={styles.displayName}>{displayName}</span>
+        <span className={styles.displayName} title={displayName}>{displayName}</span>
         <span className={styles.profileEditHint}>
           {t('edit')}
         </span>

--- a/mei-tra-frontend/components/room/RoomList/index.module.scss
+++ b/mei-tra-frontend/components/room/RoomList/index.module.scss
@@ -169,24 +169,34 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  min-width: 0;
 }
 
 .roomInfo {
   flex: 1;
+  min-width: 0;
 }
 
 .roomInfo h3 {
   margin: 0;
+  max-width: 100%;
+  overflow: hidden;
   font-size: typography.scale(1rem);
   line-height: 1.35;
   color: var(--mt-text-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .roomInfo p {
   margin: 0.35rem 0;
+  max-width: 100%;
+  overflow: hidden;
   font-size: typography.scale(0.95rem);
   line-height: 1.45;
   color: var(--mt-text-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .status {
@@ -362,7 +372,12 @@
 }
 
 .playerName {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
   color: var(--mt-text-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .readyStatus {
@@ -407,6 +422,7 @@
   margin: 0;
   padding: 0;
   list-style: none;
+  min-width: 0;
 }
 
 .playerItem {
@@ -414,7 +430,8 @@
   align-items: center;
   gap: 0.5rem;
   margin-bottom: 0.2rem;
-  flex-wrap: wrap;
+  min-width: 0;
+  flex-wrap: nowrap;
 }
 
 .teamSelectContainer {
@@ -459,6 +476,7 @@
 }
 
 .hostLabel {
+  flex: 0 0 auto;
   font-size: 0.9em;
   color: var(--mt-warning);
   margin-left: 0.25rem;

--- a/mei-tra-frontend/components/room/RoomList/index.tsx
+++ b/mei-tra-frontend/components/room/RoomList/index.tsx
@@ -179,7 +179,7 @@ export const RoomList: React.FC<RoomListProps> = ({
             return (
               <div key={room.id} className={styles.roomItem}>
                 <div className={styles.roomInfo}>
-                  <h3>{room.name}</h3>
+                  <h3 title={room.name}>{room.name}</h3>
                   <p>{t('room.players')}: {actualPlayerCount}/{room.settings.maxPlayers}</p>
                   <p className={`${styles.status} ${getStatusClass(room.status)}`}>
                     {t('room.status')}: {getStatusText(room.status, t)}
@@ -190,7 +190,7 @@ export const RoomList: React.FC<RoomListProps> = ({
                         key={`${player.playerId}-${index}`}
                         className={styles.playerItem}
                       >
-                        <span className={styles.playerName}>{player.name}</span>
+                        <span className={styles.playerName} title={player.name}>{player.name}</span>
                         {player.isHost && <span className={styles.hostLabel}>{t('room.host')}</span>}
                       </li>
                     ))}

--- a/mei-tra-frontend/components/social/ChatDock.module.scss
+++ b/mei-tra-frontend/components/social/ChatDock.module.scss
@@ -1,5 +1,12 @@
 @use '../../styles/base/typography' as typography;
 
+.chatShell {
+  position: relative;
+  z-index: 50;
+  display: flex;
+  height: 100%;
+}
+
 .chatDock {
   position: relative;
   z-index: 50;
@@ -70,29 +77,33 @@
 }
 
 .minimizedButton {
-  background: var(--mt-btn-primary-bg);
-  color: var(--mt-btn-primary-text);
+  background: var(--mt-surface-raised-2);
+  color: var(--mt-text-primary);
   padding: 0.5rem 1rem;
+  border: 1px solid var(--mt-border-hairline);
   border-radius: var(--mt-radius);
   min-height: 2.25rem;
   min-width: 5.5rem;
   height: 100%;
   font-size: typography.scale(0.875rem);
-  box-shadow: var(--mt-shadow-btn);
-  border: none;
   cursor: pointer;
-  transition: all 0.2s;
-  font-weight: 500;
+  transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
+  font-weight: 700;
 
   &:hover {
-    background: var(--mt-btn-primary-bg-hover);
-    box-shadow: var(--mt-shadow-panel);
+    background: var(--mt-surface-raised);
+    border-color: var(--mt-text-muted);
   }
 
   @media (max-width: 768px) {
     min-width: 7.5rem;
     padding: 0.5rem 0.75rem;
   }
+}
+
+.minimizedButtonActive {
+  background: var(--mt-surface-raised);
+  border-color: var(--mt-text-muted);
 }
 
 .header {

--- a/mei-tra-frontend/components/social/ChatDock.tsx
+++ b/mei-tra-frontend/components/social/ChatDock.tsx
@@ -89,66 +89,64 @@ export function ChatDock({
     sendMessage(roomId, content);
   };
 
-  if (isMinimized) {
-    return (
-      <div className={styles.minimized}>
-        <button
-          onClick={() => setIsMinimized(false)}
-          className={styles.minimizedButton}
-        >
-          {t('title')} {messages.length > 0 && `(${messages.length})`}
-        </button>
-      </div>
-    );
-  }
-
   return (
-    <div
-      className={`${styles.chatDock} ${placement === 'topbar' ? styles.topbar : ''} ${placement === 'menu' ? styles.menu : ''}`}
-      ref={chatRef}
-    >
-      {/* Header */}
-      <div className={styles.header}>
-        <div className={styles.headerLeft}>
-          <div className={`${styles.statusIndicator} ${isConnected ? styles.connected : styles.disconnected}`} />
-          <h3 className={styles.headerTitle}>{t('title')}</h3>
-        </div>
-        <button
-          onClick={() => setIsMinimized(true)}
-          className={styles.minimizeButton}
+    <div className={styles.chatShell} ref={chatRef}>
+      <button
+        onClick={() => setIsMinimized((current) => !current)}
+        className={`${styles.minimizedButton} ${!isMinimized ? styles.minimizedButtonActive : ''}`}
+        aria-expanded={!isMinimized}
+      >
+        {t('title')} {messages.length > 0 && `(${messages.length})`}
+      </button>
+
+      {!isMinimized && (
+        <div
+          className={`${styles.chatDock} ${placement === 'topbar' ? styles.topbar : ''} ${placement === 'menu' ? styles.menu : ''}`}
         >
-          <ChevronDownIcon className={styles.icon} />
-        </button>
-      </div>
-
-      {/* Messages */}
-      <div className={styles.messagesContainer}>
-        {messages.length === 0 ? (
-          <div className={styles.emptyState}>
-            {t('empty')}
+          {/* Header */}
+          <div className={styles.header}>
+            <div className={styles.headerLeft}>
+              <div className={`${styles.statusIndicator} ${isConnected ? styles.connected : styles.disconnected}`} />
+              <h3 className={styles.headerTitle}>{t('title')}</h3>
+            </div>
+            <button
+              onClick={() => setIsMinimized(true)}
+              className={styles.minimizeButton}
+            >
+              <ChevronDownIcon className={styles.icon} />
+            </button>
           </div>
-        ) : (
-          messages.map((msg) => (
-            <ChatMessage key={msg.message.id} message={msg.message} />
-          ))
-        )}
-        {typingUsers.size > 0 && (
-          <div className={styles.typingIndicator}>
-            {typingUsers.size === 1
-              ? t('typingOne')
-              : t('typingMany', { count: typingUsers.size })}
-          </div>
-        )}
-        <div ref={messagesEndRef} />
-      </div>
 
-      {/* Composer */}
-      <ChatComposer
-        onSend={handleSendMessage}
-        disabled={!isConnected}
-        connectingPlaceholder={t('connectingPlaceholder')}
-        inputPlaceholder={t('inputPlaceholder')}
-      />
+          {/* Messages */}
+          <div className={styles.messagesContainer}>
+            {messages.length === 0 ? (
+              <div className={styles.emptyState}>
+                {t('empty')}
+              </div>
+            ) : (
+              messages.map((msg) => (
+                <ChatMessage key={msg.message.id} message={msg.message} />
+              ))
+            )}
+            {typingUsers.size > 0 && (
+              <div className={styles.typingIndicator}>
+                {typingUsers.size === 1
+                  ? t('typingOne')
+                  : t('typingMany', { count: typingUsers.size })}
+              </div>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+
+          {/* Composer */}
+          <ChatComposer
+            onSend={handleSendMessage}
+            disabled={!isConnected}
+            connectingPlaceholder={t('connectingPlaceholder')}
+            inputPlaceholder={t('inputPlaceholder')}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/mei-tra-frontend/components/social/ChatMessage.module.scss
+++ b/mei-tra-frontend/components/social/ChatMessage.module.scss
@@ -11,6 +11,7 @@
 .message {
   display: flex;
   gap: 0.75rem;
+  min-width: 0;
 }
 
 .avatar {
@@ -46,15 +47,22 @@
   display: flex;
   align-items: baseline;
   gap: 0.5rem;
+  min-width: 0;
 }
 
 .senderName {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
   font-weight: 500;
   color: var(--mt-text-primary);
   font-size: typography.scale(0.875rem);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .timestamp {
+  flex: 0 0 auto;
   font-size: typography.scale(0.75rem);
   color: var(--mt-text-muted);
 }
@@ -64,4 +72,5 @@
   font-size: typography.scale(0.875rem);
   margin-top: 0.25rem;
   word-break: break-word;
+  overflow-wrap: anywhere;
 }

--- a/mei-tra-frontend/components/social/ChatMessage.tsx
+++ b/mei-tra-frontend/components/social/ChatMessage.tsx
@@ -39,7 +39,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
       {/* Content */}
       <div className={styles.content}>
         <div className={styles.header}>
-          <span className={styles.senderName}>
+          <span className={styles.senderName} title={message.sender.displayName}>
             {message.sender.displayName}
           </span>
           <span className={styles.timestamp}>

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -40,6 +40,8 @@ import {
   Field,
   GamePhase,
   Player,
+  Team,
+  TeamNames,
   TeamScores,
   TrumpType,
   fromPlayerContracts,
@@ -47,6 +49,7 @@ import {
 import { fromRoomContract, fromRoomSyncPayload } from '../types/room.types';
 import { clearPlayerProfileCache } from '../lib/utils/profileUtils';
 import { inferNextTurnAfterCardPlayed } from '../lib/utils/turnInference';
+import { getTeamDisplayName } from '../lib/utils/teamLabels';
 
 interface ProfileUpdatedPayload {
   userId: string;
@@ -216,6 +219,7 @@ export const useGame = () => {
   const [isHost, setIsHost] = useState(false);
   const [isSpectator, setIsSpectator] = useState(false);
   const [pointsToWin, setPointsToWin] = useState<number>(0);
+  const [teamNames, setTeamNames] = useState<TeamNames | undefined>();
   const [idlePlayerIds, setIdlePlayerIds] = useState<string[]>([]);
   const [disconnectedPlayerIds, setDisconnectedPlayerIds] = useState<string[]>([]);
 
@@ -241,8 +245,17 @@ export const useGame = () => {
     setDisconnectedPlayerIds([]);
     setPlayers([]);
     setTeamScores(createEmptyTeamScores());
+    setTeamNames(undefined);
     sessionStorage.removeItem('roomId');
   }, []);
+
+  const getTeamLabel = useCallback(
+    (team: Team) =>
+      getTeamDisplayName(team, teamNames, (fallbackTeam) =>
+        t(fallbackTeam === 0 ? 'teamRed' : 'teamBlack'),
+      ),
+    [teamNames, t],
+  );
 
   const syncDisconnectedPlayerIdsFromPlayers = useCallback(
     (nextPlayers: Array<Pick<Player, 'playerId' | 'isCOM' | 'socketId'>>) => {
@@ -492,6 +505,7 @@ export const useGame = () => {
         }
 
         setCurrentHostId(nextRoom.hostId);
+        setTeamNames(nextRoom.settings.teamNames);
         if (selfPlayerId) {
           setCurrentPlayerId(selfPlayerId);
         }
@@ -528,6 +542,7 @@ export const useGame = () => {
         }
 
         setCurrentHostId(nextRoom.hostId);
+        setTeamNames(nextRoom.settings.teamNames);
         if (selfPlayerId) {
           setCurrentPlayerId(selfPlayerId);
         }
@@ -545,6 +560,7 @@ export const useGame = () => {
         roomId,
         hostId,
         pointsToWin,
+        teamNames,
         isSpectator,
       }: GameStatePayload) => {
         const nextPlayers = mergePlayersPreservingIdentity(
@@ -576,6 +592,7 @@ export const useGame = () => {
         }
         setGameStarted(true);
         setPointsToWin(pointsToWin);
+        setTeamNames(teamNames);
         setIdlePlayerIds((prev) =>
           prev.filter((playerId) =>
             nextPlayers.some((player) => player.playerId === playerId),
@@ -640,6 +657,7 @@ export const useGame = () => {
         roomId,
         players: playerContracts,
         pointsToWin,
+        teamNames,
       }: GameStartedPayload) => {
         const nextPlayers = mergePlayersPreservingIdentity(
           players,
@@ -674,6 +692,7 @@ export const useGame = () => {
 
         setCurrentRoomId(roomId);
         setPointsToWin(pointsToWin);
+        setTeamNames(teamNames);
         setGameStarted(true);
         setGamePhase('blow');
       },
@@ -699,7 +718,7 @@ export const useGame = () => {
         if (winner !== null && nextPhase !== 'play' && nextPhase !== 'blow') {
           setNotification({
             message: t('phaseResult', {
-              teamName: t(winner === 0 ? 'teamRed' : 'teamBlack'),
+              teamName: getTeamLabel(winner),
               phase: t(`phaseNames.${nextPhase}` as 'phaseNames.deal'),
             }),
             type: 'success',
@@ -723,8 +742,8 @@ export const useGame = () => {
         }
         gameOverShownRef.current = gameOverKey;
 
-        const teamRedName = t('teamRed');
-        const teamBlackName = t('teamBlack');
+        const teamRedName = getTeamLabel(0);
+        const teamBlackName = getTeamLabel(1);
         const winnerTeam = winner === 'Team 0' ? teamRedName : teamBlackName;
         setGameOverModal({
           title: t('gameOver.title'),
@@ -1073,6 +1092,7 @@ export const useGame = () => {
     shouldSkipLegacyUpdatePlayers,
     resetRoomState,
     syncDisconnectedPlayerIdsFromPlayers,
+    getTeamLabel,
     t,
     tStatus,
     user?.id,
@@ -1124,6 +1144,15 @@ export const useGame = () => {
     socket.emit('shuffle-teams', {
       roomId: currentRoomId,
       playerId: currentPlayerId,
+    });
+  };
+
+  const updateTeamNames = (nextTeamNames: TeamNames) => {
+    if (!socket || !currentRoomId || !currentPlayerId) return;
+    socket.emit('update-team-names', {
+      roomId: currentRoomId,
+      playerId: currentPlayerId,
+      teamNames: nextTeamNames,
     });
   };
 
@@ -1253,8 +1282,10 @@ export const useGame = () => {
     currentRoomId,
     isHost,
     isSpectator,
+    teamNames,
     startGame,
     shuffleTeams,
+    updateTeamNames,
     removePlayerFromRoom,
     replacePlayerWithCOM,
     idlePlayerIds,

--- a/mei-tra-frontend/lib/utils/teamLabels.ts
+++ b/mei-tra-frontend/lib/utils/teamLabels.ts
@@ -1,0 +1,24 @@
+import type { Team, TeamNames } from '@/types/game.types';
+
+const DEFAULT_TEAM_NAMES: Record<Team, string> = {
+  0: '赤',
+  1: '黒',
+};
+
+export const normalizeTeamNames = (teamNames?: TeamNames): TeamNames => ({
+  0: teamNames?.[0]?.trim() || DEFAULT_TEAM_NAMES[0],
+  1: teamNames?.[1]?.trim() || DEFAULT_TEAM_NAMES[1],
+});
+
+export const getTeamDisplayName = (
+  team: Team,
+  teamNames?: TeamNames,
+  fallback?: (team: Team) => string,
+): string => {
+  const customName = teamNames?.[team]?.trim();
+  if (customName) {
+    return customName;
+  }
+
+  return fallback?.(team) ?? DEFAULT_TEAM_NAMES[team];
+};

--- a/mei-tra-frontend/messages/en.json
+++ b/mei-tra-frontend/messages/en.json
@@ -17,8 +17,8 @@
   "gameInfo": {
     "reach": "Reach",
     "win": "WIN",
-    "teamRed": "Red team",
-    "teamBlack": "Black team"
+    "teamRed": "Red",
+    "teamBlack": "Black"
   },
   "nav": {
     "rooms": "Rooms",
@@ -293,7 +293,12 @@
     },
     "shuffleTeams": "Shuffle",
     "fillWithCOM": "Add COM",
-    "removePlayer": "Remove"
+    "removePlayer": "Remove",
+    "teamNames": "Teams",
+    "editTeamNames": "Edit",
+    "teamRedName": "Red",
+    "teamBlackName": "Black",
+    "saveTeamNames": "Save"
   },
   "game": {
     "initializing": "Initializing game...",
@@ -307,8 +312,8 @@
     "yourTurn": "Your turn",
     "waiting": "Waiting...",
     "orderButton": "Order",
-    "teamRed": "Red team",
-    "teamBlack": "Black team",
+    "teamRed": "Red",
+    "teamBlack": "Black",
     "phaseResult": "{teamName} won the {phase} phase",
     "phaseNames": {
       "deal": "deal",
@@ -372,8 +377,8 @@
   "scoreBoard": {
     "round": "Round",
     "team": "Team",
-    "teamRed": "Red team",
-    "teamBlack": "Black team",
+    "teamRed": "Red",
+    "teamBlack": "Black",
     "points": "points",
     "thisRound": "This round:",
     "declared": "Declared:",
@@ -419,8 +424,8 @@
     "roundTableBid": "Bid",
     "roundTableScore": "Score",
     "setCount": "{count, plural, one {# set} other {# sets}}",
-    "teamRed": "Red team",
-    "teamBlack": "Black team",
+    "teamRed": "Red",
+    "teamBlack": "Black",
     "roundInProgress": "In progress",
     "actionFilter": "Action",
     "allActions": "All actions",

--- a/mei-tra-frontend/messages/ja.json
+++ b/mei-tra-frontend/messages/ja.json
@@ -17,8 +17,8 @@
   "gameInfo": {
     "reach": "リーチ",
     "win": "WIN",
-    "teamRed": "チーム赤",
-    "teamBlack": "チーム黒"
+    "teamRed": "赤",
+    "teamBlack": "黒"
   },
   "nav": {
     "rooms": "ルーム一覧",
@@ -293,7 +293,12 @@
     },
     "shuffleTeams": "シャッフル",
     "fillWithCOM": "COM追加",
-    "removePlayer": "退出させる"
+    "removePlayer": "退出させる",
+    "teamNames": "チーム名",
+    "editTeamNames": "編集",
+    "teamRedName": "赤",
+    "teamBlackName": "黒",
+    "saveTeamNames": "保存"
   },
   "game": {
     "initializing": "ゲームを初期化中...",
@@ -307,8 +312,8 @@
     "yourTurn": "あなたのターンです",
     "waiting": "待機中...",
     "orderButton": "強さ順",
-    "teamRed": "チーム赤",
-    "teamBlack": "チーム黒",
+    "teamRed": "赤",
+    "teamBlack": "黒",
     "phaseResult": "{teamName} が {phase} フェーズに勝利しました",
     "phaseNames": {
       "deal": "配布",
@@ -372,8 +377,8 @@
   "scoreBoard": {
     "round": "ラウンド",
     "team": "チーム",
-    "teamRed": "チーム赤",
-    "teamBlack": "チーム黒",
+    "teamRed": "赤",
+    "teamBlack": "黒",
     "points": "ポイント",
     "thisRound": "今ラウンド:",
     "declared": "宣言:",
@@ -419,8 +424,8 @@
     "roundTableBid": "宣言",
     "roundTableScore": "得点",
     "setCount": "{count}組",
-    "teamRed": "チーム赤",
-    "teamBlack": "チーム黒",
+    "teamRed": "赤",
+    "teamBlack": "黒",
     "roundInProgress": "進行中",
     "actionFilter": "アクション",
     "allActions": "全アクション",

--- a/mei-tra-frontend/types/game.types.ts
+++ b/mei-tra-frontend/types/game.types.ts
@@ -2,6 +2,8 @@ import type { PlayerContract } from '@contracts/game';
 
 export type Team = 0 | 1;
 
+export type TeamNames = Partial<Record<Team, string>>;
+
 export type GamePhase = 'deal' | 'blow' | 'play' | 'complete' | null;
 
 export type TrumpType = 'tra' | 'herz' | 'daiya' | 'club' | 'zuppe';

--- a/mei-tra-frontend/types/room.types.ts
+++ b/mei-tra-frontend/types/room.types.ts
@@ -4,7 +4,7 @@ import type {
   RoomStatusContract,
   RoomSyncPayload,
 } from '@contracts/room';
-import { Player, fromPlayerContracts } from './game.types';
+import { Player, TeamNames, fromPlayerContracts } from './game.types';
 
 export interface Room {
   id: string;
@@ -31,6 +31,7 @@ export interface RoomSettings {
   teamAssignmentMethod: 'random' | 'host-choice';
   pointsToWin: number;
   allowSpectators: boolean;
+  teamNames?: TeamNames;
 }
 
 export enum RoomStatus {


### PR DESCRIPTION
## Summary
- Add host-editable custom team names while preserving the internal team 0 / team 1 contract.
- Polish game UI labels, player info badges, score meter alignment, replay log display, and overflow handling for long names.
- Fix local Socket.IO startup/CORS behavior and make hand reorder pointer handling safe in jsdom and browsers.

## Impact
- Players can use custom display names for teams in waiting/game/history UI without changing scoring or socket team IDs.
- Long player/team names truncate instead of breaking profile, room, game, and log layouts.
- Mobile player info spacing is tighter and centered consistently.

## Validation
- `cd mei-tra-backend && npm test -- --runInBand src/config/frontend-origins.spec.ts src/use-cases/__tests__/update-team-names.use-case.spec.ts`
- `cd mei-tra-backend && npm run build`
- `cd mei-tra-frontend && npm test -- --runInBand __tests__/components/PlayerHand.test.tsx __tests__/components/GameInfo.test.tsx __tests__/components/GameHistoryDock.test.tsx`
- `cd mei-tra-frontend && npm run build`
<!-- x-demo:start -->
{
  "route": "/ja",
  "media": "video",
  "steps": [
    { "action": "fill", "placeholder": "ルーム名を入力", "value": "X demo {{timestamp}}" },
    { "action": "clickRole", "role": "button", "name": "ルーム作成" },
    { "action": "wait", "ms": 3000 },
    { "action": "clickRole", "role": "button", "name": "ゲーム開始" },
    { "action": "wait", "ms": 4500 },
    { "action": "playDemo", "maxActions": 12, "maxDurationMs": 60000 }
  ]
}
<!-- x-demo:end -->