### PR TITLE
Use room player seats as roster source

### DIFF
--- a/docs/developer-guide/05-data-auth-persistence.md
+++ b/docs/developer-guide/05-data-auth-persistence.md
@@ -307,7 +307,7 @@ room metadata は `rooms`、参加者の identity と座席情報は `room_playe
 
 ### 7.2 game state
 
-`game_states` は deck, agari, blowState, playState と player ごとの gameplay state を `state_data` JSONB に持ちつつ、current player ID / compatibility index や team scores は別カラムでも持ちます。`playerStates` は `playerId` を key にして hand / pass / broken flags だけを保存します。移行期間中は `playerOrder` と `current_player_index` を旧backendとの互換用に残し、手番の永続identityには `current_player_id` を使います。identity は `room_players` から合成します。
+`game_states` は deck, agari, blowState, playState と player ごとの gameplay state を `state_data` JSONB に持ちつつ、current player ID / compatibility index や team scores は別カラムでも持ちます。`playerStates` は `playerId` を key にして hand / pass / broken flags だけを保存します。座席順は `room_players.seat_index` を正本とし、手番の永続identityには `current_player_id` を使います。`current_player_index` は旧backendとの互換用に座席順から派生させます。
 
 この説明が指す主なコードは次です。
 

--- a/mei-tra-backend/src/main.ts
+++ b/mei-tra-backend/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module';
 import * as Sentry from '@sentry/nestjs';
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { isAllowedFrontendOrigin } from './config/frontend-origins';
+import type { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
 
 async function bootstrap() {
   if (process.env.SENTRY_DSN) {
@@ -17,8 +18,11 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useWebSocketAdapter(new IoAdapter(app));
 
-  app.enableCors({
-    origin: (origin, callback) => {
+  const corsOptions: CorsOptions = {
+    origin: (
+      origin: string | undefined,
+      callback: (err: Error | null, allow?: boolean) => void,
+    ) => {
       if (!origin || isAllowedFrontendOrigin(origin)) {
         callback(null, true);
         return;
@@ -27,7 +31,8 @@ async function bootstrap() {
       callback(new Error('Origin not allowed by CORS'));
     },
     credentials: true,
-  });
+  };
+  app.enableCors(corsOptions);
 
   app.setGlobalPrefix('api');
   app.enableShutdownHooks();

--- a/mei-tra-backend/src/repositories/implementations/supabase-chat-message.repository.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-chat-message.repository.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { Injectable } from '@nestjs/common';
 import { SupabaseService } from '../../database/supabase.service';
 import { IChatMessageRepository } from '../interfaces/chat-message.repository.interface';

--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
@@ -145,7 +145,45 @@ describe('SupabaseGameStateRepository', () => {
     ]);
   });
 
-  it('ignores player order entries missing from the authoritative roster', async () => {
+  it('uses room_players seat order instead of stale playerOrder when roster is authoritative', async () => {
+    const secondRoomPlayer = {
+      ...roomPlayerRow,
+      id: 'room-player-2',
+      player_id: 'player-2',
+      name: 'Second player',
+      team: 0,
+      seat_index: 1,
+    };
+    const rpc = jest.fn().mockResolvedValue({
+      data: {
+        gameState: {
+          ...gameStateRow,
+          state_data: {
+            ...gameStateRow.state_data,
+            playerStates: {
+              ...gameStateRow.state_data.playerStates,
+              'player-2': { hand: ['H2'] },
+            },
+            playerOrder: ['player-2', 'player-1'],
+          },
+        },
+        roomPlayers: [roomPlayerRow, secondRoomPlayer],
+      },
+      error: null,
+    });
+    const repository = new SupabaseGameStateRepository({
+      client: { rpc },
+    } as unknown as SupabaseService);
+
+    const state = await repository.findByRoomId(gameStateRow.room_id);
+
+    expect(state?.players.map((player) => player.playerId)).toEqual([
+      'player-1',
+      'player-2',
+    ]);
+  });
+
+  it('ignores player order entries when authoritative roster is empty', async () => {
     const rpc = jest.fn().mockResolvedValue({
       data: {
         gameState: gameStateRow,
@@ -258,7 +296,6 @@ describe('SupabaseGameStateRepository', () => {
     expect(rpc).toHaveBeenCalledWith('atomic_update_game_state', {
       p_room_id: gameStateRow.room_id,
       p_state_patch: {
-        playerOrder: ['player-1'],
         playerStates: {
           'player-1': {
             hand: ['S1'],
@@ -297,7 +334,6 @@ describe('SupabaseGameStateRepository', () => {
       expect.objectContaining({
         p_expected_version: 4,
         p_host_id: 'player-1',
-        p_player_order: ['player-1'],
         p_player_states: {
           'player-1': {
             hand: ['S1'],
@@ -325,8 +361,102 @@ describe('SupabaseGameStateRepository', () => {
       string,
       Record<string, unknown>,
     ];
+    expect(rosterPayload).not.toHaveProperty('p_player_order');
     expect(rosterPayload).not.toHaveProperty('p_legacy_players');
     expect(rosterPayload).not.toHaveProperty('p_team_assignments');
+    expect(state?.version).toBe(5);
+  });
+
+  it('falls back to legacy roster writes before the new RPC is migrated', async () => {
+    const roomPlayersOrder = jest.fn().mockResolvedValue({
+      data: [roomPlayerRow],
+      error: null,
+    });
+    const roomPlayersEq = jest.fn().mockReturnValue({
+      order: roomPlayersOrder,
+    });
+    const roomPlayersSelect = jest.fn().mockReturnValue({
+      eq: roomPlayersEq,
+    });
+    const roomPlayersUpsert = jest.fn().mockResolvedValue({ error: null });
+    const gameStateSingle = jest.fn().mockResolvedValue({
+      data: { state_data: gameStateRow.state_data },
+      error: null,
+    });
+    const gameStateSelectEq = jest.fn().mockReturnValue({
+      single: gameStateSingle,
+    });
+    const gameStateSelect = jest.fn().mockReturnValue({
+      eq: gameStateSelectEq,
+    });
+    const updatedGameStateSingle = jest.fn().mockResolvedValue({
+      data: { ...gameStateRow, version: 5 },
+      error: null,
+    });
+    const updatedGameStateSelect = jest.fn().mockReturnValue({
+      single: updatedGameStateSingle,
+    });
+    const updatedGameStateEq = jest.fn().mockReturnValue({
+      select: updatedGameStateSelect,
+    });
+    const gameStateUpdate = jest.fn().mockReturnValue({
+      eq: updatedGameStateEq,
+    });
+    const roomUpdateEq = jest.fn().mockResolvedValue({ error: null });
+    const roomUpdate = jest.fn().mockReturnValue({ eq: roomUpdateEq });
+    const rpc = jest.fn().mockImplementation((name: string) => {
+      if (name === 'persist_room_roster_atomic') {
+        return Promise.resolve({
+          data: null,
+          error: { code: 'PGRST202', message: 'function not found' },
+        });
+      }
+      return Promise.resolve({
+        data: {
+          gameState: { ...gameStateRow, version: 5 },
+          roomPlayers: [roomPlayerRow],
+        },
+        error: null,
+      });
+    });
+    const from = jest.fn().mockImplementation((table: string) => {
+      if (table === 'room_players') {
+        return {
+          select: roomPlayersSelect,
+          upsert: roomPlayersUpsert,
+        };
+      }
+      if (table === 'rooms') {
+        return { update: roomUpdate };
+      }
+      return {
+        select: gameStateSelect,
+        update: gameStateUpdate,
+      };
+    });
+    const repository = new SupabaseGameStateRepository({
+      client: { rpc, from },
+    } as unknown as SupabaseService);
+
+    const state = await repository.persistRoomRoster(
+      gameStateRow.room_id,
+      [createRoomPlayer()],
+      createState(),
+      'player-1',
+    );
+
+    expect(roomPlayersUpsert).toHaveBeenCalled();
+    const [legacyStateUpdate] = gameStateUpdate.mock.calls[0] as [
+      {
+        current_player_id: string;
+        current_player_index: number;
+        state_data: Record<string, unknown>;
+      },
+    ];
+    expect(legacyStateUpdate.current_player_id).toBe('player-1');
+    expect(legacyStateUpdate.current_player_index).toBe(0);
+    expect(legacyStateUpdate.state_data).toHaveProperty('playerStates');
+    expect(legacyStateUpdate.state_data).not.toHaveProperty('playerOrder');
     expect(state?.version).toBe(5);
   });
 

--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts
@@ -52,7 +52,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
           room_id: roomId,
           state_data: {
             playerStates: toPersistedPlayerStates(gameState.players),
-            playerOrder: gameState.players.map((player) => player.playerId),
             deck: gameState.deck,
             agari: gameState.agari,
             blowState: gameState.blowState,
@@ -173,7 +172,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
     hostId?: string,
   ): Promise<GameState | null> {
     const playerStates = toPersistedPlayerStates(gameState.players);
-    const playerOrder = gameState.players.map((player) => player.playerId);
     const persistedRoomPlayers = roomPlayers.map((player, seatIndex) => ({
       playerId: player.playerId,
       userId: player.userId ?? null,
@@ -193,7 +191,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
           p_room_id: roomId,
           p_room_players: persistedRoomPlayers,
           p_player_states: playerStates,
-          p_player_order: playerOrder,
           p_host_id: hostId ?? null,
           p_expected_version: gameState.version ?? null,
         },
@@ -231,7 +228,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
 
     if (gameState.players) {
       patch.playerStates = toPersistedPlayerStates(gameState.players);
-      patch.playerOrder = gameState.players.map((player) => player.playerId);
     }
     if (gameState.deck) patch.deck = gameState.deck;
     if (gameState.agari !== undefined) patch.agari = gameState.agari;
@@ -310,8 +306,13 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
         .select('state_data')
         .eq('room_id', roomId)
         .single();
-      updateData.state_data = {
+      const currentStateData = {
         ...((currentData?.state_data as Record<string, unknown>) ?? {}),
+      };
+      delete currentStateData.players;
+      delete currentStateData.playerOrder;
+      updateData.state_data = {
+        ...currentStateData,
         ...statePatch,
       };
     }
@@ -414,6 +415,8 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
 
     const persistedState = await this.updateLegacy(roomId, {
       players: gameState.players,
+      currentPlayerId: this.resolveCurrentPlayerId(gameState),
+      currentPlayerIndex: gameState.currentPlayerIndex,
     });
     if (!persistedState) {
       throw new Error(`Game state not found for room ${roomId}`);
@@ -599,21 +602,13 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
     const roomPlayersById = new Map(
       rosterPlayers.map((player) => [player.playerId, player]),
     );
-    const persistedOrder = (
-      Array.isArray(stateData.playerOrder)
+    const playerOrder = hasAuthoritativeRoster
+      ? rosterPlayers.map((player) => player.playerId)
+      : Array.isArray(stateData.playerOrder)
         ? stateData.playerOrder.filter(
             (playerId): playerId is string => typeof playerId === 'string',
           )
-        : []
-    ).filter(
-      (playerId) => !hasAuthoritativeRoster || roomPlayersById.has(playerId),
-    );
-    const playerOrder = [
-      ...persistedOrder,
-      ...rosterPlayers
-        .map((player) => player.playerId)
-        .filter((playerId) => !persistedOrder.includes(playerId)),
-    ];
+        : [];
     const players = playerOrder
       .map((playerId) => {
         const roomPlayer = roomPlayersById.get(playerId);

--- a/mei-tra-backend/supabase/migrations/20260805030000_remove_game_state_player_order.sql
+++ b/mei-tra-backend/supabase/migrations/20260805030000_remove_game_state_player_order.sql
@@ -1,0 +1,335 @@
+do $migration$
+begin
+  execute $sql$
+    create or replace function public.persist_room_roster_atomic(
+      p_room_id uuid,
+      p_room_players jsonb,
+      p_player_states jsonb,
+      p_host_id text default null,
+      p_expected_version bigint default null
+    )
+    returns jsonb
+    language plpgsql
+    security invoker
+    set search_path = public
+    as $function$
+    declare
+      current_state public.game_states%rowtype;
+      updated_state public.game_states%rowtype;
+      next_current_player_id text;
+      next_current_player_index integer;
+    begin
+      select *
+      into current_state
+      from public.game_states
+      where room_id = p_room_id
+      for update;
+
+      if not found then
+        return null;
+      end if;
+
+      if p_expected_version is not null
+        and current_state.version <> p_expected_version then
+        raise exception 'game_state_version_conflict room=% expected=% actual=%',
+          p_room_id,
+          p_expected_version,
+          current_state.version
+          using errcode = 'PT409';
+      end if;
+
+      delete from public.room_players as room_player
+      where room_player.room_id = p_room_id
+        and not exists (
+          select 1
+          from jsonb_array_elements(coalesce(p_room_players, '[]'::jsonb)) as entry
+          where entry->>'playerId' = room_player.player_id
+        );
+
+      insert into public.room_players (
+        room_id,
+        player_id,
+        socket_id,
+        user_id,
+        name,
+        team,
+        is_ready,
+        is_host,
+        is_com,
+        joined_at,
+        seat_index
+      )
+      select
+        p_room_id,
+        player."playerId",
+        null,
+        nullif(player."userId", '')::uuid,
+        player.name,
+        player.team,
+        coalesce(player."isReady", false),
+        coalesce(player."isHost", false),
+        coalesce(player."isCOM", false),
+        coalesce(player."joinedAt", now()),
+        player."seatIndex"
+      from jsonb_to_recordset(coalesce(p_room_players, '[]'::jsonb)) as player(
+        "playerId" text,
+        "userId" text,
+        name text,
+        team integer,
+        "isReady" boolean,
+        "isHost" boolean,
+        "isCOM" boolean,
+        "joinedAt" timestamptz,
+        "seatIndex" integer
+      )
+      on conflict (room_id, player_id) do update
+      set
+        socket_id = null,
+        user_id = excluded.user_id,
+        name = excluded.name,
+        team = excluded.team,
+        is_ready = excluded.is_ready,
+        is_host = excluded.is_host,
+        is_com = excluded.is_com,
+        joined_at = excluded.joined_at,
+        seat_index = excluded.seat_index;
+
+      if p_host_id is not null then
+        update public.rooms
+        set
+          host_id = p_host_id,
+          last_activity_at = now()
+        where id = p_room_id;
+      else
+        update public.rooms
+        set last_activity_at = now()
+        where id = p_room_id;
+      end if;
+
+      if current_state.current_player_id is not null then
+        select seat_position.zero_based_index
+        into next_current_player_index
+        from (
+          select
+            room_player.player_id,
+            row_number() over (order by room_player.seat_index asc) - 1 as zero_based_index
+          from public.room_players as room_player
+          where room_player.room_id = p_room_id
+        ) as seat_position
+        where seat_position.player_id = current_state.current_player_id;
+      end if;
+
+      if next_current_player_index is not null then
+        next_current_player_id := current_state.current_player_id;
+      else
+        next_current_player_index := greatest(
+          coalesce(current_state.current_player_index, 0),
+          0
+        );
+
+        select seat_position.player_id
+        into next_current_player_id
+        from (
+          select
+            room_player.player_id,
+            row_number() over (order by room_player.seat_index asc) - 1 as zero_based_index
+          from public.room_players as room_player
+          where room_player.room_id = p_room_id
+        ) as seat_position
+        where seat_position.zero_based_index = next_current_player_index;
+      end if;
+
+      update public.game_states
+      set
+        state_data = (coalesce(current_state.state_data, '{}'::jsonb) - 'players' - 'playerOrder')
+          || jsonb_build_object(
+            'playerStates', coalesce(p_player_states, '{}'::jsonb)
+          ),
+        current_player_id = next_current_player_id,
+        current_player_index = next_current_player_index,
+        version = current_state.version + 1
+      where room_id = p_room_id
+      returning * into updated_state;
+
+      return to_jsonb(updated_state);
+    end;
+    $function$
+  $sql$;
+
+  execute $sql$
+    create or replace function public.persist_room_roster_atomic(
+      p_room_id uuid,
+      p_room_players jsonb,
+      p_player_states jsonb,
+      p_player_order jsonb,
+      p_host_id text default null,
+      p_expected_version bigint default null
+    )
+    returns jsonb
+    language plpgsql
+    security invoker
+    set search_path = public
+    as $function$
+    begin
+      perform p_player_order;
+
+      return public.persist_room_roster_atomic(
+        p_room_id,
+        p_room_players,
+        p_player_states,
+        p_host_id,
+        p_expected_version
+      );
+    end;
+    $function$
+  $sql$;
+
+  execute $sql$
+    create or replace function public.atomic_update_game_state(
+      p_room_id uuid,
+      p_state_patch jsonb default '{}'::jsonb,
+      p_scalar_patch jsonb default '{}'::jsonb,
+      p_expected_version bigint default null
+    )
+    returns jsonb
+    language plpgsql
+    security invoker
+    set search_path = public
+    as $function$
+    declare
+      current_state public.game_states%rowtype;
+      updated_state public.game_states%rowtype;
+      next_current_player_id text;
+      next_current_player_index integer;
+    begin
+      select *
+      into current_state
+      from public.game_states
+      where room_id = p_room_id
+      for update;
+
+      if not found then
+        return null;
+      end if;
+
+      if p_expected_version is not null
+        and current_state.version <> p_expected_version then
+        raise exception 'game_state_version_conflict room=% expected=% actual=%',
+          p_room_id,
+          p_expected_version,
+          current_state.version
+          using errcode = 'PT409';
+      end if;
+
+      if p_scalar_patch ? 'currentPlayerId' then
+        next_current_player_id := nullif(
+          p_scalar_patch->>'currentPlayerId',
+          ''
+        );
+
+        if next_current_player_id is not null then
+          select seat_position.zero_based_index
+          into next_current_player_index
+          from (
+            select
+              room_player.player_id,
+              row_number() over (order by room_player.seat_index asc) - 1 as zero_based_index
+            from public.room_players as room_player
+            where room_player.room_id = p_room_id
+          ) as seat_position
+          where seat_position.player_id = next_current_player_id;
+        end if;
+
+        if next_current_player_index is null then
+          next_current_player_index := case
+            when p_scalar_patch ? 'currentPlayerIndex'
+              then (p_scalar_patch->>'currentPlayerIndex')::integer
+            else current_state.current_player_index
+          end;
+        end if;
+      elsif p_scalar_patch ? 'currentPlayerIndex' then
+        next_current_player_index := (p_scalar_patch->>'currentPlayerIndex')::integer;
+
+        select seat_position.player_id
+        into next_current_player_id
+        from (
+          select
+            room_player.player_id,
+            row_number() over (order by room_player.seat_index asc) - 1 as zero_based_index
+          from public.room_players as room_player
+          where room_player.room_id = p_room_id
+        ) as seat_position
+        where seat_position.zero_based_index = next_current_player_index;
+      else
+        next_current_player_id := current_state.current_player_id;
+        next_current_player_index := current_state.current_player_index;
+      end if;
+
+      update public.game_states
+      set
+        state_data = (coalesce(current_state.state_data, '{}'::jsonb) - 'players' - 'playerOrder')
+          || (coalesce(p_state_patch, '{}'::jsonb) - 'playerOrder'),
+        current_player_id = next_current_player_id,
+        current_player_index = next_current_player_index,
+        game_phase = case
+          when p_scalar_patch ? 'gamePhase'
+            then (p_scalar_patch->>'gamePhase')::game_phase
+          else current_state.game_phase
+        end,
+        round_number = case
+          when p_scalar_patch ? 'roundNumber'
+            then (p_scalar_patch->>'roundNumber')::integer
+          else current_state.round_number
+        end,
+        points_to_win = case
+          when p_scalar_patch ? 'pointsToWin'
+            then (p_scalar_patch->>'pointsToWin')::integer
+          else current_state.points_to_win
+        end,
+        team_scores = case
+          when p_scalar_patch ? 'teamScores'
+            then p_scalar_patch->'teamScores'
+          else current_state.team_scores
+        end,
+        team_score_records = case
+          when p_scalar_patch ? 'teamScoreRecords'
+            then p_scalar_patch->'teamScoreRecords'
+          else current_state.team_score_records
+        end,
+        version = current_state.version + 1
+      where room_id = p_room_id
+      returning * into updated_state;
+
+      return to_jsonb(updated_state);
+    end;
+    $function$
+  $sql$;
+
+  update public.game_states as game_state
+  set current_player_index = seat_position.zero_based_index
+  from (
+    select
+      room_player.room_id,
+      room_player.player_id,
+      row_number() over (
+        partition by room_player.room_id
+        order by room_player.seat_index asc
+      ) - 1 as zero_based_index
+    from public.room_players as room_player
+  ) as seat_position
+  where seat_position.room_id = game_state.room_id
+    and seat_position.player_id = game_state.current_player_id;
+
+  update public.game_states
+  set state_data = coalesce(state_data, '{}'::jsonb) - 'playerOrder'
+  where state_data ? 'playerOrder';
+
+  execute 'revoke all on function public.persist_room_roster_atomic(uuid, jsonb, jsonb, text, bigint) from public, anon, authenticated';
+  execute 'grant execute on function public.persist_room_roster_atomic(uuid, jsonb, jsonb, text, bigint) to service_role';
+  execute 'revoke all on function public.persist_room_roster_atomic(uuid, jsonb, jsonb, jsonb, text, bigint) from public, anon, authenticated';
+  execute 'grant execute on function public.persist_room_roster_atomic(uuid, jsonb, jsonb, jsonb, text, bigint) to service_role';
+  execute 'revoke all on function public.atomic_update_game_state(uuid, jsonb, jsonb, bigint) from public, anon, authenticated';
+  execute 'grant execute on function public.atomic_update_game_state(uuid, jsonb, jsonb, bigint) to service_role';
+  perform pg_notify('pgrst', 'reload schema');
+end;
+$migration$;

--- a/mei-tra-backend/supabase/tests/atomic_room_state_concurrency.mjs
+++ b/mei-tra-backend/supabase/tests/atomic_room_state_concurrency.mjs
@@ -23,7 +23,7 @@ try {
 
   const { error: stateError } = await supabase.from('game_states').insert({
     room_id: roomId,
-    state_data: { players: [], playerStates: {}, playerOrder: [] },
+    state_data: { players: [], playerStates: {} },
     team_assignments: {},
   });
   assert.ifError(stateError);

--- a/mei-tra-backend/supabase/tests/remove_game_state_player_order.sql
+++ b/mei-tra-backend/supabase/tests/remove_game_state_player_order.sql
@@ -1,0 +1,202 @@
+begin;
+
+select plan(8);
+
+insert into public.rooms (id, name, host_id)
+values (
+  '00000000-0000-0000-0000-000000000904',
+  'Remove playerOrder test',
+  'player-1'
+);
+
+insert into public.game_states (
+  room_id,
+  state_data,
+  current_player_id,
+  current_player_index
+)
+values (
+  '00000000-0000-0000-0000-000000000904',
+  '{"playerStates":{},"playerOrder":["player-2","player-1"],"deck":[]}'::jsonb,
+  'player-1',
+  0
+);
+
+insert into public.room_players (
+  room_id,
+  player_id,
+  name,
+  team,
+  is_host,
+  is_com,
+  seat_index
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000904',
+    'player-1',
+    'Player 1',
+    0,
+    true,
+    false,
+    0
+  ),
+  (
+    '00000000-0000-0000-0000-000000000904',
+    'player-2',
+    'Player 2',
+    1,
+    false,
+    false,
+    1
+  );
+
+select public.persist_room_roster_atomic(
+  '00000000-0000-0000-0000-000000000904',
+  '[
+    {
+      "playerId":"com-1",
+      "name":"COM",
+      "team":0,
+      "isReady":true,
+      "isHost":true,
+      "isCOM":true,
+      "joinedAt":"2026-08-05T00:00:00.000Z",
+      "seatIndex":0
+    },
+    {
+      "playerId":"player-2",
+      "name":"Player 2",
+      "team":1,
+      "isReady":true,
+      "isHost":false,
+      "isCOM":false,
+      "joinedAt":"2026-08-05T00:00:00.000Z",
+      "seatIndex":1
+    }
+  ]'::jsonb,
+  '{
+    "com-1":{"hand":["S1"]},
+    "player-2":{"hand":["H2"]}
+  }'::jsonb,
+  'com-1',
+  0
+);
+
+select is(
+  (
+    select current_player_id
+    from public.game_states
+    where room_id = '00000000-0000-0000-0000-000000000904'
+  ),
+  'com-1'::text,
+  'seat replacement remaps current_player_id'
+);
+
+select is(
+  (
+    select current_player_index
+    from public.game_states
+    where room_id = '00000000-0000-0000-0000-000000000904'
+  ),
+  0,
+  'seat replacement preserves the turn index'
+);
+
+select ok(
+  not (
+    select state_data ? 'playerOrder'
+    from public.game_states
+    where room_id = '00000000-0000-0000-0000-000000000904'
+  ),
+  'new roster RPC does not persist playerOrder'
+);
+
+select public.atomic_update_game_state(
+  '00000000-0000-0000-0000-000000000904',
+  '{"playerOrder":["player-2","com-1"],"deck":["D3"]}'::jsonb,
+  '{"currentPlayerIndex":1}'::jsonb,
+  1
+);
+
+select is(
+  (
+    select current_player_id
+    from public.game_states
+    where room_id = '00000000-0000-0000-0000-000000000904'
+  ),
+  'player-2'::text,
+  'index-only compatibility writes derive current_player_id from seat order'
+);
+
+select is(
+  (
+    select state_data->'deck'
+    from public.game_states
+    where room_id = '00000000-0000-0000-0000-000000000904'
+  ),
+  '["D3"]'::jsonb,
+  'atomic updates preserve non-playerOrder state patches'
+);
+
+select ok(
+  not (
+    select state_data ? 'playerOrder'
+    from public.game_states
+    where room_id = '00000000-0000-0000-0000-000000000904'
+  ),
+  'atomic updates reject playerOrder patches'
+);
+
+select public.persist_room_roster_atomic(
+  '00000000-0000-0000-0000-000000000904',
+  '[
+    {
+      "playerId":"com-1",
+      "name":"COM",
+      "team":0,
+      "isReady":true,
+      "isHost":true,
+      "isCOM":true,
+      "joinedAt":"2026-08-05T00:00:00.000Z",
+      "seatIndex":0
+    },
+    {
+      "playerId":"player-2",
+      "name":"Player 2",
+      "team":1,
+      "isReady":true,
+      "isHost":false,
+      "isCOM":false,
+      "joinedAt":"2026-08-05T00:00:00.000Z",
+      "seatIndex":1
+    }
+  ]'::jsonb,
+  '{"com-1":{},"player-2":{}}'::jsonb,
+  '["player-2","com-1"]'::jsonb,
+  'com-1',
+  2
+);
+
+select ok(
+  not (
+    select state_data ? 'playerOrder'
+    from public.game_states
+    where room_id = '00000000-0000-0000-0000-000000000904'
+  ),
+  'legacy roster RPC remains callable without restoring playerOrder'
+);
+
+select is(
+  (
+    select state_data->'playerStates'->'com-1'
+    from public.game_states
+    where room_id = '00000000-0000-0000-0000-000000000904'
+  ),
+  '{}'::jsonb,
+  'legacy roster RPC still persists playerStates'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## Summary
- Make `room_players.seat_index` the authoritative roster order when restoring game state
- Stop writing `state_data.playerOrder` and remove existing values after reindexing compatibility state from `current_player_id`
- Add a 5-argument roster RPC while preserving the old 6-argument signature as a compatibility wrapper
- Keep `current_player_id` and compatibility `current_player_index` synchronized during roster replacement and index-only legacy updates
- Make the code-first legacy fallback strip stale order data and persist current-player identity

## Dependency and deployment order
- Depends on #179
1. Merge and release #179, including its database migration
2. Deploy this PR's backend code; before its migration, the repository safely falls back to legacy roster writes
3. After the backend is healthy, apply `20260805030000_remove_game_state_player_order.sql`

## Validation
- `npm test -- --runInBand` (43 suites / 265 tests)
- `npm run build`
- `npx eslint "{src,apps,libs,test}/**/*.ts"`
- `supabase test db supabase/tests/remove_game_state_player_order.sql` (8 tests)
- `supabase db lint --local --fail-on error`
- Transactional migration check: stale order removed and compatibility index rederived from seat order
