### PR TITLE
Fix roster conflicts on player leave

### DIFF
--- a/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
@@ -351,6 +351,12 @@ describe('JoinRoomGatewayEffectsService', () => {
         lastPasser: null,
       },
     });
+    expect(result.events).toContainEqual({
+      scope: 'room',
+      roomId: 'room-1',
+      event: 'update-turn',
+      payload: 'player-1',
+    });
   });
 
   it('builds socket-scoped room entry events', async () => {

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -1726,6 +1726,132 @@ describe('Reconnection Token Management', () => {
         expect(gameState.getState().blowState.lastPasser).toBe(playerId);
       });
 
+      it('should advance blow turn when a joining player replaces a COM that already acted', async () => {
+        const roomId = 'room-123';
+        const replacingComId = 'com-2';
+        const joiningPlayerId = 'player-2';
+        const nextPlayerId = 'player-3';
+        const user = {
+          socketId: 'socket-new',
+          playerId: joiningPlayerId,
+          name: 'Player 2',
+        };
+        const comPlayer: RoomPlayer = {
+          socketId: 'com-socket',
+          playerId: replacingComId,
+          name: 'COM 2',
+          team: 0,
+          hand: ['H2', 'D3'],
+          isCOM: true,
+          isPasser: false,
+          hasBroken: false,
+          hasRequiredBroken: false,
+          isReady: true,
+          isHost: false,
+          joinedAt: new Date('2026-03-13T10:01:00.000Z'),
+        };
+        const nextRoomPlayer: RoomPlayer = {
+          socketId: 'socket-3',
+          playerId: nextPlayerId,
+          name: 'Player 3',
+          team: 1,
+          hand: ['C4', 'S5'],
+          isCOM: false,
+          isPasser: false,
+          hasBroken: false,
+          hasRequiredBroken: false,
+          isReady: true,
+          isHost: false,
+          joinedAt: new Date('2026-03-13T10:02:00.000Z'),
+        };
+        const room: Room = {
+          ...baseRoom,
+          players: [comPlayer, nextRoomPlayer],
+        };
+
+        roomRepository.findById.mockResolvedValue(room);
+
+        const gameState = await roomService.getRoomGameState(roomId);
+        gameStateRepository.update.mockImplementation(
+          async (_roomId, state) => ({
+            ...gameState.getState(),
+            ...state,
+            version: (gameState.getState().version ?? 0) + 1,
+          }),
+        );
+        gameState.getState().gamePhase = 'blow';
+        gameState.getState().players = [
+          {
+            playerId: replacingComId,
+            name: 'COM 2',
+            team: 0,
+            hand: ['H2', 'D3'],
+            isPasser: false,
+            hasBroken: false,
+            hasRequiredBroken: false,
+            isCOM: true,
+          },
+          {
+            playerId: nextPlayerId,
+            name: 'Player 3',
+            team: 1,
+            hand: ['C4', 'S5'],
+            isPasser: false,
+            hasBroken: false,
+            hasRequiredBroken: false,
+          },
+        ];
+        gameState.getState().currentPlayerId = replacingComId;
+        gameState.getState().currentPlayerIndex = 0;
+        gameState.getState().blowState = {
+          currentTrump: null,
+          currentHighestDeclaration: {
+            playerId: replacingComId,
+            trumpType: 'daiya',
+            numberOfPairs: 7,
+            timestamp: 1,
+          },
+          declarations: [
+            {
+              playerId: replacingComId,
+              trumpType: 'daiya',
+              numberOfPairs: 7,
+              timestamp: 1,
+            },
+          ],
+          actionHistory: [
+            {
+              type: 'declare',
+              playerId: replacingComId,
+              trumpType: 'daiya',
+              numberOfPairs: 7,
+              timestamp: 1,
+            },
+          ],
+          lastPasser: null,
+          isRoundCancelled: false,
+          currentBlowIndex: 0,
+        };
+
+        const result = await roomService.joinRoom(roomId, user);
+
+        expect(result).toBe(true);
+        expect(gameState.getState().players[0]?.playerId).toBe(joiningPlayerId);
+        expect(
+          gameState.getState().blowState.currentHighestDeclaration?.playerId,
+        ).toBe(joiningPlayerId);
+        expect(gameState.getState().blowState.declarations[0]?.playerId).toBe(
+          joiningPlayerId,
+        );
+        expect(gameState.getState().currentPlayerId).toBe(nextPlayerId);
+        expect(gameState.getState().currentPlayerIndex).toBe(1);
+        expect(gameStateRepository.update).toHaveBeenCalledWith(
+          roomId,
+          expect.objectContaining({ currentPlayerId: nextPlayerId }),
+          expect.any(Number),
+        );
+      });
+
       it('should allow different player to take vacant seat and remove original token', async () => {
         const roomId = 'room-123';
         const originalPlayerId = 'player-1';
@@ -2012,6 +2138,94 @@ describe('Reconnection Token Management', () => {
           gameState.getState().teamAssignments[replacementCom?.playerId ?? ''],
         ).toBe(1);
         expect(gameState.getState().teamAssignments[playerId]).toBeUndefined();
+      });
+
+      it('should avoid duplicate COM player ids when waiting-room state order is stale', async () => {
+        const roomId = 'room-123';
+        const playerId = 'player-2';
+
+        const hostPlayer: RoomPlayer = {
+          socketId: 'socket-1',
+          playerId: 'player-1',
+          name: 'Host Player',
+          team: 0,
+          hand: [],
+          isPasser: false,
+          hasBroken: false,
+          isReady: true,
+          isHost: true,
+          joinedAt: new Date(),
+        };
+        const leavingPlayer: RoomPlayer = {
+          socketId: 'socket-2',
+          playerId,
+          name: 'Leaving Player',
+          team: 1,
+          hand: [],
+          isPasser: false,
+          hasBroken: false,
+          isReady: true,
+          isHost: false,
+          joinedAt: new Date(),
+        };
+        const comPlayer2: RoomPlayer = {
+          ...leavingPlayer,
+          socketId: 'com-2',
+          playerId: 'com-2',
+          name: 'COM',
+          team: 0,
+          isCOM: true,
+          isReady: false,
+        };
+        const comPlayer3: RoomPlayer = {
+          ...comPlayer2,
+          socketId: 'com-3',
+          playerId: 'com-3',
+          team: 1,
+        };
+
+        const room: Room = {
+          ...baseRoom,
+          status: RoomStatus.WAITING,
+          players: [hostPlayer, leavingPlayer, comPlayer2, comPlayer3],
+        };
+
+        const roomState = bindRoomRepositoryToState(room);
+        const gameState = await roomService.getRoomGameState(roomId);
+        gameState.getState().players = [
+          makeGamePlayer(hostPlayer.playerId, hostPlayer.name, hostPlayer.team),
+          makeGamePlayer(
+            comPlayer2.playerId,
+            comPlayer2.name,
+            comPlayer2.team,
+            {
+              isCOM: true,
+              isPasser: true,
+            },
+          ),
+          makeGamePlayer(
+            leavingPlayer.playerId,
+            leavingPlayer.name,
+            leavingPlayer.team,
+          ),
+          makeGamePlayer(
+            comPlayer3.playerId,
+            comPlayer3.name,
+            comPlayer3.team,
+            {
+              isCOM: true,
+              isPasser: true,
+            },
+          ),
+        ];
+
+        await roomService.leaveRoom(roomId, playerId);
+
+        const updatedRoom = roomState.getPersistedRoom();
+        const playerIds = updatedRoom?.players.map((player) => player.playerId);
+        expect(playerIds).toContain('com-1');
+        expect(new Set(playerIds).size).toBe(playerIds?.length);
+        expect(gameState.getState().players[2].playerId).toBe('com-1');
       });
 
       it('should not remove reconnectToken when leaving during play', async () => {

--- a/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
@@ -248,6 +248,14 @@ export class JoinRoomGatewayEffectsService {
           lastPasser: joinData.resumeGame.gameState.blowState.lastPasser,
         },
       });
+      if (joinData.resumeGame.gameState.currentTurn) {
+        events.push({
+          scope: 'room',
+          roomId,
+          event: 'update-turn',
+          payload: joinData.resumeGame.gameState.currentTurn,
+        });
+      }
     }
 
     return {

--- a/mei-tra-backend/src/services/room-join.service.ts
+++ b/mei-tra-backend/src/services/room-join.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DomainPlayer, Team } from '../types/game.types';
+import { BlowState, DomainPlayer, GameState, Team } from '../types/game.types';
 import { toDomainPlayer } from '../types/player-adapters';
 import { Room, RoomPlayer } from '../types/room.types';
 import { GameStateService } from './game-state.service';
@@ -82,6 +82,9 @@ export class RoomJoinService {
         isAuthenticated: updatedPlayer.isAuthenticated,
       });
       await gameState.persistRoster(room.players, room.hostId);
+      if (this.advanceBlowTurnPastActedPlayer(gameState.getState())) {
+        await gameState.saveState();
+      }
       return true;
     }
 
