### PR TITLE
Fix immediate COM replacement after disconnect

### DIFF
--- a/mei-tra-backend/src/services/__tests__/disconnect-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/disconnect-gateway-effects.service.spec.ts
@@ -188,6 +188,7 @@ describe('DisconnectGatewayEffectsService', () => {
   it('removes lobby players on disconnect timeout', async () => {
     const roomGameState = {
       removePlayer: jest.fn(),
+      getPlayerConnectionState: jest.fn(() => ({ socketId: '' })),
       getTransportPlayers: jest.fn(() => [{ playerId: 'player-1' }]),
     };
     const roomService = {
@@ -226,5 +227,56 @@ describe('DisconnectGatewayEffectsService', () => {
         payload: [{ playerId: 'player-1' }],
       },
     ]);
+  });
+
+  it('keeps a reconnected lobby player when an old timeout fires', async () => {
+    const roomGameState = {
+      removePlayer: jest.fn(),
+      getPlayerConnectionState: jest.fn(() => ({ socketId: 'socket-new' })),
+      getTransportPlayers: jest.fn(),
+    };
+    const roomService = {
+      getRoomGameState: jest.fn().mockResolvedValue(roomGameState),
+      getRoom: jest.fn().mockResolvedValue({ id: 'room-1' }),
+    } as unknown as IRoomService;
+    const service = new DisconnectGatewayEffectsService(
+      roomService,
+      {} as never,
+    );
+
+    const events = await service.buildTimeoutEvents({
+      roomId: 'room-1',
+      playerId: 'player-1',
+      playerName: 'Player 1',
+      timeoutMode: 'remove-player',
+    });
+
+    expect(events).toEqual([]);
+    expect(roomGameState.removePlayer).not.toHaveBeenCalled();
+  });
+
+  it('requires the player to still be disconnected before timeout conversion', async () => {
+    const roomService = {
+      getRoom: jest.fn().mockResolvedValue({ id: 'room-1', status: 'playing' }),
+      convertPlayerToCOM: jest.fn().mockResolvedValue(false),
+    } as unknown as IRoomService;
+    const service = new DisconnectGatewayEffectsService(
+      roomService,
+      {} as never,
+    );
+
+    const events = await service.buildTimeoutEvents({
+      roomId: 'room-1',
+      playerId: 'player-1',
+      playerName: 'Player 1',
+      timeoutMode: 'convert-to-com',
+    });
+
+    expect(events).toEqual([]);
+    expect(roomService.convertPlayerToCOM).toHaveBeenCalledWith(
+      'room-1',
+      'player-1',
+      { requireDisconnected: true },
+    );
   });
 });

