### PR TITLE
Install ffmpeg for X media capture

### DIFF
--- a/.github/workflows/x-post-draft.yml
+++ b/.github/workflows/x-post-draft.yml
@@ -43,6 +43,9 @@ jobs:
           cd mei-tra-frontend
           npx playwright install --with-deps chromium
 
+      - name: Install media conversion tools
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: Save the PR body for the capture script
         id: pr
         uses: actions/github-script@v7


### PR DESCRIPTION
# Summary
- Install ffmpeg on the GitHub Actions runner before converting Playwright WebM captures to MP4.
- Preserve video media instead of falling back to a text-only draft when capture succeeds.

# Root cause
The authenticated Playwright capture completed and produced capture.webm, but the runner did not have ffmpeg installed, so the conversion step exited with code 127 and discarded the media.

# Validation
- YAML parsed successfully with Ruby.
- Reproduced workflow run 30696630840: capture completed, then failed only at the missing ffmpeg command.
