### PR TITLE
Stabilize player lifecycle and seat order

### DIFF
--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -906,6 +906,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       this.playerRooms.delete(client.id);
 
       if (roomDeleted) {
+        this.clearTurnAckMonitor(data.roomId);
+        this.comAutoPlayRecoveryService.clearRoom(data.roomId);
         this.server.to(client.id).emit('back-to-lobby');
         this.emitRoomsListToAll(roomsList);
         return { success: true };
@@ -999,6 +1001,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
       if (result.mode === 'remove') {
         if (result.roomDeleted) {
+          this.clearTurnAckMonitor(data.roomId);
+          this.comAutoPlayRecoveryService.clearRoom(data.roomId);
           this.emitRoomsListToAll(result.roomsList);
           return { success: true };
         }

--- a/mei-tra-backend/src/services/__tests__/com-autoplay-recovery.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-autoplay-recovery.service.spec.ts
@@ -16,6 +16,7 @@ const flushPromises = async (): Promise<void> => {
 
 const createService = () => {
   const roomService = {
+    getRoom: jest.fn().mockResolvedValue({ id: 'room-1' }),
     getRoomGameState: jest.fn(),
   };
   const comAutoPlayUseCase = {
@@ -44,6 +45,53 @@ const createService = () => {
 };
 
 describe('ComAutoPlayRecoveryService', () => {
+  it('stops recovery when the room no longer exists', async () => {
+    jest.useFakeTimers();
+    const { service, roomService, comAutoPlayUseCase, handlers } =
+      createService();
+
+    roomService.getRoom.mockResolvedValue(null);
+    roomService.getRoomGameState.mockRejectedValue(
+      new Error('Room not found: room-1'),
+    );
+
+    service.trigger('room-1', handlers);
+    await flushPromises();
+    await jest.runOnlyPendingTimersAsync();
+
+    expect(roomService.getRoomGameState).toHaveBeenCalledTimes(1);
+    expect(comAutoPlayUseCase.execute).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
+    jest.useRealTimers();
+  });
+
+  it('stops a delayed auto-play retry when the room is deleted', async () => {
+    jest.useFakeTimers();
+    const { service, roomService, comAutoPlayUseCase, handlers } =
+      createService();
+
+    roomService.getRoomGameState.mockResolvedValue({
+      getState: () => ({
+        gamePhase: 'play',
+        playState: { currentField: null },
+        pendingBrokenHandReveal: null,
+      }),
+    });
+    comAutoPlayUseCase.execute.mockRejectedValue(
+      new Error('Room not found: room-1'),
+    );
+
+    service.trigger('room-1', handlers);
+    await flushPromises();
+    roomService.getRoom.mockResolvedValue(null);
+    await jest.advanceTimersByTimeAsync(2_000);
+    await flushPromises();
+
+    expect(comAutoPlayUseCase.execute).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+    jest.useRealTimers();
+  });
+
   it('completes a persisted full field when its timer was lost', async () => {
     jest.useFakeTimers();
     const {

--- a/mei-tra-backend/src/services/__tests__/disconnect-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/disconnect-gateway-effects.service.spec.ts
@@ -2,6 +2,25 @@ import { DisconnectGatewayEffectsService } from '../disconnect-gateway-effects.s
 import { IRoomService } from '../interfaces/room-service.interface';
 
 describe('DisconnectGatewayEffectsService', () => {
+  it('ignores disconnect cleanup after the room has been deleted', async () => {
+    const roomService = {
+      getRoom: jest.fn().mockResolvedValue(null),
+      getRoomGameState: jest.fn(),
+    } as unknown as IRoomService;
+    const service = new DisconnectGatewayEffectsService(
+      roomService,
+      {} as never,
+    );
+
+    const result = await service.prepareDisconnect({
+      roomId: 'deleted-room',
+      socketId: 'socket-1',
+    });
+
+    expect(result).toBeNull();
+    expect(roomService.getRoomGameState).not.toHaveBeenCalled();
+  });
+
   it('reassigns host and emits disconnect events', async () => {
     const state = {
       players: [
@@ -173,6 +192,7 @@ describe('DisconnectGatewayEffectsService', () => {
     };
     const roomService = {
       getRoomGameState: jest.fn().mockResolvedValue(roomGameState),
+      getRoom: jest.fn().mockResolvedValue({ id: 'room-1' }),
     } as unknown as IRoomService;
     const roomUpdateGatewayEffectsService = {
       buildRoomEvents: jest.fn(),

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -561,6 +561,16 @@ describe('Reconnection Token Management', () => {
       };
     };
 
+    it('does not create game state for a deleted room', async () => {
+      roomRepository.findById.mockResolvedValue(null);
+
+      await expect(
+        roomService.getRoomGameState('deleted-room'),
+      ).rejects.toThrow('Room not found: deleted-room');
+      expect(gameStateRepository.findByRoomId).not.toHaveBeenCalled();
+      expect(gameStateRepository.create).not.toHaveBeenCalled();
+    });
+
     it('does not overwrite current gameplay when updating roster metadata', async () => {
       const player = makeGamePlayer('player-1', 'Player 1', 0, {
         hand: ['stale-card'],

--- a/mei-tra-backend/src/services/__tests__/start-game-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/start-game-gateway-effects.service.spec.ts
@@ -8,6 +8,7 @@ describe('StartGameGatewayEffectsService', () => {
       getRoom: jest.fn().mockResolvedValue({
         id: 'room-1',
         name: 'Room 1',
+        settings: { teamNames: undefined },
         players: [
           {
             playerId: 'player-1',

--- a/mei-tra-backend/src/services/com-autoplay-recovery.service.ts
+++ b/mei-tra-backend/src/services/com-autoplay-recovery.service.ts
@@ -67,16 +67,15 @@ export class ComAutoPlayRecoveryService {
         this.scheduleInitialAutoPlay(roomId, handlers);
       }
     })()
-      .catch((error) => {
-        if (!this.isCurrentGeneration(roomId, generation)) {
-          return;
-        }
-        this.logger.error(
+      .catch((error) =>
+        this.handleRecoveryError(
+          roomId,
+          generation,
+          handlers,
           `COM auto-play recovery failed for room ${roomId}`,
-          error instanceof Error ? error.stack : String(error),
-        );
-        this.scheduleRetry(roomId, handlers);
-      })
+          error,
+        ),
+      )
       .finally(() => {
         this.activeRooms.delete(roomId);
         if (this.pendingReruns.delete(roomId)) {
@@ -109,16 +108,15 @@ export class ComAutoPlayRecoveryService {
             generation,
           ),
         )
-        .catch((error) => {
-          if (!this.isCurrentGeneration(trigger.roomId, generation)) {
-            return;
-          }
-          this.logger.error(
+        .catch((error) =>
+          this.handleRecoveryError(
+            trigger.roomId,
+            generation,
+            handlers,
             `Error completing field in room ${trigger.roomId}`,
-            error instanceof Error ? error.stack : String(error),
-          );
-          this.scheduleRetry(trigger.roomId, handlers);
-        });
+            error,
+          ),
+        );
     }, trigger.delayMs);
 
     this.fieldCompletionTimeouts.set(trigger.roomId, timeout);
@@ -199,6 +197,9 @@ export class ComAutoPlayRecoveryService {
     }
 
     if (!result.success) {
+      if (await this.stopRecoveryIfRoomMissing(roomId, generation)) {
+        return;
+      }
       this.logger.error(`COM auto-play failed: ${result.error}`);
       this.scheduleRetry(roomId, handlers);
       return;
@@ -243,6 +244,9 @@ export class ComAutoPlayRecoveryService {
     }
 
     if (!response.success) {
+      if (await this.stopRecoveryIfRoomMissing(roomId, generation)) {
+        return;
+      }
       this.scheduleRetry(roomId, handlers);
       return;
     }
@@ -316,16 +320,15 @@ export class ComAutoPlayRecoveryService {
         return;
       }
 
-      void this.runAutoPlayStep(roomId, handlers, generation).catch((error) => {
-        if (!this.isCurrentGeneration(roomId, generation)) {
-          return;
-        }
-        this.logger.error(
+      void this.runAutoPlayStep(roomId, handlers, generation).catch((error) =>
+        this.handleRecoveryError(
+          roomId,
+          generation,
+          handlers,
           `COM auto-play initial step failed for room ${roomId}`,
-          error instanceof Error ? error.stack : String(error),
-        );
-        this.scheduleRetry(roomId, handlers);
-      });
+          error,
+        ),
+      );
     }, COM_AUTO_PLAY_INITIAL_DELAY_MS);
     this.retryTimeouts.set(roomId, timeout);
   }
@@ -355,6 +358,47 @@ export class ComAutoPlayRecoveryService {
     if (timeout) {
       clearTimeout(timeout);
       this.retryTimeouts.delete(roomId);
+    }
+  }
+
+  private async handleRecoveryError(
+    roomId: string,
+    generation: number,
+    handlers: ComAutoPlayRecoveryHandlers,
+    message: string,
+    error: unknown,
+  ): Promise<void> {
+    if (!this.isCurrentGeneration(roomId, generation)) {
+      return;
+    }
+    if (await this.stopRecoveryIfRoomMissing(roomId, generation)) {
+      return;
+    }
+
+    this.logger.error(
+      message,
+      error instanceof Error ? error.stack : String(error),
+    );
+    this.scheduleRetry(roomId, handlers);
+  }
+
+  private async stopRecoveryIfRoomMissing(
+    roomId: string,
+    generation: number,
+  ): Promise<boolean> {
+    try {
+      const room = await this.roomService.getRoom(roomId);
+      if (!this.isCurrentGeneration(roomId, generation)) {
+        return true;
+      }
+      if (room) {
+        return false;
+      }
+
+      this.clearRoom(roomId);
+      return true;
+    } catch {
+      return false;
     }
   }
 

--- a/mei-tra-backend/src/services/disconnect-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/disconnect-gateway-effects.service.ts
@@ -30,6 +30,10 @@ export class DisconnectGatewayEffectsService {
     displayName?: string;
   }): Promise<DisconnectPreparation | null> {
     const { roomId, socketId, displayName } = params;
+    const room = await this.roomService.getRoom(roomId);
+    if (!room) {
+      return null;
+    }
     const roomGameState = await this.roomService.getRoomGameState(roomId);
     const state = roomGameState.getState();
     const players = await this.sanitizePlayers(
@@ -37,7 +41,6 @@ export class DisconnectGatewayEffectsService {
       state.players,
       roomGameState,
     );
-    const room = await this.roomService.getRoom(roomId);
     const player = this.findPlayerForDisconnect(
       socketId,
       roomGameState,
@@ -78,6 +81,10 @@ export class DisconnectGatewayEffectsService {
     timeoutMode: DisconnectTimeoutMode;
   }): Promise<GatewayEvent[]> {
     const { roomId, playerId, playerName, timeoutMode } = params;
+    const room = await this.roomService.getRoom(roomId);
+    if (!room) {
+      return [];
+    }
 
     if (timeoutMode === 'remove-player') {
       const roomGameState = await this.roomService.getRoomGameState(roomId);
@@ -91,7 +98,6 @@ export class DisconnectGatewayEffectsService {
       ];
     }
 
-    const room = await this.roomService.getRoom(roomId);
     if (room?.status !== RoomStatus.PLAYING) {
       return [];
     }

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -563,49 +563,6 @@ export class GameStateService implements IGameStateService {
     return this.state.players[this.state.currentPlayerIndex] || null;
   }
 
-  private arrangePlayersForSeatOrder(): void {
-    if (this.state.players.length <= 1) {
-      return;
-    }
-
-    const currentPlayerId =
-      this.state.players[this.state.currentPlayerIndex]?.playerId || null;
-
-    const team0 = this.state.players.filter((player) => player.team === 0);
-    const team1 = this.state.players.filter((player) => player.team === 1);
-
-    if (team0.length === 0 || team1.length === 0) {
-      return;
-    }
-
-    const maxTeamSize = Math.max(team0.length, team1.length);
-    const ordered: DomainPlayer[] = [];
-
-    for (let i = 0; i < maxTeamSize; i++) {
-      if (team0[i]) {
-        ordered.push(team0[i]);
-      }
-      if (team1[i]) {
-        ordered.push(team1[i]);
-      }
-    }
-
-    if (ordered.length !== this.state.players.length) {
-      return;
-    }
-
-    this.state.players = ordered;
-
-    if (currentPlayerId) {
-      const newIndex = this.state.players.findIndex(
-        (player) => player.playerId === currentPlayerId,
-      );
-      this.state.currentPlayerIndex = newIndex === -1 ? 0 : newIndex;
-    } else {
-      this.state.currentPlayerIndex = 0;
-    }
-  }
-
   isPlayerTurn(playerId: string): boolean {
     const currentPlayer = this.getCurrentPlayer();
     return currentPlayer?.playerId === playerId;
@@ -708,9 +665,6 @@ export class GameStateService implements IGameStateService {
   async startGame(): Promise<void> {
     await this.transitionPhase('blow');
     let state = this.getState();
-
-    // Arrange seats so partners sit opposite and turns follow seat order
-    this.arrangePlayersForSeatOrder();
 
     // Initialize game state
     state.deck = this.cardService.generateDeck();

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -684,6 +684,11 @@ export class RoomService implements IRoomService, OnModuleDestroy {
   async getRoomGameState(roomId: string): Promise<GameStateService> {
     let gameState = this.roomGameStates.get(roomId);
     if (!gameState) {
+      const room = await this.getRoom(roomId);
+      if (!room) {
+        throw new Error(`Room not found: ${roomId}`);
+      }
+
       gameState = this.gameStateFactory.createGameState();
       gameState.setRoomId(roomId);
       await gameState.loadState(roomId);

--- a/mei-tra-backend/src/use-cases/__tests__/game-event-instrumentation.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game-event-instrumentation.spec.ts
@@ -42,11 +42,12 @@ describe('Game event instrumentation', () => {
           blowState: { currentBlowIndex: 0 },
         }),
         startGame: jest.fn().mockResolvedValue(undefined),
+        persistRoster: jest.fn().mockResolvedValue(undefined),
         registerPlayerToken: jest.fn(),
       }),
       canStartGame: jest.fn().mockResolvedValue({ canStart: true }),
+      updateRoomStatus: jest.fn().mockResolvedValue(true),
       fillVacantSeatsWithCOM: jest.fn().mockResolvedValue(undefined),
-      updateRoomStatus: jest.fn().mockResolvedValue(undefined),
     } as unknown as IRoomService;
 
     const gameEventLogService = {

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -658,6 +658,7 @@ describe('Game Use Cases', () => {
       const roomGameState = {
         getState: jest.fn(() => state),
         startGame: jest.fn().mockResolvedValue(undefined),
+        persistRoster: jest.fn().mockResolvedValue(undefined),
       } as unknown as GameStateService;
 
       roomService.getRoom.mockResolvedValue(room);
@@ -728,6 +729,7 @@ describe('Game Use Cases', () => {
       const roomGameState = {
         getState: jest.fn(() => state),
         startGame: jest.fn().mockResolvedValue(undefined),
+        persistRoster: jest.fn().mockResolvedValue(undefined),
         updateState: jest.fn(async (updates) => {
           state.currentPlayerIndex = updates.currentPlayerIndex;
           state.blowState = updates.blowState;
@@ -774,10 +776,10 @@ describe('Game Use Cases', () => {
             joinedAt: new Date(),
           },
           {
-            socketId: 'socket-3',
-            playerId: 'player-3',
-            name: 'Player 3',
-            team: 1 as const,
+            socketId: 'socket-2',
+            playerId: 'player-2',
+            name: 'Player 2',
+            team: 0 as const,
             hand: [],
             isPasser: false,
             isReady: true,
@@ -786,10 +788,10 @@ describe('Game Use Cases', () => {
             joinedAt: new Date(),
           },
           {
-            socketId: 'socket-2',
-            playerId: 'player-2',
-            name: 'Player 2',
-            team: 0 as const,
+            socketId: 'socket-3',
+            playerId: 'player-3',
+            name: 'Player 3',
+            team: 1 as const,
             hand: [],
             isPasser: false,
             isReady: true,
@@ -855,6 +857,7 @@ describe('Game Use Cases', () => {
       };
 
       const registerPlayerTokenMock = jest.fn();
+      const persistRosterMock = jest.fn().mockResolvedValue(undefined);
       const startGameMock = jest.fn(() => {
         state.players = [
           state.players[0],
@@ -867,6 +870,7 @@ describe('Game Use Cases', () => {
         getState: jest.fn(() => state),
         registerPlayerToken: registerPlayerTokenMock,
         startGame: startGameMock,
+        persistRoster: persistRosterMock,
       } as unknown as GameStateService;
 
       roomService.getRoom.mockResolvedValue(room);
@@ -901,6 +905,33 @@ describe('Game Use Cases', () => {
         'player-3',
       );
       expect(registerPlayerTokenMock).toHaveBeenCalledTimes(1);
+      const persistedPlayers = persistRosterMock.mock.calls[0]?.[0] as
+        | RoomPlayer[]
+        | undefined;
+      expect(persistedPlayers?.map((player) => player.playerId)).toEqual([
+        'player-1',
+        'player-3',
+        'player-2',
+        'player-4',
+      ]);
+      expect(
+        persistedPlayers?.map((player) => ({
+          playerId: player.playerId,
+          seatIndex: player.seatIndex,
+        })),
+      ).toEqual([
+        { playerId: 'player-1', seatIndex: 0 },
+        { playerId: 'player-3', seatIndex: 1 },
+        { playerId: 'player-2', seatIndex: 2 },
+        { playerId: 'player-4', seatIndex: 3 },
+      ]);
+      expect(persistRosterMock).toHaveBeenCalledWith(
+        expect.any(Array),
+        room.hostId,
+      );
+      expect(persistRosterMock.mock.invocationCallOrder[0]).toBeLessThan(
+        startGameMock.mock.invocationCallOrder[0],
+      );
     });
 
     it('returns failure when canStartGame denies', async () => {
@@ -935,6 +966,64 @@ describe('Game Use Cases', () => {
 
       expect(result.success).toBe(false);
       expect(result.errorMessage).toBe('Need more players');
+    });
+
+    it('does not start when the room status cannot be updated', async () => {
+      const roomService = createRoomServiceMock();
+      const useCase = new StartGameUseCase(roomService);
+      const room: Room = {
+        ...baseRoom,
+        status: RoomStatus.READY,
+        players: baseRoom.players.map((player) => ({
+          ...player,
+          isReady: true,
+        })) as RoomPlayer[],
+      };
+      const state = {
+        players: room.players.map((player) => ({
+          ...player,
+          hand: [],
+        })) as DomainPlayer[],
+        currentPlayerIndex: 0,
+        blowState: {
+          currentBlowIndex: 0,
+          currentTrump: null,
+          currentHighestDeclaration: null,
+          declarations: [],
+          lastPasser: null,
+          isRoundCancelled: false,
+        },
+        teamScores: {
+          0: { play: 0, total: 0 },
+          1: { play: 0, total: 0 },
+        } as TeamScores,
+        teamAssignments: {},
+        pointsToWin: 0,
+        gamePhase: null,
+      };
+      const startGame = jest.fn().mockResolvedValue(undefined);
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        startGame,
+        persistRoster: jest.fn().mockResolvedValue(undefined),
+      } as unknown as GameStateService;
+
+      roomService.getRoom.mockResolvedValue(room);
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+      roomService.canStartGame.mockResolvedValue({ canStart: true });
+      roomService.fillVacantSeatsWithCOM.mockResolvedValue(undefined);
+      roomService.updateRoomStatus.mockResolvedValue(false);
+
+      const result = await useCase.execute({
+        playerId: room.hostId,
+        roomId: room.id,
+      });
+
+      expect(result).toEqual({
+        success: false,
+        errorMessage: 'Failed to mark room as playing',
+      });
+      expect(startGame).not.toHaveBeenCalled();
     });
 
     it('rejects starting a full room with unbalanced teams', async () => {

--- a/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
@@ -5,6 +5,58 @@ import { RoomStatus } from '../../types/room.types';
 import { UserProfile } from '../../types/user.types';
 
 describe('ReconnectionUseCase', () => {
+  it('does not load game state after the room has been deleted', async () => {
+    const roomService = {
+      getRoom: jest.fn().mockResolvedValue(null),
+      getRoomGameState: jest.fn(),
+    } as Partial<IRoomService> as IRoomService;
+    const gameState = {
+      upsertSessionUser: jest.fn(),
+    } as Partial<IGameStateService> as IGameStateService;
+    const useCase = new ReconnectionUseCase(roomService, gameState);
+
+    const result = await useCase.execute({
+      roomId: 'deleted-room',
+      socketId: 'socket-1',
+      authenticatedUser: {
+        id: 'user-1',
+        email: 'user@example.com',
+        profile: {} as UserProfile,
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: 'roomUnavailable',
+      }),
+    );
+    expect(roomService.getRoomGameState).not.toHaveBeenCalled();
+  });
+
+  it('does not load an active snapshot after the room has been deleted', async () => {
+    const roomService = {
+      getRoom: jest.fn().mockResolvedValue(null),
+      getRoomGameState: jest.fn(),
+    } as Partial<IRoomService> as IRoomService;
+    const gameState = {
+      upsertSessionUser: jest.fn(),
+    } as Partial<IGameStateService> as IGameStateService;
+    const useCase = new ReconnectionUseCase(roomService, gameState);
+
+    const snapshot = await useCase.getActiveGameSnapshot({
+      roomId: 'deleted-room',
+      authenticatedUser: {
+        id: 'user-1',
+        email: 'user@example.com',
+        profile: {} as UserProfile,
+      },
+    });
+
+    expect(snapshot).toBeNull();
+    expect(roomService.getRoomGameState).not.toHaveBeenCalled();
+  });
+
   it('uses the persisted room player mapping after an active-game restart', async () => {
     const roomGameState = {
       findSessionUserByUserId: jest.fn().mockReturnValue(null),
@@ -61,6 +113,7 @@ describe('ReconnectionUseCase', () => {
         id: 'room-1',
         hostId: 'seat-1',
         status: RoomStatus.PLAYING,
+        settings: { teamNames: undefined },
         players: [
           {
             playerId: 'seat-1',
@@ -185,6 +238,7 @@ describe('ReconnectionUseCase', () => {
         id: 'room-1',
         hostId: 'seat-1',
         status: RoomStatus.PLAYING,
+        settings: { teamNames: undefined },
         players: [
           {
             playerId: 'seat-1',

--- a/mei-tra-backend/src/use-cases/reconnection.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reconnection.use-case.ts
@@ -74,7 +74,6 @@ export class ReconnectionUseCase {
     const { roomId, socketId, authenticatedUser } = request;
 
     try {
-      const roomGameState = await this.roomService.getRoomGameState(roomId);
       const room = await this.roomService.getRoom(roomId);
       if (!room) {
         return {
@@ -85,6 +84,7 @@ export class ReconnectionUseCase {
             'Your previous room session is no longer available. Please join or create a room again.',
         };
       }
+      const roomGameState = await this.roomService.getRoomGameState(roomId);
 
       const state = roomGameState.getState();
       const isActiveGame =
@@ -250,11 +250,11 @@ export class ReconnectionUseCase {
     const { roomId, authenticatedUser } = request;
 
     try {
-      const roomGameState = await this.roomService.getRoomGameState(roomId);
       const room = await this.roomService.getRoom(roomId);
       if (!room) {
         return null;
       }
+      const roomGameState = await this.roomService.getRoomGameState(roomId);
 
       const state = roomGameState.getState();
       const isActiveGame =

--- a/mei-tra-backend/src/use-cases/start-game.use-case.ts
+++ b/mei-tra-backend/src/use-cases/start-game.use-case.ts
@@ -83,9 +83,25 @@ export class StartGameUseCase implements IStartGameUseCase {
         };
       }
 
+      roomWithFilledSeats.players = this.arrangeRoomPlayersForSeatOrder(
+        roomWithFilledSeats.players,
+      );
       this.syncStatePlayersFromRoom(roomGameState, roomWithFilledSeats);
+      await roomGameState.persistRoster(
+        roomWithFilledSeats.players,
+        roomWithFilledSeats.hostId,
+      );
 
-      await this.roomService.updateRoomStatus(roomId, RoomStatus.PLAYING);
+      const statusUpdated = await this.roomService.updateRoomStatus(
+        roomId,
+        RoomStatus.PLAYING,
+      );
+      if (!statusUpdated) {
+        return {
+          success: false,
+          errorMessage: 'Failed to mark room as playing',
+        };
+      }
       await roomGameState.startGame();
 
       let updatedState = roomGameState.getState();
@@ -214,6 +230,40 @@ export class StartGameUseCase implements IStartGameUseCase {
     );
 
     return state;
+  }
+
+  private arrangeRoomPlayersForSeatOrder(
+    players: Room['players'],
+  ): Room['players'] {
+    const team0Players = players.filter((player) => player.team === 0);
+    const team1Players = players.filter((player) => player.team === 1);
+
+    if (team0Players.length === 0 || team1Players.length === 0) {
+      return players.map((player, seatIndex) => ({ ...player, seatIndex }));
+    }
+
+    const orderedPlayers: Room['players'] = [];
+    const maxTeamSize = Math.max(team0Players.length, team1Players.length);
+
+    for (let teamIndex = 0; teamIndex < maxTeamSize; teamIndex += 1) {
+      const team0Player = team0Players[teamIndex];
+      const team1Player = team1Players[teamIndex];
+      if (team0Player) {
+        orderedPlayers.push(team0Player);
+      }
+      if (team1Player) {
+        orderedPlayers.push(team1Player);
+      }
+    }
+
+    if (orderedPlayers.length !== players.length) {
+      throw new Error('Failed to arrange the complete room roster');
+    }
+
+    return orderedPlayers.map((player, seatIndex) => ({
+      ...player,
+      seatIndex,
+    }));
   }
 
   private validateFullRoomTeamBalance(room: Room): string | null {


### PR DESCRIPTION
## Summary
- persist the alternating team seat order before starting a game so room, database, and game state share one roster order
- stop reconnection/disconnect flows from creating game state for rooms that no longer exist
- clear COM recovery and turn acknowledgement timers when a room is deleted
- stop delayed COM recovery retries after room deletion

## Validation
- `npm test -- --runInBand` (39 suites, 237 tests)
- `npm run build`
- targeted ESLint for changed production and focused test files
- `git diff --check`
- manual local play: room creation, COM fill, game start, blow/play progression, in-game reload/reconnection, and host leave/room deletion

## Notes
- full backend lint still reports pre-existing `no-unsafe-*` errors in `src/main.ts` and older sections of `src/use-cases/__tests__/game.use-cases.spec.ts`; no new lint errors were introduced by this PR