@@ -319,10 +322,68 @@ export class RoomJoinService {
       isAuthenticated: player.isAuthenticated,
     });
     await gameState.persistRoster(room.players, room.hostId);
+    if (this.advanceBlowTurnPastActedPlayer(gameState.getState())) {
+      await gameState.saveState();
+    }
     return true;
   }
 
   private countActualPlayers(players: RoomPlayer[]): number {
     return players.filter((player) => !player.isCOM).length;
+  }
+
+  private advanceBlowTurnPastActedPlayer(state: GameState): boolean {
+    if (state.gamePhase !== 'blow' || state.players.length === 0) {
+      return false;
+    }
+
+    const currentIndex = this.resolveCurrentPlayerIndex(state);
+    const currentPlayer = state.players[currentIndex];
+    if (
+      !currentPlayer ||
+      !this.hasActedInBlow(state.blowState, currentPlayer)
+    ) {
+      return false;
+    }
+
+    for (let offset = 1; offset < state.players.length; offset += 1) {
+      const candidateIndex = (currentIndex + offset) % state.players.length;
+      const candidatePlayer = state.players[candidateIndex];
+      if (!this.hasActedInBlow(state.blowState, candidatePlayer)) {
+        state.currentPlayerIndex = candidateIndex;
+        state.currentPlayerId = candidatePlayer.playerId;
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private resolveCurrentPlayerIndex(state: GameState): number {
+    if (state.currentPlayerId) {
+      const index = state.players.findIndex(
+        (player) => player.playerId === state.currentPlayerId,
+      );
+      if (index !== -1) {
+        return index;
+      }
+    }
+
+    return Math.min(
+      Math.max(state.currentPlayerIndex ?? 0, 0),
+      state.players.length - 1,
+    );
+  }
+
+  private hasActedInBlow(blowState: BlowState, player: DomainPlayer): boolean {
+    return (
+      player.isPasser ||
+      blowState.declarations.some(
+        (declaration) => declaration.playerId === player.playerId,
+      ) ||
+      (blowState.actionHistory ?? []).some(
+        (action) => action.playerId === player.playerId,
+      )
+    );
   }
 }

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -280,6 +280,48 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     return comPlayer;
   }
 
+  private createWaitingCOMReplacement(
+    preferredIndex: number,
+    fallbackIndex: number,
+    team: Team,
+    roomPlayers: RoomPlayer[],
+    statePlayers: DomainPlayer[],
+    replacingRoomIndex: number,
+    replacingStateIndex: number,
+  ): RoomPlayer {
+    const occupiedPlayerIds = new Set<string>();
+    roomPlayers.forEach((player, index) => {
+      if (index !== replacingRoomIndex) {
+        occupiedPlayerIds.add(player.playerId);
+      }
+    });
+    statePlayers.forEach((player, index) => {
+      if (index !== replacingStateIndex) {
+        occupiedPlayerIds.add(player.playerId);
+      }
+    });
+
+    const candidateIndexes = [
+      preferredIndex,
+      fallbackIndex,
+      ...Array.from(
+        { length: roomPlayers.length + statePlayers.length + 1 },
+        (_, index) => index,
+      ),
+    ];
+    for (const candidateIndex of candidateIndexes) {
+      const candidatePlayerId = `com-${candidateIndex}`;
+      if (!occupiedPlayerIds.has(candidatePlayerId)) {
+        return this.createCOMPlaceholder(candidateIndex, team);
+      }
+    }
+
+    return this.createCOMPlaceholder(
+      `vacant-${fallbackIndex}-${Date.now()}`,
+      team,
+    );
+  }
+
   async initCOMPlaceholders(roomId: string): Promise<void> {
     const room = await this.getRoom(roomId);
     if (!room) return;
@@ -457,9 +499,14 @@ export class RoomService implements IRoomService, OnModuleDestroy {
         const state = gameState.getState();
         const gsIndex = state.players.findIndex((p) => p.playerId === playerId);
         const seatIndex = gsIndex !== -1 ? gsIndex : playerIndex;
-        const comPlaceholder = this.createCOMPlaceholder(
+        const comPlaceholder = this.createWaitingCOMReplacement(
           seatIndex,
+          playerIndex,
           leavingPlayer.team,
+          room.players,
+          state.players,
+          playerIndex,
+          gsIndex,
         );
         room.players[playerIndex] = comPlaceholder;
 

--- a/mei-tra-backend/src/use-cases/join-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/join-room.use-case.ts
@@ -133,9 +133,13 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
     // （プレイ中ルームへの途中参加・COM引き継ぎに対応）
 
     const currentTurn =
-      state.currentPlayerIndex !== -1 && state.players[state.currentPlayerIndex]
-        ? state.players[state.currentPlayerIndex].playerId
-        : null;
+      state.currentPlayerId &&
+      state.players.some((player) => player.playerId === state.currentPlayerId)
+        ? state.currentPlayerId
+        : state.currentPlayerIndex !== -1 &&
+            state.players[state.currentPlayerIndex]
+          ? state.players[state.currentPlayerIndex].playerId
+          : null;
 
     return {
       message: 'Joined active game.',


### PR DESCRIPTION
## Summary
- Avoid duplicate COM player ids when a player leaves from the waiting room
- Keep blow turn state consistent when a human joins over a COM seat that already acted
- Broadcast the restored current turn when joining an active game

## Root cause
- Waiting-room leave could generate a COM placeholder id that already existed in room/game roster state, causing Supabase `persist_room_roster_atomic` to fail with `ON CONFLICT DO UPDATE command cannot affect row a second time`.
- Active-game join could remap COM declarations to the joining player while leaving the current turn on an already-acted player.

## Validation
- `npm test -- --runInBand src/services/__tests__/reconnection.spec.ts src/services/__tests__/join-room-gateway-effects.service.spec.ts`
- `npm run lint`
- `npm run build`