--- a/mei-tra-backend/src/services/__tests__/player-connection-manager.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/player-connection-manager.service.spec.ts
@@ -1,0 +1,46 @@
+import { Logger } from '@nestjs/common';
+import { PlayerConnectionManager } from '../player-connection-manager.service';
+
+describe('PlayerConnectionManager', () => {
+  it('disconnects only the requested player when other sockets are empty', () => {
+    const manager = new PlayerConnectionManager({
+      log: jest.fn(),
+    } as unknown as Logger);
+    manager.upsertSessionUser({
+      socketId: '',
+      playerId: 'host',
+      name: 'Host',
+      userId: 'host-user',
+      isAuthenticated: true,
+    });
+    manager.upsertSessionUser({
+      socketId: '',
+      playerId: 'com-1',
+      name: 'COM',
+      isAuthenticated: false,
+    });
+    manager.upsertSessionUser({
+      socketId: 'target-socket',
+      playerId: 'target',
+      name: 'Target',
+      userId: 'target-user',
+      isAuthenticated: true,
+    });
+
+    manager.applyConnectionState('target', 'Target', { socketId: '' });
+
+    expect(manager.getPlayerConnectionState('target')).toEqual({
+      socketId: '',
+      userId: 'target-user',
+      isAuthenticated: true,
+    });
+    expect(manager.findSessionUserByPlayerId('host')).toEqual(
+      expect.objectContaining({
+        playerId: 'host',
+        name: 'Host',
+        userId: 'host-user',
+      }),
+    );
+    expect(manager.getSessionUsers()).toHaveLength(3);
+  });
+});

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -608,6 +608,43 @@ describe('Reconnection Token Management', () => {
     });
 
     describe('convertPlayerToCOM', () => {
+      it('does not convert a player who reconnected before timeout handling', async () => {
+        const roomId = 'room-123';
+        const playerId = 'player-1';
+        const player: RoomPlayer = {
+          socketId: 'socket-new',
+          playerId,
+          name: 'Test Player',
+          team: 0,
+          hand: ['H2'],
+          isPasser: false,
+          hasBroken: false,
+          isReady: true,
+          isHost: true,
+          joinedAt: new Date(),
+        };
+        const room: Room = { ...baseRoom, players: [player] };
+        roomRepository.findById.mockResolvedValue(room);
+
+        const gameState = await roomService.getRoomGameState(roomId);
+        gameState.getState().players = [
+          makeGamePlayer(playerId, player.name, player.team, {
+            hand: [...player.hand],
+          }),
+        ];
+        await gameState.applyPlayerConnectionState(playerId, {
+          socketId: 'socket-new',
+        });
+
+        const result = await roomService.convertPlayerToCOM(roomId, playerId, {
+          requireDisconnected: true,
+        });
+
+        expect(result).toBe(false);
+        expect(room.players[0]).toEqual(player);
+        expect(gameStateRepository.persistRoomRoster).not.toHaveBeenCalled();
+      });
+
       it('should convert player to com and save to vacantSeats', async () => {
         const roomId = 'room-123';
         const playerId = 'player-1';

--- a/mei-tra-backend/src/services/disconnect-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/disconnect-gateway-effects.service.ts
@@ -88,6 +88,10 @@ export class DisconnectGatewayEffectsService {
 
     if (timeoutMode === 'remove-player') {
       const roomGameState = await this.roomService.getRoomGameState(roomId);
+      if (roomGameState.getPlayerConnectionState(playerId)?.socketId) {
+        return [];
+      }
+
       roomGameState.removePlayer(playerId);
       return [
         this.roomUpdateGatewayEffectsService.buildPlayersEvent({
@@ -105,6 +109,7 @@ export class DisconnectGatewayEffectsService {
     const converted = await this.roomService.convertPlayerToCOM(
       roomId,
       playerId,
+      { requireDisconnected: true },
     );
     if (!converted) {
       return [];

--- a/mei-tra-backend/src/services/interfaces/room-service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/room-service.interface.ts
@@ -29,7 +29,11 @@ export interface IRoomService {
   ): Promise<boolean>;
   canStartGame(roomId: string): Promise<{ canStart: boolean; reason?: string }>;
   getRoomGameState(roomId: string): Promise<GameStateService>;
-  convertPlayerToCOM(roomId: string, playerId: string): Promise<boolean>;
+  convertPlayerToCOM(
+    roomId: string,
+    playerId: string,
+    options?: { requireDisconnected?: boolean },
+  ): Promise<boolean>;
   restorePlayerFromVacantSeat(
     roomId: string,
     playerId: string,

--- a/mei-tra-backend/src/services/player-connection-manager.service.ts
+++ b/mei-tra-backend/src/services/player-connection-manager.service.ts
@@ -53,9 +53,13 @@ export class PlayerConnectionManager {
     changed: boolean;
   } {
     const existingUser =
+      this.findSessionUserByPlayerId(sessionUser.playerId) ??
       (sessionUser.userId
         ? this.findSessionUserByUserId(sessionUser.userId)
-        : null) ?? this.findSessionUserBySocketId(sessionUser.socketId);
+        : null) ??
+      (sessionUser.socketId
+        ? this.findSessionUserBySocketId(sessionUser.socketId)
+        : null);
 
     if (!existingUser) {
       this.users.push(sessionUser);
@@ -69,17 +73,22 @@ export class PlayerConnectionManager {
       };
     }
 
+    const nextUserId = sessionUser.userId ?? existingUser.userId;
+    const nextIsAuthenticated =
+      sessionUser.isAuthenticated ?? existingUser.isAuthenticated;
     const changed =
       existingUser.socketId !== sessionUser.socketId ||
+      existingUser.playerId !== sessionUser.playerId ||
       existingUser.name !== sessionUser.name ||
-      existingUser.userId !== sessionUser.userId ||
-      existingUser.isAuthenticated !== sessionUser.isAuthenticated;
+      existingUser.userId !== nextUserId ||
+      existingUser.isAuthenticated !== nextIsAuthenticated;
 
     if (changed) {
       existingUser.socketId = sessionUser.socketId;
+      existingUser.playerId = sessionUser.playerId;
       existingUser.name = sessionUser.name;
-      existingUser.userId = sessionUser.userId;
-      existingUser.isAuthenticated = sessionUser.isAuthenticated;
+      existingUser.userId = nextUserId;
+      existingUser.isAuthenticated = nextIsAuthenticated;
     }
 
     if (sessionUser.userId) {
@@ -190,17 +199,22 @@ export class PlayerConnectionManager {
       this.disconnectedPlayers.delete(playerId);
     }
 
+    const existingUser = this.findSessionUserByPlayerId(playerId);
+    const resolvedUserId = userId ?? existingUser?.userId;
     const { user } = this.upsertSessionUser({
       socketId,
       playerId,
       name,
-      userId,
-      isAuthenticated: isAuthenticated ?? Boolean(userId),
+      userId: resolvedUserId,
+      isAuthenticated:
+        isAuthenticated ??
+        existingUser?.isAuthenticated ??
+        Boolean(resolvedUserId),
     });
 
-    if (userId) {
+    if (resolvedUserId) {
       this.logger.log(
-        `[GameState] Updated player ${playerId} with userId: ${userId}`,
+        `[GameState] Updated player ${playerId} with userId: ${resolvedUserId}`,
       );
     }
 

--- a/mei-tra-backend/src/services/room-join.service.ts
+++ b/mei-tra-backend/src/services/room-join.service.ts
@@ -75,6 +75,7 @@ export class RoomJoinService {
           updatedPlayer.playerId,
         );
       }
+      gameState.clearDisconnectTimeout(updatedPlayer.playerId);
       await gameState.applyPlayerConnectionState(updatedPlayer.playerId, {
         socketId: updatedPlayer.socketId,
         userId: updatedPlayer.userId,

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -362,10 +362,21 @@ export class RoomService implements IRoomService, OnModuleDestroy {
    * プレイヤーをCOMに変換（タイムアウト時など）
    * reconnectTokenは保持したまま、席をvacantにする
    */
-  async convertPlayerToCOM(roomId: string, playerId: string): Promise<boolean> {
+  async convertPlayerToCOM(
+    roomId: string,
+    playerId: string,
+    options?: { requireDisconnected?: boolean },
+  ): Promise<boolean> {
     const room = await this.getRoom(roomId);
     if (!room) return false;
     const gameState = await this.getRoomGameState(roomId);
+    if (
+      options?.requireDisconnected &&
+      gameState.getPlayerConnectionState(playerId)?.socketId
+    ) {
+      return false;
+    }
+
     return this.comSessionService.convertPlayerToCOM(
       roomId,
       playerId,
@@ -727,6 +738,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       connectionState.isAuthenticated = true;
     }
 
+    roomGameState.clearDisconnectTimeout(playerId);
     await roomGameState.applyPlayerConnectionState(playerId, connectionState);
 
     const roomPlayerUpdates: {

--- a/mei-tra-backend/src/use-cases/__tests__/moderate-player.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/moderate-player.use-case.spec.ts
@@ -31,6 +31,7 @@ describe('ModeratePlayerUseCase', () => {
   });
 
   it('replaces idle or disconnected players with COM', async () => {
+    const clearDisconnectTimeout = jest.fn();
     const roomService = {
       getRoom: jest.fn().mockResolvedValue(createRoom()),
       getRoomGameState: jest.fn().mockResolvedValue({
@@ -46,6 +47,7 @@ describe('ModeratePlayerUseCase', () => {
           ],
         }),
         getPlayerConnectionState: () => ({ socketId: '' }),
+        clearDisconnectTimeout,
       }),
       convertPlayerToCOM: jest.fn().mockResolvedValue(true),
       listRooms: jest.fn().mockResolvedValue([]),
@@ -70,5 +72,6 @@ describe('ModeratePlayerUseCase', () => {
       'room-1',
       'target',
     );
+    expect(clearDisconnectTimeout).toHaveBeenCalledWith('target');
   });
 });

--- a/mei-tra-backend/src/use-cases/moderate-player.use-case.ts
+++ b/mei-tra-backend/src/use-cases/moderate-player.use-case.ts
@@ -136,6 +136,7 @@ export class ModeratePlayerUseCase {
     if (!converted) {
       return { success: false, error: 'Failed to replace player with COM' };
     }
+    roomGameState.clearDisconnectTimeout(request.targetPlayerId);
 
     const updatedRoom = await this.roomService.getRoom(request.roomId);
     if (!updatedRoom) {


### PR DESCRIPTION
## Summary
- update player connection state by stable `playerId` instead of falling back to shared empty socket IDs
- preserve authenticated identity while marking a player disconnected
- cancel disconnect timers on reconnect and manual COM replacement
- require timeout callbacks to re-check that the player is still disconnected before removing or converting the seat

## Validation
- `npm test -- --runInBand` (40 suites, 241 tests)
- `npm run build`
- targeted ESLint for changed files
- manual two-account game: disconnect during blow, replace with COM immediately, finish blow, play a card, and advance to the next trick

## Dependency
- stacked on #167 (`fix/player-lifecycle-stability`)
