### PR TITLE
Unify active room membership transitions

### DIFF
--- a/mei-tra-backend/src/game.module.ts
+++ b/mei-tra-backend/src/game.module.ts
@@ -53,9 +53,11 @@ import { GameHistoryController } from './controllers/game-history.controller';
 import { GetGameHistoryUseCase } from './use-cases/get-game-history.use-case';
 import { GetUserRecentGameHistoryUseCase } from './use-cases/get-user-recent-game-history.use-case';
 import { ComAutoPlayRecoveryService } from './services/com-autoplay-recovery.service';
+import { RoomMembershipService } from './services/room-membership.service';
+import { DatabaseModule } from './database/database.module';
 
 @Module({
-  imports: [RepositoriesModule, AuthModule, SocialModule],
+  imports: [DatabaseModule, RepositoriesModule, AuthModule, SocialModule],
   controllers: [GameHistoryController],
   providers: [
     GameGateway,
@@ -67,6 +69,7 @@ import { ComAutoPlayRecoveryService } from './services/com-autoplay-recovery.ser
     ComSessionService,
     SeatRestorationService,
     RoomJoinService,
+    RoomMembershipService,
     JoinRoomGatewayEffectsService,
     DisconnectGatewayEffectsService,
     RoomUpdateGatewayEffectsService,

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -10,6 +10,7 @@ import { CardService } from '../card.service';
 import { ChomboService } from '../chombo.service';
 import { PlayService } from '../play.service';
 import { IComPlayerService } from '../interfaces/com-player-service.interface';
+import { RoomMembershipService } from '../room-membership.service';
 
 const makeGamePlayer = (
   playerId: string,
@@ -421,11 +422,39 @@ describe('Reconnection Token Management', () => {
         gameStateRepository,
       );
 
+      const roomMembershipService = {
+        reserve: jest.fn(),
+        claim: jest
+          .fn()
+          .mockImplementation(
+            (userId: string, roomId: string, playerId: string) =>
+              Promise.resolve({
+                result: 'reconnected',
+                membership: {
+                  userId,
+                  roomId,
+                  playerId,
+                  status: 'active',
+                  membershipVersion: 1,
+                  transitionId: 'transition-1',
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  lastSeenAt: new Date(),
+                },
+              }),
+          ),
+        cancelReservation: jest.fn().mockResolvedValue(false),
+        release: jest.fn().mockResolvedValue('released'),
+        releaseByPlayer: jest.fn().mockResolvedValue(true),
+        releaseRoom: jest.fn().mockResolvedValue(0),
+      } as unknown as RoomMembershipService;
+
       roomService = new RoomService(
         roomRepository,
         userProfileRepository,
         gameStateFactory,
         comPlayerService,
+        roomMembershipService,
       );
     });
 

--- a/mei-tra-backend/src/services/__tests__/room-membership-lifecycle.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room-membership-lifecycle.spec.ts
@@ -1,0 +1,161 @@
+import { GameStateFactory } from '../game-state.factory';
+import { RoomJoinService } from '../room-join.service';
+import { RoomMembershipService } from '../room-membership.service';
+import { RoomService } from '../room.service';
+import { IRoomRepository } from '../../repositories/interfaces/room.repository.interface';
+import { IUserProfileRepository } from '../../repositories/interfaces/user-profile.repository.interface';
+import { IComPlayerService } from '../interfaces/com-player-service.interface';
+import { ActiveRoomMembershipConflictError } from '../../types/room-membership.types';
+import { Room, RoomStatus } from '../../types/room.types';
+import { GameStateService } from '../game-state.service';
+
+describe('RoomService active membership lifecycle', () => {
+  const room: Room = {
+    id: 'room-1',
+    name: 'Room 1',
+    hostId: 'user-1',
+    status: RoomStatus.WAITING,
+    settings: {
+      maxPlayers: 4,
+      isPrivate: false,
+      password: null,
+      teamAssignmentMethod: 'random',
+      pointsToWin: 5,
+      allowSpectators: true,
+    },
+    players: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastActivityAt: new Date(),
+  };
+
+  const membership = {
+    userId: 'user-1',
+    roomId: 'room-1',
+    playerId: 'user-1',
+    status: 'active' as const,
+    membershipVersion: 2,
+    transitionId: 'transition-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastSeenAt: new Date(),
+  };
+
+  let roomRepository: jest.Mocked<IRoomRepository>;
+  let membershipService: {
+    claim: jest.Mock;
+    release: jest.Mock;
+    releaseByPlayer: jest.Mock;
+    releaseRoom: jest.Mock;
+  };
+  let roomJoinService: { joinRoom: jest.Mock };
+  let service: RoomService;
+
+  beforeEach(() => {
+    roomRepository = {
+      delete: jest.fn(),
+      update: jest.fn(),
+      updateLastActivity: jest.fn(),
+    } as unknown as jest.Mocked<IRoomRepository>;
+    membershipService = {
+      claim: jest.fn(),
+      release: jest.fn().mockResolvedValue('released'),
+      releaseByPlayer: jest.fn().mockResolvedValue(true),
+      releaseRoom: jest.fn().mockResolvedValue(0),
+    };
+    roomJoinService = { joinRoom: jest.fn() };
+    service = new RoomService(
+      roomRepository,
+      {} as IUserProfileRepository,
+      {} as GameStateFactory,
+      {} as IComPlayerService,
+      membershipService as unknown as RoomMembershipService,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      roomJoinService as unknown as RoomJoinService,
+    );
+    jest.spyOn(service, 'getRoom').mockResolvedValue(room);
+    jest
+      .spyOn(service, 'getRoomGameState')
+      .mockResolvedValue({} as GameStateService);
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+  });
+
+  it('rejects a cross-room conflict before mutating the target room', async () => {
+    membershipService.claim.mockResolvedValue({
+      result: 'conflict',
+      membership: { ...membership, roomId: 'room-existing' },
+    });
+
+    await expect(
+      service.joinRoom('room-1', {
+        socketId: 'socket-1',
+        playerId: 'user-1',
+        userId: 'user-1',
+        name: 'Player 1',
+      }),
+    ).rejects.toBeInstanceOf(ActiveRoomMembershipConflictError);
+
+    expect(service.getRoomGameState).not.toHaveBeenCalled();
+    expect(roomJoinService.joinRoom).not.toHaveBeenCalled();
+  });
+
+  it('rolls back a fresh claim with its membership version when joining fails', async () => {
+    membershipService.claim.mockResolvedValue({
+      result: 'claimed',
+      membership,
+    });
+    roomJoinService.joinRoom.mockResolvedValue(false);
+
+    await expect(
+      service.joinRoom('room-1', {
+        socketId: 'socket-1',
+        playerId: 'user-1',
+        userId: 'user-1',
+        name: 'Player 1',
+      }),
+    ).resolves.toBe(false);
+
+    expect(membershipService.release).toHaveBeenCalledWith(
+      'user-1',
+      'room-1',
+      2,
+    );
+    expect(membershipService.releaseByPlayer).not.toHaveBeenCalled();
+  });
+
+  it('preserves an existing same-room membership when reconnect joining fails', async () => {
+    membershipService.claim.mockResolvedValue({
+      result: 'reconnected',
+      membership: { ...membership, membershipVersion: 3 },
+    });
+    roomJoinService.joinRoom.mockResolvedValue(false);
+
+    await service.joinRoom('room-1', {
+      socketId: 'socket-2',
+      playerId: 'user-1',
+      userId: 'user-1',
+      name: 'Player 1',
+    });
+
+    expect(membershipService.release).not.toHaveBeenCalled();
+  });
+
+  it('releases all memberships when a room becomes inactive', async () => {
+    roomRepository.update.mockResolvedValue({
+      ...room,
+      status: RoomStatus.ABANDONED,
+    });
+
+    await expect(
+      service.updateRoomStatus('room-1', RoomStatus.ABANDONED),
+    ).resolves.toBe(true);
+
+    expect(membershipService.releaseRoom).toHaveBeenCalledWith('room-1');
+  });
+});

--- a/mei-tra-backend/src/services/__tests__/room-membership.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room-membership.service.spec.ts
@@ -1,0 +1,85 @@
+import { SupabaseService } from '../../database/supabase.service';
+import { RoomMembershipService } from '../room-membership.service';
+
+describe('RoomMembershipService', () => {
+  const row = {
+    user_id: 'user-1',
+    room_id: 'room-1',
+    player_id: 'player-1',
+    status: 'active' as const,
+    membership_version: 4,
+    transition_id: 'transition-existing',
+    created_at: '2026-08-03T00:00:00.000Z',
+    updated_at: '2026-08-03T00:01:00.000Z',
+    last_seen_at: '2026-08-03T00:01:00.000Z',
+  };
+
+  let rpc: jest.Mock;
+  let service: RoomMembershipService;
+
+  beforeEach(() => {
+    rpc = jest.fn();
+    const supabase = {
+      client: { rpc },
+    } as unknown as SupabaseService;
+    service = new RoomMembershipService(supabase);
+  });
+
+  it('reuses the moving reservation transition when claiming a created room', async () => {
+    jest.spyOn(service, 'get').mockResolvedValue({
+      userId: 'user-1',
+      roomId: null,
+      playerId: 'player-1',
+      status: 'moving',
+      membershipVersion: 1,
+      transitionId: 'transition-moving',
+      createdAt: new Date(row.created_at),
+      updatedAt: new Date(row.updated_at),
+      lastSeenAt: new Date(row.last_seen_at),
+    });
+    rpc.mockResolvedValue({
+      data: {
+        result: 'claimed',
+        membership: {
+          ...row,
+          transition_id: 'transition-moving',
+        },
+      },
+      error: null,
+    });
+
+    const result = await service.claim('user-1', 'room-1', 'player-1');
+
+    expect(rpc).toHaveBeenCalledWith('claim_room_membership', {
+      p_user_id: 'user-1',
+      p_room_id: 'room-1',
+      p_player_id: 'player-1',
+      p_transition_id: 'transition-moving',
+    });
+    expect(result.result).toBe('claimed');
+    expect(result.membership.membershipVersion).toBe(4);
+  });
+
+  it('returns the authoritative membership when a cross-room claim conflicts', async () => {
+    jest.spyOn(service, 'get').mockResolvedValue(null);
+    rpc.mockResolvedValue({
+      data: { result: 'conflict', membership: row },
+      error: null,
+    });
+
+    const result = await service.claim('user-1', 'room-2', 'player-1');
+
+    expect(result.result).toBe('conflict');
+    expect(result.membership.roomId).toBe('room-1');
+    expect(result.membership.membershipVersion).toBe(4);
+  });
+
+  it('surfaces stale compare-and-set releases without deleting a newer claim', async () => {
+    rpc.mockResolvedValue({
+      data: { result: 'stale', membership: row },
+      error: null,
+    });
+
+    await expect(service.release('user-1', 'room-1', 3)).resolves.toBe('stale');
+  });
+});

--- a/mei-tra-backend/src/services/interfaces/room-service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/room-service.interface.ts
@@ -15,6 +15,7 @@ export interface IRoomService {
     pointsToWin: number,
     teamAssignmentMethod: 'random' | 'host-choice',
   ): Promise<Room>;
+  cancelRoomMembershipReservation(userId: string): Promise<boolean>;
   leaveRoom(roomId: string, playerId: string): Promise<boolean>;
   joinRoom(roomId: string, user: SessionUser): Promise<boolean>;
   updateRoomStatus(roomId: string, status: RoomStatus): Promise<boolean>;

--- a/mei-tra-backend/src/services/room-membership.service.ts
+++ b/mei-tra-backend/src/services/room-membership.service.ts
@@ -1,0 +1,252 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { SupabaseService } from '../database/supabase.service';
+import {
+  ActiveRoomMembership,
+  RoomMembershipTransition,
+  RoomMembershipTransitionResult,
+} from '../types/room-membership.types';
+
+type MembershipRow = {
+  user_id: string;
+  room_id: string | null;
+  player_id: string;
+  status: 'moving' | 'active' | 'disconnected';
+  membership_version: number;
+  transition_id: string;
+  created_at: string;
+  updated_at: string;
+  last_seen_at: string;
+};
+
+@Injectable()
+export class RoomMembershipService {
+  constructor(private readonly supabaseService: SupabaseService) {}
+
+  async get(userId: string): Promise<ActiveRoomMembership | null> {
+    const { data, error } = await this.supabaseService.client
+      .from('active_room_memberships')
+      .select('*')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(
+        `Failed to load active room membership: ${error.message}`,
+      );
+    }
+
+    return data ? this.mapMembership(data) : null;
+  }
+
+  async reserve(
+    userId: string,
+    playerId: string,
+  ): Promise<RoomMembershipTransition> {
+    const transitionId = randomUUID();
+    const { data, error } = await this.supabaseService.client.rpc(
+      'reserve_room_membership',
+      {
+        p_user_id: userId,
+        p_player_id: playerId,
+        p_transition_id: transitionId,
+      },
+    );
+
+    if (error) {
+      throw new Error(`Failed to reserve room membership: ${error.message}`);
+    }
+
+    return this.parseTransition(data);
+  }
+
+  async claim(
+    userId: string,
+    roomId: string,
+    playerId: string,
+  ): Promise<RoomMembershipTransition> {
+    const currentMembership = await this.get(userId);
+    const transitionId =
+      currentMembership?.status === 'moving' &&
+      currentMembership.playerId === playerId
+        ? currentMembership.transitionId
+        : randomUUID();
+    const { data, error } = await this.supabaseService.client.rpc(
+      'claim_room_membership',
+      {
+        p_user_id: userId,
+        p_room_id: roomId,
+        p_player_id: playerId,
+        p_transition_id: transitionId,
+      },
+    );
+
+    if (error) {
+      throw new Error(`Failed to claim room membership: ${error.message}`);
+    }
+
+    return this.parseTransition(data);
+  }
+
+  async cancelReservation(
+    userId: string,
+    transitionId?: string,
+  ): Promise<boolean> {
+    const membership = transitionId ? null : await this.get(userId);
+    const reservationTransitionId =
+      transitionId ??
+      (membership?.status === 'moving' ? membership.transitionId : null);
+    if (!reservationTransitionId) {
+      return false;
+    }
+
+    const { data, error } = await this.supabaseService.client.rpc(
+      'cancel_room_membership_reservation',
+      {
+        p_user_id: userId,
+        p_transition_id: reservationTransitionId,
+      },
+    );
+
+    if (error) {
+      throw new Error(
+        `Failed to cancel room membership reservation: ${error.message}`,
+      );
+    }
+
+    return data;
+  }
+
+  async release(
+    userId: string,
+    roomId: string,
+    expectedVersion: number,
+  ): Promise<'released' | 'stale'> {
+    const { data, error } = await this.supabaseService.client.rpc(
+      'release_room_membership',
+      {
+        p_user_id: userId,
+        p_room_id: roomId,
+        p_expected_version: expectedVersion,
+        p_transition_id: randomUUID(),
+      },
+    );
+
+    if (error) {
+      throw new Error(`Failed to release room membership: ${error.message}`);
+    }
+
+    const result = this.readString(data, 'result');
+    if (result !== 'released' && result !== 'stale') {
+      throw new Error(`Unexpected room membership release result: ${result}`);
+    }
+    return result;
+  }
+
+  async releaseByPlayer(roomId: string, playerId: string): Promise<boolean> {
+    const { data, error } = await this.supabaseService.client.rpc(
+      'release_room_membership_by_player',
+      {
+        p_room_id: roomId,
+        p_player_id: playerId,
+        p_transition_id: randomUUID(),
+      },
+    );
+
+    if (error) {
+      throw new Error(`Failed to release player membership: ${error.message}`);
+    }
+
+    return data;
+  }
+
+  async releaseRoom(roomId: string): Promise<number> {
+    const { data, error } = await this.supabaseService.client.rpc(
+      'release_room_memberships_for_room',
+      {
+        p_room_id: roomId,
+        p_transition_id: randomUUID(),
+      },
+    );
+
+    if (error) {
+      throw new Error(`Failed to release room memberships: ${error.message}`);
+    }
+
+    return data;
+  }
+
+  private parseTransition(
+    data: Record<string, unknown>,
+  ): RoomMembershipTransition {
+    const result = this.readString(data, 'result');
+    if (!this.isTransitionResult(result)) {
+      throw new Error(
+        `Unexpected room membership transition result: ${result}`,
+      );
+    }
+
+    const membership = data.membership;
+    if (!this.isRecord(membership)) {
+      throw new Error('Room membership transition omitted membership data');
+    }
+
+    return {
+      result,
+      membership: this.mapMembership(membership),
+    };
+  }
+
+  private mapMembership(
+    row: MembershipRow | Record<string, unknown>,
+  ): ActiveRoomMembership {
+    if (!this.isMembershipRow(row)) {
+      throw new Error('Room membership response has an invalid shape');
+    }
+    return {
+      userId: row.user_id,
+      roomId: row.room_id,
+      playerId: row.player_id,
+      status: row.status,
+      membershipVersion: row.membership_version,
+      transitionId: row.transition_id,
+      createdAt: new Date(row.created_at),
+      updatedAt: new Date(row.updated_at),
+      lastSeenAt: new Date(row.last_seen_at),
+    };
+  }
+
+  private readString(data: Record<string, unknown>, key: string): string {
+    const value = data[key];
+    if (typeof value !== 'string') {
+      throw new Error(`Room membership response omitted ${key}`);
+    }
+    return value;
+  }
+
+  private isTransitionResult(
+    result: string,
+  ): result is RoomMembershipTransitionResult {
+    return ['reserved', 'claimed', 'reconnected', 'conflict'].includes(result);
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+
+  private isMembershipRow(
+    value: MembershipRow | Record<string, unknown>,
+  ): value is MembershipRow {
+    return (
+      typeof value.user_id === 'string' &&
+      (typeof value.room_id === 'string' || value.room_id === null) &&
+      typeof value.player_id === 'string' &&
+      ['moving', 'active', 'disconnected'].includes(String(value.status)) &&
+      typeof value.membership_version === 'number' &&
+      typeof value.transition_id === 'string' &&
+      typeof value.created_at === 'string' &&
+      typeof value.updated_at === 'string' &&
+      typeof value.last_seen_at === 'string'
+    );
+  }
+}

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -21,6 +21,8 @@ import { ComSessionService, VacantSeats } from './com-session.service';
 import { SeatRestorationService } from './seat-restoration.service';
 import { RoomJoinService } from './room-join.service';
 import { PlayerConnectionState, SessionUser } from '../types/session.types';
+import { RoomMembershipService } from './room-membership.service';
+import { ActiveRoomMembershipConflictError } from '../types/room-membership.types';
 
 @Injectable()
 export class RoomService implements IRoomService, OnModuleDestroy {
@@ -57,6 +59,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     private readonly gameStateFactory: GameStateFactory,
     @Inject('IComPlayerService')
     private readonly comPlayerService: IComPlayerService,
+    private readonly roomMembershipService: RoomMembershipService,
     @Optional()
     playerReferenceRemapperService?: PlayerReferenceRemapperService,
     @Optional()
@@ -148,6 +151,14 @@ export class RoomService implements IRoomService, OnModuleDestroy {
   }
 
   async deleteRoom(roomId: string): Promise<void> {
+    try {
+      await this.roomMembershipService.releaseRoom(roomId);
+    } catch (error) {
+      this.logger.error(
+        `Failed to release memberships before deleting room ${roomId}`,
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
     await this.roomRepository.delete(roomId);
     await this.releaseRoomResources(roomId);
   }
@@ -176,6 +187,14 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     pointsToWin: number,
     teamAssignmentMethod: 'random' | 'host-choice',
   ): Promise<Room> {
+    const reservation = await this.roomMembershipService.reserve(
+      hostId,
+      hostId,
+    );
+    if (reservation.result === 'conflict') {
+      throw new ActiveRoomMembershipConflictError(reservation.membership);
+    }
+
     const room: Room = {
       id: '', // データベースでUUIDが自動生成される
       name,
@@ -195,19 +214,34 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       lastActivityAt: new Date(),
     };
 
-    const createdRoom = await this.roomRepository.create(room);
+    try {
+      const createdRoom = await this.roomRepository.create(room);
+      const gameState = this.gameStateFactory.createGameState();
+      gameState.setRoomId(createdRoom.id);
+      await gameState.loadState(createdRoom.id);
+      await gameState.configureGameSettings(pointsToWin);
+      this.roomGameStates.set(createdRoom.id, gameState);
+      return createdRoom;
+    } catch (error) {
+      try {
+        await this.roomMembershipService.cancelReservation(
+          hostId,
+          reservation.membership.transitionId,
+        );
+      } catch (reservationError) {
+        this.logger.error(
+          `Failed to cancel room creation reservation for user ${hostId}`,
+          reservationError instanceof Error
+            ? reservationError.stack
+            : String(reservationError),
+        );
+      }
+      throw error;
+    }
+  }
 
-    // ルームごとに新しいゲーム状態を作成
-    const gameState = this.gameStateFactory.createGameState();
-    gameState.setRoomId(createdRoom.id);
-    await gameState.loadState(createdRoom.id);
-
-    // Configure game settings with the room's pointsToWin
-    await gameState.configureGameSettings(pointsToWin);
-
-    this.roomGameStates.set(createdRoom.id, gameState);
-
-    return createdRoom;
+  cancelRoomMembershipReservation(userId: string): Promise<boolean> {
+    return this.roomMembershipService.cancelReservation(userId);
   }
 
   private createCOMPlaceholder(
@@ -377,13 +411,17 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       return false;
     }
 
-    return this.comSessionService.convertPlayerToCOM(
+    const converted = await this.comSessionService.convertPlayerToCOM(
       roomId,
       playerId,
       room,
       gameState,
       this.vacantSeats,
     );
+    if (converted) {
+      await this.releasePlayerMembership(roomId, playerId);
+    }
+    return converted;
   }
 
   async leaveRoom(roomId: string, playerId: string): Promise<boolean> {
@@ -516,6 +554,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       player.isHost = player.playerId === room.hostId;
     });
     await gameState.persistRoster(room.players, room.hostId);
+    await this.releasePlayerMembership(roomId, playerId);
     return true;
   }
 
@@ -524,14 +563,50 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     if (!room) {
       return false;
     }
+    const membershipTransition = user.userId
+      ? await this.roomMembershipService.claim(
+          user.userId,
+          roomId,
+          user.playerId,
+        )
+      : null;
+    if (membershipTransition?.result === 'conflict') {
+      throw new ActiveRoomMembershipConflictError(
+        membershipTransition.membership,
+      );
+    }
+
     const gameState = await this.getRoomGameState(roomId);
-    return this.roomJoinService.joinRoom({
-      roomId,
-      room,
-      gameState,
-      user,
-      vacantSeats: this.vacantSeats,
-    });
+    try {
+      const joined = await this.roomJoinService.joinRoom({
+        roomId,
+        room,
+        gameState,
+        user,
+        vacantSeats: this.vacantSeats,
+      });
+      if (
+        !joined &&
+        user.userId &&
+        membershipTransition?.result === 'claimed'
+      ) {
+        await this.rollbackMembershipClaim(
+          user.userId,
+          roomId,
+          membershipTransition.membership.membershipVersion,
+        );
+      }
+      return joined;
+    } catch (error) {
+      if (user.userId && membershipTransition?.result === 'claimed') {
+        await this.rollbackMembershipClaim(
+          user.userId,
+          roomId,
+          membershipTransition.membership.membershipVersion,
+        );
+      }
+      throw error;
+    }
   }
 
   async restorePlayerFromVacantSeat(
@@ -570,7 +645,53 @@ export class RoomService implements IRoomService, OnModuleDestroy {
 
     const updatedRoom = await this.updateRoom(roomId, { status });
     await this.updateRoomActivity(roomId);
+    if (
+      updatedRoom &&
+      (status === RoomStatus.FINISHED || status === RoomStatus.ABANDONED)
+    ) {
+      try {
+        await this.roomMembershipService.releaseRoom(roomId);
+      } catch (error) {
+        this.logger.error(
+          `Failed to release memberships for inactive room ${roomId}`,
+          error instanceof Error ? error.stack : String(error),
+        );
+      }
+    }
     return !!updatedRoom;
+  }
+
+  private async releasePlayerMembership(
+    roomId: string,
+    playerId: string,
+  ): Promise<void> {
+    try {
+      await this.roomMembershipService.releaseByPlayer(roomId, playerId);
+    } catch (error) {
+      this.logger.error(
+        `Failed to release membership for player ${playerId} in room ${roomId}`,
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
+  }
+
+  private async rollbackMembershipClaim(
+    userId: string,
+    roomId: string,
+    membershipVersion: number,
+  ): Promise<void> {
+    try {
+      await this.roomMembershipService.release(
+        userId,
+        roomId,
+        membershipVersion,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to roll back membership claim for user ${userId} in room ${roomId}`,
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
   }
 
   async updatePlayerInRoom(

--- a/mei-tra-backend/src/types/database.types.ts
+++ b/mei-tra-backend/src/types/database.types.ts
@@ -65,6 +65,7 @@ export interface Database {
           updated_at?: string;
           last_activity_at?: string;
         };
+        Relationships: [];
       };
       room_players: {
         Row: {
@@ -109,6 +110,94 @@ export interface Database {
           seat_index?: number;
           user_id?: string | null;
         };
+        Relationships: [];
+      };
+      chat_rooms: {
+        Row: {
+          id: string;
+          scope: 'global' | 'lobby' | 'table' | 'private';
+          name: string | null;
+          owner_id: string | null;
+          visibility: 'public' | 'friends' | 'private';
+          message_ttl_hours: number;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          scope: 'global' | 'lobby' | 'table' | 'private';
+          name?: string | null;
+          owner_id?: string | null;
+          visibility?: 'public' | 'friends' | 'private';
+          message_ttl_hours?: number;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          scope?: 'global' | 'lobby' | 'table' | 'private';
+          name?: string | null;
+          owner_id?: string | null;
+          visibility?: 'public' | 'friends' | 'private';
+          message_ttl_hours?: number;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
+      chat_members: {
+        Row: {
+          id: string;
+          room_id: string | null;
+          user_id: string | null;
+          role: 'member' | 'moderator';
+          joined_at: string;
+        };
+        Insert: {
+          id?: string;
+          room_id?: string | null;
+          user_id?: string | null;
+          role?: 'member' | 'moderator';
+          joined_at?: string;
+        };
+        Update: {
+          id?: string;
+          room_id?: string | null;
+          user_id?: string | null;
+          role?: 'member' | 'moderator';
+          joined_at?: string;
+        };
+        Relationships: [];
+      };
+      chat_messages: {
+        Row: {
+          id: string;
+          room_id: string | null;
+          sender_id: string | null;
+          content: string;
+          content_type: 'text' | 'emoji' | 'system';
+          reply_to: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          room_id?: string | null;
+          sender_id?: string | null;
+          content: string;
+          content_type?: 'text' | 'emoji' | 'system';
+          reply_to?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          room_id?: string | null;
+          sender_id?: string | null;
+          content?: string;
+          content_type?: 'text' | 'emoji' | 'system';
+          reply_to?: string | null;
+          created_at?: string;
+        };
+        Relationships: [];
       };
       active_room_memberships: {
         Row: {
@@ -144,6 +233,7 @@ export interface Database {
           updated_at?: string;
           last_seen_at?: string;
         };
+        Relationships: [];
       };
       room_membership_events: {
         Row: {
@@ -179,6 +269,7 @@ export interface Database {
           metadata?: Record<string, any>;
           created_at?: string;
         };
+        Relationships: [];
       };
       game_states: {
         Row: {
@@ -247,6 +338,7 @@ export interface Database {
           created_at?: string;
           updated_at?: string;
         };
+        Relationships: [];
       };
       user_profiles: {
         Row: {
@@ -303,6 +395,7 @@ export interface Database {
             fontSize?: 'standard' | 'large' | 'xlarge' | 'xxlarge';
           };
         };
+        Relationships: [];
       };
       game_history: {
         Row: {
@@ -332,6 +425,58 @@ export interface Database {
           action_data?: Record<string, any>;
           timestamp?: string;
         };
+        Relationships: [];
+      };
+    };
+    Views: { [_ in never]: never };
+    Functions: {
+      reserve_room_membership: {
+        Args: {
+          p_user_id: string;
+          p_player_id: string;
+          p_transition_id: string;
+        };
+        Returns: Record<string, unknown>;
+      };
+      claim_room_membership: {
+        Args: {
+          p_user_id: string;
+          p_room_id: string;
+          p_player_id: string;
+          p_transition_id: string;
+        };
+        Returns: Record<string, unknown>;
+      };
+      cancel_room_membership_reservation: {
+        Args: {
+          p_user_id: string;
+          p_transition_id: string;
+        };
+        Returns: boolean;
+      };
+      release_room_membership: {
+        Args: {
+          p_user_id: string;
+          p_room_id: string;
+          p_expected_version: number;
+          p_transition_id: string;
+        };
+        Returns: Record<string, unknown>;
+      };
+      release_room_membership_by_player: {
+        Args: {
+          p_room_id: string;
+          p_player_id: string;
+          p_transition_id: string;
+        };
+        Returns: boolean;
+      };
+      release_room_memberships_for_room: {
+        Args: {
+          p_room_id: string;
+          p_transition_id: string;
+        };
+        Returns: number;
       };
     };
   };

--- a/mei-tra-backend/src/types/room-membership.types.ts
+++ b/mei-tra-backend/src/types/room-membership.types.ts
@@ -1,0 +1,31 @@
+export type ActiveRoomMembershipStatus = 'moving' | 'active' | 'disconnected';
+
+export interface ActiveRoomMembership {
+  userId: string;
+  roomId: string | null;
+  playerId: string;
+  status: ActiveRoomMembershipStatus;
+  membershipVersion: number;
+  transitionId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  lastSeenAt: Date;
+}
+
+export type RoomMembershipTransitionResult =
+  | 'reserved'
+  | 'claimed'
+  | 'reconnected'
+  | 'conflict';
+
+export interface RoomMembershipTransition {
+  result: RoomMembershipTransitionResult;
+  membership: ActiveRoomMembership;
+}
+
+export class ActiveRoomMembershipConflictError extends Error {
+  constructor(readonly membership: ActiveRoomMembership) {
+    super('User is already active in another room');
+    this.name = 'ActiveRoomMembershipConflictError';
+  }
+}

--- a/mei-tra-backend/src/use-cases/__tests__/create-room-with-chat.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/create-room-with-chat.spec.ts
@@ -56,6 +56,7 @@ describe('CreateRoomUseCase', () => {
     roomService = {
       createRoom: jest.fn(),
       createNewRoom: jest.fn().mockResolvedValue(createdRoom),
+      cancelRoomMembershipReservation: jest.fn().mockResolvedValue(false),
       listRooms: jest.fn().mockResolvedValue([updatedRoom]),
       getRoom: jest.fn().mockResolvedValue(updatedRoom),
       joinRoom: jest.fn().mockResolvedValue(true),
@@ -138,5 +139,24 @@ describe('CreateRoomUseCase', () => {
 
     expect(result.success).toBe(true);
     expect(result.data?.room.id).toBe(roomId);
+  });
+
+  it('cleans up the room and reservation when the host cannot join', async () => {
+    roomService.joinRoom.mockResolvedValueOnce(false);
+
+    const result = await createRoomUseCase.execute({
+      roomName: 'Test Game Room',
+      pointsToWin: 10,
+      teamAssignmentMethod: 'random',
+      playerName: 'Test Player',
+      authenticatedUser: { id: userId, profile: {} as any },
+    });
+
+    expect(result.success).toBe(false);
+    expect(roomService.deleteRoom).toHaveBeenCalledWith(roomId);
+    expect(roomService.cancelRoomMembershipReservation).toHaveBeenCalledWith(
+      userId,
+    );
+    expect(roomService.initCOMPlaceholders).not.toHaveBeenCalled();
   });
 });

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -39,6 +39,7 @@ import {
   BROKEN_HAND_REVEAL_PENDING_TTL_MS,
   REQUIRED_BROKEN_HAND_REVEAL_ERROR,
 } from '../helpers/broken-hand.helper';
+import { ActiveRoomMembershipConflictError } from '../../types/room-membership.types';
 describe('Game Use Cases', () => {
   const createRoomServiceMock = () => {
     const mock: Partial<jest.Mocked<IRoomService>> = {
@@ -52,6 +53,7 @@ describe('Game Use Cases', () => {
       updatePlayersInRoom: jest.fn().mockResolvedValue(true),
       canStartGame: jest.fn(),
       createNewRoom: jest.fn(),
+      cancelRoomMembershipReservation: jest.fn().mockResolvedValue(false),
       leaveRoom: jest.fn(),
       updateRoom: jest.fn(),
       deleteRoom: jest.fn(),
@@ -256,6 +258,41 @@ describe('Game Use Cases', () => {
 
       expect(result.success).toBe(false);
       expect(result.errorMessage).toBe('Failed to join room');
+    });
+
+    it('returns a stable conflict when the user is active in another room', async () => {
+      const roomService = createRoomServiceMock();
+      const useCase = new JoinRoomUseCase(roomService);
+      roomService.joinRoom.mockRejectedValue(
+        new ActiveRoomMembershipConflictError({
+          userId: 'user-1',
+          roomId: 'room-existing',
+          playerId: 'player-1',
+          status: 'active',
+          membershipVersion: 3,
+          transitionId: 'transition-existing',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          lastSeenAt: new Date(),
+        }),
+      );
+
+      const result = await useCase.execute({
+        socketId: 'socket-1',
+        targetRoomId: 'room-new',
+        user: {
+          socketId: 'socket-1',
+          playerId: 'player-1',
+          userId: 'user-1',
+          name: 'Player 1',
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errorMessage).toBe(
+        'You are already active in another room.',
+      );
+      expect(roomService.getRoom).not.toHaveBeenCalled();
     });
   });
 
@@ -3316,7 +3353,9 @@ describe('Game Use Cases', () => {
         saveState: jest.fn(),
         resetRoundState: jest.fn(async () => {}),
         transitionPhase: jest.fn(async () => {}),
-        updateState: jest.fn(async (updates) => Object.assign(state, updates)),
+        updateState: jest.fn(async (updates) => {
+          Object.assign(state, updates);
+        }),
       } as unknown as GameStateService;
 
       roomService.getRoomGameState.mockResolvedValue(roomGameState);
@@ -3370,7 +3409,9 @@ describe('Game Use Cases', () => {
         saveState: jest.fn(),
         resetRoundState: jest.fn(async () => {}),
         transitionPhase: jest.fn(async () => {}),
-        updateState: jest.fn(async (updates) => Object.assign(state, updates)),
+        updateState: jest.fn(async (updates) => {
+          Object.assign(state, updates);
+        }),
       } as unknown as GameStateService;
 
       roomService.getRoomGameState.mockResolvedValue(roomGameState);

--- a/mei-tra-backend/src/use-cases/create-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/create-room.use-case.ts
@@ -7,6 +7,7 @@ import {
 } from './interfaces/create-room.use-case.interface';
 import { ChatService } from '../services/chat.service';
 import { SessionUser } from '../types/session.types';
+import { ActiveRoomMembershipConflictError } from '../types/room-membership.types';
 
 type ChatRoomCreator = {
   createRoom(
@@ -29,6 +30,8 @@ export class CreateRoomUseCase implements ICreateRoomUseCase {
   }
 
   async execute(request: CreateRoomRequest): Promise<CreateRoomResponse> {
+    let createdRoomId: string | null = null;
+    let creatingUserId: string | null = null;
     try {
       const {
         roomName,
@@ -56,6 +59,7 @@ export class CreateRoomUseCase implements ICreateRoomUseCase {
           errorMessage: 'Authentication required to create a room.',
         };
       }
+      creatingUserId = playerId;
 
       const room = await this.roomService.createNewRoom(
         roomName,
@@ -63,6 +67,7 @@ export class CreateRoomUseCase implements ICreateRoomUseCase {
         pointsToWin,
         teamAssignmentMethod,
       );
+      createdRoomId = room.id;
 
       const hostUser: SessionUser = {
         socketId: '',
@@ -74,6 +79,7 @@ export class CreateRoomUseCase implements ICreateRoomUseCase {
 
       const joined = await this.roomService.joinRoom(room.id, hostUser);
       if (!joined) {
+        await this.cleanupFailedCreation(room.id, playerId);
         return {
           success: false,
           errorMessage: 'Failed to join created room',
@@ -83,6 +89,7 @@ export class CreateRoomUseCase implements ICreateRoomUseCase {
       await this.roomService.initCOMPlaceholders(room.id);
       const updatedRoom = await this.roomService.getRoom(room.id);
       if (!updatedRoom) {
+        await this.cleanupFailedCreation(room.id, playerId);
         return {
           success: false,
           errorMessage: 'Failed to load created room',
@@ -93,6 +100,7 @@ export class CreateRoomUseCase implements ICreateRoomUseCase {
         (player) => player.playerId === hostUser.playerId,
       );
       if (!hostPlayer) {
+        await this.cleanupFailedCreation(room.id, playerId);
         return {
           success: false,
           errorMessage: 'Host player not found in created room',
@@ -125,6 +133,17 @@ export class CreateRoomUseCase implements ICreateRoomUseCase {
         },
       };
     } catch (error) {
+      if (createdRoomId && creatingUserId) {
+        await this.cleanupFailedCreation(createdRoomId, creatingUserId);
+      } else if (creatingUserId) {
+        await this.roomService.cancelRoomMembershipReservation(creatingUserId);
+      }
+      if (error instanceof ActiveRoomMembershipConflictError) {
+        return {
+          success: false,
+          errorMessage: 'You are already active in another room.',
+        };
+      }
       this.logger.error(
         'Unexpected error while executing CreateRoomUseCase',
         error instanceof Error ? error.stack : String(error),
@@ -133,6 +152,28 @@ export class CreateRoomUseCase implements ICreateRoomUseCase {
         success: false,
         errorMessage: 'Failed to create room',
       };
+    }
+  }
+
+  private async cleanupFailedCreation(
+    roomId: string,
+    userId: string,
+  ): Promise<void> {
+    try {
+      await this.roomService.deleteRoom(roomId);
+    } catch (error) {
+      this.logger.error(
+        `Failed to delete incomplete room ${roomId}`,
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
+    try {
+      await this.roomService.cancelRoomMembershipReservation(userId);
+    } catch (error) {
+      this.logger.error(
+        `Failed to cancel incomplete room reservation for user ${userId}`,
+        error instanceof Error ? error.stack : String(error),
+      );
     }
   }
 }

--- a/mei-tra-backend/src/use-cases/join-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/join-room.use-case.ts
@@ -10,6 +10,7 @@ import {
 import { AuthenticatedUser } from '../types/user.types';
 import { RoomStatus } from '../types/room.types';
 import { SessionUser } from '../types/session.types';
+import { ActiveRoomMembershipConflictError } from '../types/room-membership.types';
 
 @Injectable()
 export class JoinRoomUseCase implements IJoinRoomUseCase {
@@ -78,6 +79,12 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
         data,
       };
     } catch (error) {
+      if (error instanceof ActiveRoomMembershipConflictError) {
+        return {
+          success: false,
+          errorMessage: 'You are already active in another room.',
+        };
+      }
       this.logger.error(
         'Unexpected error while executing JoinRoomUseCase',
         error instanceof Error ? error.stack : String(error),


### PR DESCRIPTION
## Summary
- wire the active membership RPCs into room creation and joins
- reject authenticated cross-room joins before mutating seats
- release or roll back memberships on leave, COM replacement, inactive rooms, and failed room creation
- restore current Supabase schema typing and module DI for the membership service

## Validation
- `npm run build`
- targeted ESLint on all changed backend files
- `npm test -- --runInBand` (42 suites, 250 tests)
- local Nest startup on port 3334
- manual two-account Socket.IO flow:
  - cross-room join rejected
  - same-room reconnect accepted
  - explicit leave releases membership
  - joining another room after leave succeeds
- verified no active membership or room rows remain after cleanup

## Stack
- Base: `fix/active-membership-schema` (#169)
