### PR TITLE
Fix reconnect player identity

### DIFF
--- a/mei-tra-backend/src/__tests__/game.gateway.com-recovery.spec.ts
+++ b/mei-tra-backend/src/__tests__/game.gateway.com-recovery.spec.ts
@@ -248,7 +248,7 @@ describe('GameGateway COM recovery integration', () => {
       execute: jest.fn().mockResolvedValue({
         success: true,
         data: {
-          playerId: 'user-1',
+          playerId: 'seat-1',
           roomDeleted: true,
           roomsList: [],
         },
@@ -263,7 +263,7 @@ describe('GameGateway COM recovery integration', () => {
       getRoom: jest.fn().mockResolvedValue({
         players: [
           {
-            playerId: 'user-1',
+            playerId: 'seat-1',
             userId: 'user-1',
             isCOM: false,
           },
@@ -315,6 +315,10 @@ describe('GameGateway COM recovery integration', () => {
       playerId: 'user-1',
     });
 
+    expect(testGateway.leaveRoomUseCase.execute).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      playerId: 'seat-1',
+    });
     expect(socketOne.leave).toHaveBeenCalledWith('room-1');
     expect(socketTwo.leave).toHaveBeenCalledWith('room-1');
     expect(socketOne.emit).toHaveBeenCalledWith('back-to-lobby');

--- a/mei-tra-backend/src/__tests__/game.gateway.com-recovery.spec.ts
+++ b/mei-tra-backend/src/__tests__/game.gateway.com-recovery.spec.ts
@@ -234,6 +234,7 @@ describe('GameGateway COM recovery integration', () => {
       turnMonitorService: { clearMonitor: jest.Mock };
       comAutoPlayRecoveryService: { clearRoom: jest.Mock };
       spectatorGatewayEffectsService: { sendRoomBackToLobby: jest.Mock };
+      roomService: { getRoom: jest.Mock };
       connectionGatewayEffectsService: {
         sendRoomPlayersBackToLobby: jest.Mock;
       };
@@ -257,6 +258,17 @@ describe('GameGateway COM recovery integration', () => {
     testGateway.comAutoPlayRecoveryService = { clearRoom: jest.fn() };
     testGateway.spectatorGatewayEffectsService = {
       sendRoomBackToLobby: jest.fn().mockResolvedValue(undefined),
+    };
+    testGateway.roomService = {
+      getRoom: jest.fn().mockResolvedValue({
+        players: [
+          {
+            playerId: 'user-1',
+            userId: 'user-1',
+            isCOM: false,
+          },
+        ],
+      }),
     };
     testGateway.connectionGatewayEffectsService = {
       sendRoomPlayersBackToLobby: jest.fn(

--- a/mei-tra-backend/src/__tests__/game.gateway.com-recovery.spec.ts
+++ b/mei-tra-backend/src/__tests__/game.gateway.com-recovery.spec.ts
@@ -46,6 +46,10 @@ interface ActiveReconnectGatewayHarness {
 }
 
 describe('GameGateway COM recovery integration', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('retries COM progress after a turn acknowledgement', async () => {
     const gateway = createGateway();
     const testGateway = gateway as unknown as {
@@ -166,6 +170,79 @@ describe('GameGateway COM recovery integration', () => {
     expect(previousSocket.leave).toHaveBeenCalledWith('room-1');
     expect(previousSocket.emit).toHaveBeenCalledWith('back-to-lobby');
     expect(testGateway.playerRooms.has('socket-old')).toBe(false);
+  });
+
+  it('delegates COM recovery after disconnect timeout converts the current player to COM', async () => {
+    jest.useFakeTimers();
+
+    const gateway = createGateway();
+    const testGateway = gateway as unknown as {
+      activityTracker: { decrementConnections: jest.Mock };
+      spectatorGatewayEffectsService: { handleDisconnect: jest.Mock };
+      disconnectGatewayEffectsService: {
+        prepareDisconnect: jest.Mock;
+        buildTimeoutEvents: jest.Mock;
+      };
+      turnMonitorService: { isMonitoringPlayer: jest.Mock };
+      clearTurnAckMonitor: jest.Mock;
+      dispatchEvents: jest.Mock;
+      comAutoPlayRecoveryService: { trigger: jest.Mock };
+      playerRooms: Map<string, string>;
+    };
+    const triggerRecovery = jest.fn();
+    const roomGameState = {
+      setDisconnectTimeout: jest.fn(),
+    };
+
+    testGateway.activityTracker = { decrementConnections: jest.fn() };
+    testGateway.spectatorGatewayEffectsService = {
+      handleDisconnect: jest.fn().mockResolvedValue(false),
+    };
+    testGateway.disconnectGatewayEffectsService = {
+      prepareDisconnect: jest.fn().mockResolvedValue({
+        playerId: 'player-1',
+        playerName: 'Player 1',
+        roomGameState,
+        timeoutMode: 'convert-to-com',
+        membership: null,
+        events: [],
+      }),
+      buildTimeoutEvents: jest.fn().mockResolvedValue([
+        {
+          scope: 'room',
+          roomId: 'room-1',
+          event: 'player-converted-to-com',
+          payload: { playerId: 'player-1' },
+        },
+      ]),
+    };
+    testGateway.turnMonitorService = {
+      isMonitoringPlayer: jest.fn().mockReturnValue(false),
+    };
+    testGateway.clearTurnAckMonitor = jest.fn();
+    testGateway.dispatchEvents = jest.fn();
+    testGateway.comAutoPlayRecoveryService = { trigger: triggerRecovery };
+    testGateway.playerRooms = new Map([['socket-1', 'room-1']]);
+
+    const client = {
+      id: 'socket-1',
+      data: { user: { profile: { displayName: 'Player 1' } } },
+      leave: jest.fn().mockResolvedValue(undefined),
+    } as unknown as Socket;
+
+    await gateway.handleDisconnect(client);
+    await jest.advanceTimersByTimeAsync(2 * 60 * 1000);
+
+    expect(
+      testGateway.disconnectGatewayEffectsService.buildTimeoutEvents,
+    ).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      playerId: 'player-1',
+      playerName: 'Player 1',
+      timeoutMode: 'convert-to-com',
+      membership: null,
+    });
+    expect(triggerRecovery).toHaveBeenCalledWith('room-1', expect.anything());
   });
 
   it('returns an authoritative active-game snapshot after the client registers handlers', async () => {

--- a/mei-tra-backend/src/controllers/game-history.controller.spec.ts
+++ b/mei-tra-backend/src/controllers/game-history.controller.spec.ts
@@ -317,6 +317,35 @@ describe('GameHistoryController', () => {
     expect(getGameHistoryUseCase.summarize).not.toHaveBeenCalled();
   });
 
+  it('rejects an ambiguous participant identity', async () => {
+    const getGameHistoryUseCase: IGetGameHistoryUseCase = {
+      execute: jest.fn(),
+      replay: jest.fn(),
+      summarize: jest.fn(),
+    };
+    const roomRepository = createRoomRepository({
+      ...room,
+      players: [
+        room.players[0],
+        {
+          ...room.players[0],
+          playerId: 'player-duplicate',
+          socketId: 'socket-duplicate',
+          isHost: false,
+        },
+      ],
+    });
+    const controller = new GameHistoryController(
+      getGameHistoryUseCase,
+      roomRepository,
+    );
+
+    await expect(
+      controller.listByRoomId('room-1', {}, currentUser),
+    ).rejects.toThrow('Cannot access another user game history');
+    expect(getGameHistoryUseCase.execute).not.toHaveBeenCalled();
+  });
+
   it('returns 404 when the room does not exist', async () => {
     const getGameHistoryUseCase: IGetGameHistoryUseCase = {
       execute: jest.fn(),

--- a/mei-tra-backend/src/controllers/game-history.controller.ts
+++ b/mei-tra-backend/src/controllers/game-history.controller.ts
@@ -98,12 +98,14 @@ export class GameHistoryController {
       throw new NotFoundException('Room not found');
     }
 
-    const participant = room.players.find((player) => player.userId === userId);
-    if (!participant) {
+    const participants = room.players.filter(
+      (player) => !player.isCOM && player.userId === userId,
+    );
+    if (participants.length !== 1) {
       throw new ForbiddenException('Cannot access another user game history');
     }
 
-    return participant;
+    return participants[0];
   }
 
   private withViewerStartingHands(

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -165,6 +165,24 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     return this.getAuthenticatedUser(client)?.id ?? client.id;
   }
 
+  private async resolveClientRoomPlayerId(
+    roomId: string,
+    client: Socket,
+    fallbackPlayerId: string,
+  ): Promise<string> {
+    const authenticatedUser = this.getAuthenticatedUser(client);
+    if (!authenticatedUser) {
+      return fallbackPlayerId;
+    }
+
+    const room = await this.roomService.getRoom(roomId);
+    const roomPlayer = room?.players.find(
+      (player) => !player.isCOM && player.userId === authenticatedUser.id,
+    );
+
+    return roomPlayer?.playerId ?? fallbackPlayerId;
+  }
+
   private normalizeGatewayPayload(event: GatewayEvent): unknown {
     if (event.event === 'room-updated' && event.payload) {
       return toRoomContract(event.payload as Room);
@@ -883,9 +901,14 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
 
     try {
+      const playerId = await this.resolveClientRoomPlayerId(
+        data.roomId,
+        client,
+        data.playerId,
+      );
       const result = await this.togglePlayerReadyUseCase.execute({
         roomId: data.roomId,
-        playerId: data.playerId,
+        playerId,
       });
 
       if (!result.success || !result.updatedRoom) {
@@ -915,8 +938,13 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
   ) {
     try {
       const authenticatedUser = this.getAuthenticatedUser(client);
+      const resolvedPlayerId = await this.resolveClientRoomPlayerId(
+        data.roomId,
+        client,
+        data.playerId,
+      );
       const result = await this.leaveRoomUseCase.execute({
-        playerId: data.playerId,
+        playerId: resolvedPlayerId,
         roomId: data.roomId,
       });
 
@@ -1021,9 +1049,14 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
 
     try {
+      const requesterPlayerId = await this.resolveClientRoomPlayerId(
+        data.roomId,
+        client,
+        data.requesterPlayerId,
+      );
       const result = await this.moderatePlayerUseCase.execute({
         roomId: data.roomId,
-        requesterPlayerId: data.requesterPlayerId,
+        requesterPlayerId,
         targetPlayerId: data.targetPlayerId,
         action: data.action,
         isPlayerIdle: this.isPlayerIdle(data.roomId, data.targetPlayerId),
@@ -1186,9 +1219,14 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
 
     try {
+      const playerId = await this.resolveClientRoomPlayerId(
+        data.roomId,
+        client,
+        data.playerId,
+      );
       const result = await this.changePlayerTeamUseCase.execute({
         roomId: data.roomId,
-        playerId: data.playerId,
+        playerId,
         teamChanges: data.teamChanges,
       });
 
@@ -1226,9 +1264,14 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
 
     try {
+      const playerId = await this.resolveClientRoomPlayerId(
+        data.roomId,
+        client,
+        data.playerId,
+      );
       const result = await this.shuffleTeamsUseCase.execute({
         roomId: data.roomId,
-        playerId: data.playerId,
+        playerId,
       });
       if (!result.success || !result.updatedRoom) {
         client.emit('error-message', result.error || 'Failed to change teams');
@@ -1265,7 +1308,15 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
 
     try {
-      const result = await this.updateTeamNamesUseCase.execute(data);
+      const playerId = await this.resolveClientRoomPlayerId(
+        data.roomId,
+        client,
+        data.playerId,
+      );
+      const result = await this.updateTeamNamesUseCase.execute({
+        ...data,
+        playerId,
+      });
       if (!result.success || !result.updatedRoom) {
         client.emit(
           'error-message',
@@ -1301,9 +1352,14 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
 
     try {
+      const playerId = await this.resolveClientRoomPlayerId(
+        data.roomId,
+        client,
+        data.playerId,
+      );
       const result = await this.fillWithComUseCase.execute({
         roomId: data.roomId,
-        playerId: data.playerId,
+        playerId,
       });
 
       if (!result.success || !result.updatedRoom) {
@@ -1342,8 +1398,13 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       return { success: false, error: 'Spectators cannot start the game' };
     }
 
+    const playerId = await this.resolveClientRoomPlayerId(
+      data.roomId,
+      client,
+      data.playerId,
+    );
     const result = await this.startGameUseCase.execute({
-      playerId: data.playerId,
+      playerId,
       roomId: data.roomId,
     });
 
@@ -1621,10 +1682,15 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     try {
       const actorId = this.getActorId(client);
+      const playerId = await this.resolveClientRoomPlayerId(
+        data.roomId,
+        client,
+        data.playerId,
+      );
       const preparation = await this.revealBrokenHandUseCase.prepare({
         roomId: data.roomId,
         actorId,
-        playerId: data.playerId,
+        playerId,
       });
 
       if (!preparation.success || !preparation.followUp) {

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -176,11 +176,20 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
 
     const room = await this.roomService.getRoom(roomId);
-    const roomPlayer = room?.players.find(
+    if (!room) {
+      throw new Error(`Room not found while resolving player: ${roomId}`);
+    }
+
+    const roomPlayers = room.players.filter(
       (player) => !player.isCOM && player.userId === authenticatedUser.id,
     );
+    if (roomPlayers.length !== 1) {
+      throw new Error(
+        `Authenticated room player is ambiguous or missing: room=${roomId} user=${authenticatedUser.id} matches=${roomPlayers.length}`,
+      );
+    }
 
-    return roomPlayer?.playerId ?? fallbackPlayerId;
+    return roomPlayers[0].playerId;
   }
 
   private normalizeGatewayPayload(event: GatewayEvent): unknown {
@@ -1398,38 +1407,44 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       return { success: false, error: 'Spectators cannot start the game' };
     }
 
-    const playerId = await this.resolveClientRoomPlayerId(
-      data.roomId,
-      client,
-      data.playerId,
-    );
-    const result = await this.startGameUseCase.execute({
-      playerId,
-      roomId: data.roomId,
-    });
-
-    if (!result.success || !result.data) {
-      const errorMessage = result.errorMessage || 'Failed to start game';
-      client.emit('error-message', errorMessage);
-      return { success: false, error: errorMessage };
-    }
-
-    const { players, pointsToWin, updatePhase, currentTurnPlayerId } =
-      result.data;
-    const startGameEvents =
-      await this.startGameGatewayEffectsService.buildEvents({
+    try {
+      const playerId = await this.resolveClientRoomPlayerId(
+        data.roomId,
+        client,
+        data.playerId,
+      );
+      const result = await this.startGameUseCase.execute({
+        playerId,
         roomId: data.roomId,
-        players,
-        pointsToWin,
-        updatePhase,
-        currentTurnPlayerId,
       });
 
-    this.dispatchEvents(startGameEvents);
+      if (!result.success || !result.data) {
+        const errorMessage = result.errorMessage || 'Failed to start game';
+        client.emit('error-message', errorMessage);
+        return { success: false, error: errorMessage };
+      }
 
-    this.triggerComAutoPlayIfNeeded(data.roomId);
+      const { players, pointsToWin, updatePhase, currentTurnPlayerId } =
+        result.data;
+      const startGameEvents =
+        await this.startGameGatewayEffectsService.buildEvents({
+          roomId: data.roomId,
+          players,
+          pointsToWin,
+          updatePhase,
+          currentTurnPlayerId,
+        });
 
-    return { success: true };
+      this.dispatchEvents(startGameEvents);
+
+      this.triggerComAutoPlayIfNeeded(data.roomId);
+
+      return { success: true };
+    } catch (error) {
+      this.logger.error('Failed to start game', error);
+      client.emit('error-message', 'Failed to start game');
+      return { success: false, error: 'Failed to start game' };
+    }
   }
 
   @SubscribeMessage('declare-blow')
@@ -1556,18 +1571,11 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       );
       const state = roomGameState.getState();
       const actorId = this.getActorId(client);
-      const room = await this.roomService.getRoom(data.roomId);
-      const sessionUser =
-        roomGameState.findSessionUserByUserId(actorId) ??
-        roomGameState.findSessionUserBySocketId(client.id) ??
-        roomGameState.findSessionUserByPlayerId(actorId);
-      const roomPlayer = room?.players.find(
-        (player) =>
-          player.userId === actorId ||
-          player.socketId === client.id ||
-          player.playerId === sessionUser?.playerId,
+      const requesterPlayerId = await this.resolveClientRoomPlayerId(
+        data.roomId,
+        client,
+        actorId,
       );
-      const requesterPlayerId = sessionUser?.playerId ?? roomPlayer?.playerId;
       const winningPlayerId =
         state.blowState.currentHighestDeclaration?.playerId;
 

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -661,7 +661,14 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
             timeoutMode: preparation.timeoutMode,
             membership: preparation.membership,
           })
-          .then((events) => this.dispatchEvents(events))
+          .then((events) => {
+            this.dispatchEvents(events);
+            if (
+              events.some((event) => event.event === 'player-converted-to-com')
+            ) {
+              this.triggerComAutoPlayIfNeeded(roomId);
+            }
+          })
           .catch((error) => {
             console.error(
               '[Disconnect] Error processing disconnect timeout:',

--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
@@ -180,6 +180,93 @@ describe('SupabaseGameStateRepository', () => {
     ]);
   });
 
+  it('remaps an orphan blow actor to the only roster player without a blow action', async () => {
+    const secondRoomPlayer = {
+      ...roomPlayerRow,
+      id: 'room-player-2',
+      player_id: 'player-2',
+      name: 'Second player',
+      team: 0,
+      seat_index: 1,
+    };
+    const thirdRoomPlayer = {
+      ...roomPlayerRow,
+      id: 'room-player-3',
+      player_id: 'player-3',
+      name: 'Third player',
+      team: 1,
+      seat_index: 2,
+    };
+    const rpc = jest.fn().mockResolvedValue({
+      data: {
+        gameState: {
+          ...gameStateRow,
+          game_phase: 'blow',
+          state_data: {
+            ...gameStateRow.state_data,
+            playerStates: {
+              ...gameStateRow.state_data.playerStates,
+              'player-2': { hand: ['H2'], isPasser: false },
+              'player-3': { hand: ['D3'], isPasser: true },
+            },
+            blowState: {
+              ...gameStateRow.state_data.blowState,
+              currentHighestDeclaration: {
+                playerId: 'com-orphan',
+                team: 0,
+                trumpType: 'zuppe',
+                numberOfPairs: 6,
+                timestamp: 1,
+              },
+              declarations: [
+                {
+                  playerId: 'com-orphan',
+                  team: 0,
+                  trumpType: 'zuppe',
+                  numberOfPairs: 6,
+                  timestamp: 1,
+                },
+              ],
+              actionHistory: [
+                {
+                  type: 'pass',
+                  playerId: 'player-1',
+                  timestamp: 1,
+                },
+                {
+                  type: 'declare',
+                  playerId: 'com-orphan',
+                  trumpType: 'zuppe',
+                  numberOfPairs: 6,
+                  timestamp: 2,
+                },
+                {
+                  type: 'pass',
+                  playerId: 'player-3',
+                  timestamp: 3,
+                },
+              ],
+            },
+          },
+        },
+        roomPlayers: [roomPlayerRow, secondRoomPlayer, thirdRoomPlayer],
+      },
+      error: null,
+    });
+    const repository = new SupabaseGameStateRepository({
+      client: { rpc },
+    } as unknown as SupabaseService);
+
+    const state = await repository.findByRoomId(gameStateRow.room_id);
+
+    expect(state?.blowState.currentHighestDeclaration?.playerId).toBe(
+      'player-2',
+    );
+    expect(state?.blowState.currentHighestDeclaration?.team).toBe(0);
+    expect(state?.blowState.declarations[0]?.playerId).toBe('player-2');
+    expect(state?.blowState.actionHistory[1]?.playerId).toBe('player-2');
+  });
+
   it('ignores player order entries when authoritative roster is empty', async () => {
     const rpc = jest.fn().mockResolvedValue({
       data: {

--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts
@@ -3,6 +3,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { SupabaseService } from '../../database/supabase.service';
 import { IGameStateRepository } from '../interfaces/game-state.repository.interface';
 import {
+  BlowState,
   GameState,
   DomainPlayer,
   PlayerConnectionMetadata,
@@ -436,6 +437,18 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
       currentPlayerId === null
         ? 0
         : players.findIndex((player) => player.playerId === currentPlayerId);
+    const blowState = this.reconcileBlowStateForRoster(
+      (stateData.blowState ?? {
+        currentTrump: null,
+        currentHighestDeclaration: null,
+        declarations: [],
+        actionHistory: [],
+        lastPasser: null,
+        isRoundCancelled: false,
+        currentBlowIndex: 0,
+      }) as BlowState,
+      players,
+    );
 
     return {
       version: dbGameState.version,
@@ -451,7 +464,7 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
       teamScoreRecords: this.convertTimestampRecords(
         dbGameState.team_score_records,
       ),
-      blowState: stateData.blowState,
+      blowState,
       playState: stateData.playState,
       pendingBrokenHandReveal: stateData.pendingBrokenHandReveal ?? null,
       agari: stateData.agari,
@@ -461,6 +474,94 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
         players.map((player) => [player.playerId, player.team]),
       ),
     };
+  }
+
+  private reconcileBlowStateForRoster(
+    blowState: BlowState,
+    players: DomainPlayer[],
+  ): BlowState {
+    if (players.length === 0) {
+      return blowState;
+    }
+
+    const rosterPlayerIds = new Set(players.map((player) => player.playerId));
+    const referencedPlayerIds = new Set<string>();
+
+    blowState.declarations.forEach((declaration) => {
+      referencedPlayerIds.add(declaration.playerId);
+    });
+    (blowState.actionHistory ?? []).forEach((action) => {
+      referencedPlayerIds.add(action.playerId);
+    });
+    if (blowState.currentHighestDeclaration?.playerId) {
+      referencedPlayerIds.add(blowState.currentHighestDeclaration.playerId);
+    }
+    if (blowState.lastPasser) {
+      referencedPlayerIds.add(blowState.lastPasser);
+    }
+
+    const orphanPlayerIds = [...referencedPlayerIds].filter(
+      (playerId) => !rosterPlayerIds.has(playerId),
+    );
+    if (orphanPlayerIds.length !== 1) {
+      return blowState;
+    }
+
+    const actedRosterPlayerIds = new Set(
+      [...referencedPlayerIds].filter((playerId) =>
+        rosterPlayerIds.has(playerId),
+      ),
+    );
+    const missingPlayers = players.filter(
+      (player) => !actedRosterPlayerIds.has(player.playerId),
+    );
+    if (missingPlayers.length !== 1) {
+      return blowState;
+    }
+
+    const fromPlayerId = orphanPlayerIds[0];
+    const toPlayer = missingPlayers[0];
+    const remappedBlowState: BlowState = {
+      ...blowState,
+      declarations: blowState.declarations.map((declaration) =>
+        declaration.playerId === fromPlayerId
+          ? {
+              ...declaration,
+              playerId: toPlayer.playerId,
+              team: toPlayer.team,
+            }
+          : declaration,
+      ),
+      actionHistory: (blowState.actionHistory ?? []).map((action) =>
+        action.playerId === fromPlayerId
+          ? { ...action, playerId: toPlayer.playerId }
+          : action,
+      ),
+      currentHighestDeclaration:
+        blowState.currentHighestDeclaration?.playerId === fromPlayerId
+          ? {
+              ...blowState.currentHighestDeclaration,
+              playerId: toPlayer.playerId,
+              team: toPlayer.team,
+            }
+          : blowState.currentHighestDeclaration,
+      lastPasser:
+        blowState.lastPasser === fromPlayerId
+          ? toPlayer.playerId
+          : blowState.lastPasser,
+    };
+
+    if (
+      remappedBlowState.lastPasser === toPlayer.playerId ||
+      remappedBlowState.actionHistory.some(
+        (action) =>
+          action.type === 'pass' && action.playerId === toPlayer.playerId,
+      )
+    ) {
+      toPlayer.isPasser = true;
+    }
+
+    return remappedBlowState;
   }
 
   private resolveCurrentPlayerId(gameState: GameState): string | null {

--- a/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
@@ -423,27 +423,25 @@ describe('JoinRoomGatewayEffectsService', () => {
       },
     });
 
-    expect(result.events).toContainEqual(
-      expect.objectContaining({
-        scope: 'socket',
-        socketId: 'socket-1',
-        event: 'game-player-joined',
-        payload: expect.objectContaining({
-          playerId: 'actual-seat',
-          isSelf: true,
-        }),
-      }),
+    const selfJoinedEvent = result.events.find(
+      (event) =>
+        event.scope === 'socket' && event.event === 'game-player-joined',
     );
-    expect(result.events).toContainEqual(
-      expect.objectContaining({
-        scope: 'room',
-        roomId: 'room-1',
-        event: 'room-player-joined',
-        payload: expect.objectContaining({
-          playerId: 'actual-seat',
-        }),
-      }),
+    expect(selfJoinedEvent).toMatchObject({
+      socketId: 'socket-1',
+      payload: {
+        playerId: 'actual-seat',
+        isSelf: true,
+      },
+    });
+    const roomPlayerJoinedEvent = result.events.find(
+      (event) => event.event === 'room-player-joined',
     );
+    expect(roomPlayerJoinedEvent).toMatchObject({
+      scope: 'room',
+      roomId: 'room-1',
+      payload: { playerId: 'actual-seat' },
+    });
   });
 
   it('uses the authenticated room player id when masking active resume hands', async () => {
@@ -491,8 +489,7 @@ describe('JoinRoomGatewayEffectsService', () => {
               hand: [...player.hand],
               team: player.team,
               isPasser: player.isPasser,
-              userId:
-                player.playerId === 'actual-seat' ? 'user-1' : undefined,
+              userId: player.playerId === 'actual-seat' ? 'user-1' : undefined,
             }),
           ),
       ),

--- a/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
@@ -359,6 +359,130 @@ describe('JoinRoomGatewayEffectsService', () => {
     });
   });
 
+  it('uses the authenticated room player id when masking active resume hands', async () => {
+    const room = {
+      id: 'room-1',
+      name: 'Room',
+      hostId: 'actual-seat',
+      status: RoomStatus.PLAYING,
+      players: [
+        {
+          socketId: 'socket-1',
+          playerId: 'actual-seat',
+          userId: 'user-1',
+          name: 'User 1',
+          hand: ['A'],
+          team: 0 as const,
+          isPasser: false,
+          isReady: true,
+          isHost: true,
+          isCOM: false,
+          joinedAt: new Date(),
+        },
+      ],
+      settings: {
+        maxPlayers: 4,
+        isPrivate: false,
+        password: null,
+        teamAssignmentMethod: 'random' as const,
+        pointsToWin: 10,
+        allowSpectators: false,
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      lastActivityAt: new Date(),
+    };
+
+    roomService.getRoomGameState.mockResolvedValue({
+      getTransportPlayers: jest.fn(
+        (players: DomainPlayer[]): TransportPlayer[] =>
+          players.map(
+            (player): TransportPlayer => ({
+              socketId: player.playerId === 'actual-seat' ? 'socket-1' : '',
+              playerId: player.playerId,
+              name: player.name,
+              hand: [...player.hand],
+              team: player.team,
+              isPasser: player.isPasser,
+              userId:
+                player.playerId === 'actual-seat' ? 'user-1' : undefined,
+            }),
+          ),
+      ),
+    } as never);
+
+    const result = await service.buildEffects({
+      clientId: 'socket-1',
+      roomId: 'room-1',
+      normalizedUser: {
+        socketId: 'socket-1',
+        playerId: 'stale-player',
+        userId: 'user-1',
+        name: 'User 1',
+        isAuthenticated: true,
+      },
+      joinData: {
+        room: room as never,
+        isHost: true,
+        roomStatus: RoomStatus.PLAYING,
+        roomsList: [room] as never,
+        resumeGame: {
+          message: 'resume',
+          gameState: {
+            players: [
+              {
+                playerId: 'actual-seat',
+                name: 'User 1',
+                hand: ['A'],
+                team: 0 as const,
+                isPasser: false,
+              },
+              {
+                playerId: 'other-seat',
+                name: 'Other',
+                hand: ['B'],
+                team: 1 as const,
+                isPasser: false,
+              },
+            ],
+            gamePhase: 'play',
+            currentField: null,
+            currentTurn: 'actual-seat',
+            blowState: {
+              currentTrump: null,
+              currentHighestDeclaration: null,
+              declarations: [],
+              actionHistory: [],
+              lastPasser: null,
+              isRoundCancelled: false,
+              currentBlowIndex: 0,
+            },
+            teamScores: {
+              0: { play: 0, total: 0 },
+              1: { play: 0, total: 0 },
+            },
+            negriCard: null,
+            fields: [],
+            roomId: 'room-1',
+            pointsToWin: 10,
+          },
+        },
+      },
+    });
+
+    const gameStateEvent = result.events.find(
+      (event) => event.event === 'game-state',
+    );
+
+    expect((gameStateEvent?.payload as any).you).toBe('actual-seat');
+    expect((gameStateEvent?.payload as any).players).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ playerId: 'actual-seat', hand: ['A'] }),
+        expect.objectContaining({ playerId: 'other-seat', hand: [] }),
+      ]),
+    );
+  });
+
   it('builds socket-scoped room entry events', async () => {
     const room = {
       id: 'room-1',

--- a/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
@@ -359,6 +359,93 @@ describe('JoinRoomGatewayEffectsService', () => {
     });
   });
 
+  it('uses the authenticated room player id for self join events', async () => {
+    const room = {
+      id: 'room-1',
+      name: 'Room',
+      hostId: 'actual-seat',
+      status: RoomStatus.WAITING,
+      players: [
+        {
+          socketId: 'socket-1',
+          playerId: 'actual-seat',
+          userId: 'user-1',
+          name: 'User 1',
+          hand: [],
+          team: 0 as const,
+          isPasser: false,
+          isReady: true,
+          isHost: true,
+          isCOM: false,
+          joinedAt: new Date(),
+        },
+        {
+          socketId: 'com-1',
+          playerId: 'com-1',
+          name: 'COM 1',
+          hand: [],
+          team: 1 as const,
+          isPasser: false,
+          isReady: false,
+          isHost: false,
+          isCOM: true,
+          joinedAt: new Date(),
+        },
+      ],
+      settings: {
+        maxPlayers: 4,
+        isPrivate: false,
+        password: null,
+        teamAssignmentMethod: 'random' as const,
+        pointsToWin: 10,
+        allowSpectators: false,
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      lastActivityAt: new Date(),
+    };
+
+    const result = await service.buildEffects({
+      clientId: 'socket-1',
+      roomId: 'room-1',
+      normalizedUser: {
+        socketId: 'socket-1',
+        playerId: 'stale-player',
+        userId: 'user-1',
+        name: 'User 1',
+        isAuthenticated: true,
+      },
+      joinData: {
+        room: room as never,
+        isHost: true,
+        roomStatus: RoomStatus.WAITING,
+        roomsList: [room] as never,
+      },
+    });
+
+    expect(result.events).toContainEqual(
+      expect.objectContaining({
+        scope: 'socket',
+        socketId: 'socket-1',
+        event: 'game-player-joined',
+        payload: expect.objectContaining({
+          playerId: 'actual-seat',
+          isSelf: true,
+        }),
+      }),
+    );
+    expect(result.events).toContainEqual(
+      expect.objectContaining({
+        scope: 'room',
+        roomId: 'room-1',
+        event: 'room-player-joined',
+        payload: expect.objectContaining({
+          playerId: 'actual-seat',
+        }),
+      }),
+    );
+  });
+
   it('uses the authenticated room player id when masking active resume hands', async () => {
     const room = {
       id: 'room-1',

--- a/mei-tra-backend/src/services/__tests__/play.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/play.service.spec.ts
@@ -56,6 +56,48 @@ describe('PlayService', () => {
     expect(winner?.playerId).toBe('com-1');
   });
 
+  it('uses playedBy as the source of truth when card attribution differs from current seat order', () => {
+    const players = [
+      makePlayer('player-1'),
+      makePlayer('player-2'),
+      makePlayer('player-3'),
+      makePlayer('player-4'),
+    ];
+
+    const field: Field = {
+      cards: ['5♣', 'A♣', '6♣', 'K♣'],
+      playedBy: ['player-1', 'player-3', 'player-2', 'player-4'],
+      baseCard: '5♣',
+      dealerId: 'player-1',
+      isComplete: true,
+    };
+
+    const winner = playService.determineFieldWinner(field, players, null);
+
+    expect(winner?.playerId).toBe('player-3');
+  });
+
+  it('falls back to dealer order for legacy fields without playedBy attribution', () => {
+    const players = [
+      makePlayer('player-1'),
+      makePlayer('player-2'),
+      makePlayer('player-3'),
+      makePlayer('player-4'),
+    ];
+
+    const field: Field = {
+      cards: ['5♣', 'A♣', '6♣', 'K♣'],
+      playedBy: [],
+      baseCard: '5♣',
+      dealerId: 'player-1',
+      isComplete: true,
+    };
+
+    const winner = playService.determineFieldWinner(field, players, null);
+
+    expect(winner?.playerId).toBe('player-2');
+  });
+
   it('returns only base-suit cards when the hand can follow suit', () => {
     const field: Field = {
       cards: ['K♠'],

--- a/mei-tra-backend/src/services/__tests__/player-connection-manager.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/player-connection-manager.service.spec.ts
@@ -43,4 +43,66 @@ describe('PlayerConnectionManager', () => {
     );
     expect(manager.getSessionUsers()).toHaveLength(3);
   });
+
+  it('collapses a stale auth session into the resolved room seat', () => {
+    const manager = new PlayerConnectionManager({
+      log: jest.fn(),
+    } as unknown as Logger);
+    manager.upsertSessionUser({
+      socketId: 'old-socket',
+      playerId: 'user-1',
+      name: 'Player',
+      userId: 'user-1',
+      isAuthenticated: true,
+    });
+    manager.upsertSessionUser({
+      socketId: 'room-socket',
+      playerId: 'seat-1',
+      name: 'Player',
+    });
+
+    manager.upsertSessionUser({
+      socketId: 'new-socket',
+      playerId: 'seat-1',
+      name: 'Player',
+      userId: 'user-1',
+      isAuthenticated: true,
+    });
+
+    expect(manager.getSessionUsers()).toEqual([
+      {
+        socketId: 'new-socket',
+        playerId: 'seat-1',
+        name: 'Player',
+        userId: 'user-1',
+        isAuthenticated: true,
+      },
+    ]);
+    expect(manager.findSessionUserByUserId('user-1')?.playerId).toBe('seat-1');
+  });
+
+  it('removes a stale user mapping when one socket changes identity', () => {
+    const manager = new PlayerConnectionManager({
+      log: jest.fn(),
+    } as unknown as Logger);
+    manager.upsertSessionUser({
+      socketId: 'shared-socket',
+      playerId: 'seat-1',
+      name: 'Player 1',
+      userId: 'user-1',
+      isAuthenticated: true,
+    });
+
+    manager.upsertSessionUser({
+      socketId: 'shared-socket',
+      playerId: 'seat-2',
+      name: 'Player 2',
+      userId: 'user-2',
+      isAuthenticated: true,
+    });
+
+    expect(manager.findSessionUserByUserId('user-1')).toBeNull();
+    expect(manager.playerIds.has('user-1')).toBe(false);
+    expect(manager.playerIds.get('user-2')).toBe('seat-2');
+  });
 });

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -1147,7 +1147,7 @@ describe('Reconnection Token Management', () => {
 
         const result = await roomService.joinRoom(roomId, {
           socketId: 'socket-new',
-          playerId: 'player-1',
+          playerId: 'stale-player',
           userId: 'user-1',
           isAuthenticated: true,
           name: 'Test Player',
@@ -1156,6 +1156,9 @@ describe('Reconnection Token Management', () => {
         expect(result).toBe(true);
         expect(roomRepository.addPlayer).not.toHaveBeenCalled();
         expect(roomRepository.updatePlayer).not.toHaveBeenCalled();
+        expect(roomState.getPersistedRoom()?.players[0].playerId).toBe(
+          'player-1',
+        );
         expect(roomState.getPersistedRoom()?.players[0].socketId).toBe('');
         expect(gameStateRepository.persistRoomRoster).toHaveBeenCalledWith(
           roomId,

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -40,7 +40,13 @@ describe('Reconnection Token Management', () => {
       gameStateRepository = {
         findByRoomId: jest.fn(),
         create: jest.fn(),
-        update: jest.fn().mockResolvedValue({} as GameState),
+        update: jest.fn().mockImplementation(
+          async (_roomId: string, state: Partial<GameState>) =>
+            ({
+              ...state,
+              version: ((state as GameState).version ?? 0) + 1,
+            }) as GameState,
+        ),
         persistRoomRoster: jest
           .fn()
           .mockImplementation(
@@ -386,7 +392,13 @@ describe('Reconnection Token Management', () => {
       gameStateRepository = {
         findByRoomId: jest.fn(),
         create: jest.fn(),
-        update: jest.fn().mockResolvedValue({} as GameState),
+        update: jest.fn().mockImplementation(
+          async (_roomId: string, state: Partial<GameState>) =>
+            ({
+              ...state,
+              version: ((state as GameState).version ?? 0) + 1,
+            }) as GameState,
+        ),
         persistRoomRoster: jest
           .fn()
           .mockImplementation(
@@ -1851,6 +1863,186 @@ describe('Reconnection Token Management', () => {
         expect(gameStateRepository.update).toHaveBeenCalledWith(
           roomId,
           expect.objectContaining({ currentPlayerId: nextPlayerId }),
+          expect.any(Number),
+        );
+      });
+
+      it('should inherit the original seat blow action when a different player takes a vacant blow seat', async () => {
+        const roomId = 'room-123';
+        const originalPlayerId = 'player-left';
+        const replacingComId = 'com-left';
+        const joiningPlayerId = 'player-join';
+        const nextPlayerId = 'player-next';
+        const user = {
+          socketId: 'socket-join',
+          playerId: joiningPlayerId,
+          name: 'Joining Player',
+        };
+        const comPlayer: RoomPlayer = {
+          socketId: 'com-socket',
+          playerId: replacingComId,
+          name: 'COM',
+          team: 0,
+          hand: ['H2', 'D3'],
+          isCOM: true,
+          isPasser: false,
+          hasBroken: false,
+          hasRequiredBroken: false,
+          isReady: true,
+          isHost: false,
+          joinedAt: new Date('2026-03-13T10:01:00.000Z'),
+        };
+        const nextRoomPlayer: RoomPlayer = {
+          socketId: 'socket-next',
+          playerId: nextPlayerId,
+          name: 'Next Player',
+          team: 1,
+          hand: ['C4', 'S5'],
+          isCOM: false,
+          isPasser: false,
+          hasBroken: false,
+          hasRequiredBroken: false,
+          isReady: true,
+          isHost: false,
+          joinedAt: new Date('2026-03-13T10:02:00.000Z'),
+        };
+        const room: Room = {
+          ...baseRoom,
+          players: [comPlayer, nextRoomPlayer],
+        };
+
+        roomRepository.findById.mockResolvedValue(room);
+
+        const gameState = await roomService.getRoomGameState(roomId);
+        gameStateRepository.update.mockImplementation(
+          async (_roomId, state) => ({
+            ...gameState.getState(),
+            ...state,
+            version: (gameState.getState().version ?? 0) + 1,
+          }),
+        );
+        gameState.getState().gamePhase = 'blow';
+        gameState.getState().players = [
+          {
+            playerId: replacingComId,
+            name: 'COM',
+            team: 0,
+            hand: ['H2', 'D3'],
+            isPasser: false,
+            hasBroken: false,
+            hasRequiredBroken: false,
+            isCOM: true,
+          },
+          {
+            playerId: nextPlayerId,
+            name: 'Next Player',
+            team: 1,
+            hand: ['C4', 'S5'],
+            isPasser: false,
+            hasBroken: false,
+            hasRequiredBroken: false,
+          },
+        ];
+        gameState.getState().currentPlayerId = replacingComId;
+        gameState.getState().currentPlayerIndex = 0;
+        gameState.getState().blowState = {
+          currentTrump: null,
+          currentHighestDeclaration: {
+            playerId: originalPlayerId,
+            trumpType: 'club',
+            numberOfPairs: 7,
+            timestamp: 1,
+          },
+          declarations: [
+            {
+              playerId: originalPlayerId,
+              trumpType: 'club',
+              numberOfPairs: 7,
+              timestamp: 1,
+            },
+          ],
+          actionHistory: [
+            {
+              type: 'declare',
+              playerId: originalPlayerId,
+              trumpType: 'club',
+              numberOfPairs: 7,
+              timestamp: 1,
+            },
+          ],
+          lastPasser: null,
+          isRoundCancelled: false,
+          currentBlowIndex: 0,
+        };
+        const stalePersistedBlowState = JSON.parse(
+          JSON.stringify(gameState.getState().blowState),
+        ) as GameState['blowState'];
+        gameStateRepository.persistRoomRoster.mockImplementationOnce(
+          async (_roomId, _roomPlayers, state) => ({
+            ...state,
+            currentPlayerId: replacingComId,
+            currentPlayerIndex: 0,
+            blowState: stalePersistedBlowState,
+            version: (state.version ?? 0) + 1,
+          }),
+        );
+        (roomService as any)['vacantSeats'][roomId] = {
+          0: {
+            roomPlayer: {
+              socketId: 'socket-left',
+              playerId: originalPlayerId,
+              name: 'Left Player',
+              team: 0,
+              hand: ['H2', 'D3'],
+              isPasser: false,
+              hasBroken: false,
+              hasRequiredBroken: false,
+              isReady: true,
+              isHost: false,
+              joinedAt: new Date('2026-03-13T09:59:00.000Z'),
+            },
+            gamePlayer: {
+              playerId: originalPlayerId,
+              name: 'Left Player',
+              team: 0,
+              hand: ['H2', 'D3'],
+              isPasser: false,
+              hasBroken: false,
+              hasRequiredBroken: false,
+            },
+            replacementPlayerId: replacingComId,
+          },
+        };
+
+        const result = await roomService.joinRoom(roomId, user);
+
+        expect(result).toBe(true);
+        expect(gameState.getState().players[0]?.playerId).toBe(joiningPlayerId);
+        expect(
+          gameState.getState().blowState.currentHighestDeclaration?.playerId,
+        ).toBe(joiningPlayerId);
+        expect(gameState.getState().blowState.declarations[0]?.playerId).toBe(
+          joiningPlayerId,
+        );
+        expect(gameState.getState().blowState.actionHistory[0]?.playerId).toBe(
+          joiningPlayerId,
+        );
+        expect(gameState.getState().currentPlayerId).toBe(nextPlayerId);
+        expect(gameState.getState().currentPlayerIndex).toBe(1);
+        expect(gameStateRepository.update).toHaveBeenCalledWith(
+          roomId,
+          expect.objectContaining({ currentPlayerId: nextPlayerId }),
+          expect.any(Number),
+        );
+        expect(gameStateRepository.update).toHaveBeenCalledWith(
+          roomId,
+          expect.objectContaining({
+            blowState: expect.objectContaining({
+              currentHighestDeclaration: expect.objectContaining({
+                playerId: joiningPlayerId,
+              }),
+            }),
+          }),
           expect.any(Number),
         );
       });

--- a/mei-tra-backend/src/services/__tests__/room-membership-lifecycle.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room-membership-lifecycle.spec.ts
@@ -148,12 +148,45 @@ describe('RoomService active membership lifecycle', () => {
       'room-1',
       'seat-1',
     );
-    expect(roomJoinService.joinRoom).toHaveBeenCalledWith(
-      expect.objectContaining({
-        user: expect.objectContaining({ playerId: 'seat-1' }),
-      }),
-    );
+    const joinRequest: unknown = roomJoinService.joinRoom.mock.calls[0]?.[0];
+    expect(joinRequest).toMatchObject({
+      user: { playerId: 'seat-1' },
+    });
     expect(membershipService.get).not.toHaveBeenCalled();
+  });
+
+  it('rejects an ambiguous authenticated room identity before claiming membership', async () => {
+    const duplicatePlayer = {
+      socketId: 'socket-old',
+      userId: 'user-1',
+      isAuthenticated: true,
+      name: 'Player 1',
+      hand: [],
+      team: 0 as const,
+      isPasser: false,
+      isReady: true,
+      isHost: false,
+      joinedAt: new Date(),
+    };
+    jest.spyOn(service, 'getRoom').mockResolvedValue({
+      ...room,
+      players: [
+        { ...duplicatePlayer, playerId: 'seat-1' },
+        { ...duplicatePlayer, playerId: 'seat-2' },
+      ],
+    });
+
+    await expect(
+      service.joinRoom('room-1', {
+        socketId: 'socket-new',
+        playerId: 'user-1',
+        userId: 'user-1',
+        name: 'Player 1',
+      }),
+    ).rejects.toThrow('Ambiguous room player identity');
+
+    expect(membershipService.claim).not.toHaveBeenCalled();
+    expect(roomJoinService.joinRoom).not.toHaveBeenCalled();
   });
 
   it('rolls back a fresh claim with its membership version when joining fails', async () => {

--- a/mei-tra-backend/src/services/__tests__/room-membership-lifecycle.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room-membership-lifecycle.spec.ts
@@ -43,6 +43,7 @@ describe('RoomService active membership lifecycle', () => {
 
   let roomRepository: jest.Mocked<IRoomRepository>;
   let membershipService: {
+    get: jest.Mock;
     claim: jest.Mock;
     release: jest.Mock;
     releaseByPlayer: jest.Mock;
@@ -58,6 +59,7 @@ describe('RoomService active membership lifecycle', () => {
       updateLastActivity: jest.fn(),
     } as unknown as jest.Mocked<IRoomRepository>;
     membershipService = {
+      get: jest.fn().mockResolvedValue(null),
       claim: jest.fn(),
       release: jest.fn().mockResolvedValue('released'),
       releaseByPlayer: jest.fn().mockResolvedValue(true),
@@ -103,6 +105,55 @@ describe('RoomService active membership lifecycle', () => {
 
     expect(service.getRoomGameState).not.toHaveBeenCalled();
     expect(roomJoinService.joinRoom).not.toHaveBeenCalled();
+  });
+
+  it('claims and joins with the persisted room seat id', async () => {
+    const roomWithResolvedSeat: Room = {
+      ...room,
+      hostId: 'seat-1',
+      players: [
+        {
+          socketId: 'socket-old',
+          playerId: 'seat-1',
+          userId: 'user-1',
+          isAuthenticated: true,
+          name: 'Player 1',
+          hand: [],
+          team: 0,
+          isPasser: false,
+          isReady: true,
+          isHost: true,
+          joinedAt: new Date(),
+        },
+      ],
+    };
+    jest.spyOn(service, 'getRoom').mockResolvedValue(roomWithResolvedSeat);
+    membershipService.claim.mockResolvedValue({
+      result: 'reconnected',
+      membership: { ...membership, playerId: 'seat-1' },
+    });
+    roomJoinService.joinRoom.mockResolvedValue(true);
+
+    await expect(
+      service.joinRoom('room-1', {
+        socketId: 'socket-new',
+        playerId: 'user-1',
+        userId: 'user-1',
+        name: 'Player 1',
+      }),
+    ).resolves.toBe(true);
+
+    expect(membershipService.claim).toHaveBeenCalledWith(
+      'user-1',
+      'room-1',
+      'seat-1',
+    );
+    expect(roomJoinService.joinRoom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: expect.objectContaining({ playerId: 'seat-1' }),
+      }),
+    );
+    expect(membershipService.get).not.toHaveBeenCalled();
   });
 
   it('rolls back a fresh claim with its membership version when joining fails', async () => {

--- a/mei-tra-backend/src/services/__tests__/room-membership-reconciler.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room-membership-reconciler.service.spec.ts
@@ -90,6 +90,50 @@ describe('RoomMembershipReconcilerService', () => {
     );
   });
 
+  it('repairs a same-room membership that points to a stale player id', async () => {
+    const repairedMembership: ActiveRoomMembership = {
+      ...membership,
+      playerId: 'seat-1',
+      membershipVersion: 5,
+    };
+    const roomService = {
+      getRoom: jest.fn().mockResolvedValue({
+        id: 'room-authoritative',
+        players: [
+          {
+            playerId: 'seat-1',
+            userId: 'user-1',
+            isAuthenticated: true,
+          },
+        ],
+      }),
+      listRooms: jest.fn().mockResolvedValue([]),
+      leaveRoom: jest.fn(),
+    } as unknown as IRoomService;
+    const membershipService = {
+      list: jest.fn().mockResolvedValue([membership]),
+      claim: jest.fn().mockResolvedValue({
+        result: 'reconnected',
+        membership: repairedMembership,
+      }),
+      release: jest.fn(),
+      cancelReservation: jest.fn(),
+    } as unknown as RoomMembershipService;
+    const service = new RoomMembershipReconcilerService(
+      roomService,
+      membershipService,
+    );
+
+    await service.reconcile();
+
+    expect(membershipService.claim).toHaveBeenCalledWith(
+      'user-1',
+      'room-authoritative',
+      'seat-1',
+    );
+    expect(membershipService.release).not.toHaveBeenCalled();
+  });
+
   it('cancels an expired room-creation reservation', async () => {
     const expiredReservation: ActiveRoomMembership = {
       ...membership,

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -587,12 +587,15 @@ export class GameStateService implements IGameStateService {
     }
 
     field.isComplete = true;
-    const winnerTeam =
-      state.players.find((p) => p.playerId === winnerId)?.team ?? (0 as const);
+    const winner = state.players.find((p) => p.playerId === winnerId);
+    if (!winner) {
+      return null;
+    }
+
     const completedField: CompletedField = {
       cards: [...field.cards],
       winnerId: winnerId,
-      winnerTeam,
+      winnerTeam: winner.team,
       dealerId: field.dealerId,
     };
 

--- a/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
@@ -12,7 +12,7 @@ import {
 import { resolveTransportPlayers } from '../use-cases/helpers/player-resolution.helper';
 import { DomainPlayer, Team } from '../types/game.types';
 import { SessionUser } from '../types/session.types';
-import { RoomStatus } from '../types/room.types';
+import { RoomPlayer, RoomStatus } from '../types/room.types';
 import { IRoomService } from './interfaces/room-service.interface';
 import { RoomUpdateGatewayEffectsService } from './room-update-gateway-effects.service';
 
@@ -69,6 +69,8 @@ export class JoinRoomGatewayEffectsService {
   }: BuildJoinRoomEffectsParams): Promise<JoinRoomEffectsResult> {
     const events: GatewayEvent[] = [];
     let room = joinData.room;
+    const selfRoomPlayer = this.resolveSelfRoomPlayer(room, normalizedUser);
+    const selfPlayerId = selfRoomPlayer?.playerId ?? normalizedUser.playerId;
 
     if (currentRoomId && currentRoomId !== roomId) {
       events.push({
@@ -83,13 +85,10 @@ export class JoinRoomGatewayEffectsService {
       });
     }
 
-    const joiningPlayer = room.players.find(
-      (player) => player.playerId === normalizedUser.playerId,
-    );
-    const joiningTeam = joiningPlayer?.team;
+    const joiningTeam = selfRoomPlayer?.team;
 
     const roomPlayerJoinedPayload: RoomPlayerJoinedPayload = {
-      playerId: normalizedUser.playerId,
+      playerId: selfPlayerId,
       roomId,
       isHost: joinData.isHost,
     };
@@ -102,13 +101,13 @@ export class JoinRoomGatewayEffectsService {
     });
 
     const selfJoinedPayload: GamePlayerJoinedPayload = {
-      playerId: normalizedUser.playerId,
+      playerId: selfPlayerId,
       roomId,
       isHost: joinData.isHost,
       roomStatus: joinData.roomStatus,
       isSelf: true,
       team: joiningTeam,
-      name: normalizedUser.name,
+      name: selfRoomPlayer?.name ?? normalizedUser.name,
     };
     events.push({
       scope: 'socket',
@@ -118,12 +117,12 @@ export class JoinRoomGatewayEffectsService {
     });
 
     const otherJoinedPayload: GamePlayerJoinedPayload = {
-      playerId: normalizedUser.playerId,
+      playerId: selfPlayerId,
       roomId,
       isHost: joinData.isHost,
       roomStatus: joinData.roomStatus,
       team: joiningTeam,
-      name: normalizedUser.name,
+      name: selfRoomPlayer?.name ?? normalizedUser.name,
     };
     events.push({
       scope: 'room',
@@ -135,7 +134,7 @@ export class JoinRoomGatewayEffectsService {
 
     if (!joinData.resumeGame) {
       for (const existingPlayer of room.players) {
-        if (existingPlayer.playerId === normalizedUser.playerId) {
+        if (existingPlayer.playerId === selfPlayerId) {
           continue;
         }
 
@@ -190,7 +189,7 @@ export class JoinRoomGatewayEffectsService {
 
     if (joinData.resumeGame) {
       const roomGameState = await this.roomService.getRoomGameState(roomId);
-      const selfPlayerId = this.resolveResumeSelfPlayerId(
+      const resumeSelfPlayerId = this.resolveResumeSelfPlayerId(
         room,
         joinData.resumeGame.gameState.players,
         normalizedUser,
@@ -208,9 +207,9 @@ export class JoinRoomGatewayEffectsService {
           },
         ).map((player) => ({
           ...player,
-          hand: player.playerId === selfPlayerId ? player.hand : [],
+          hand: player.playerId === resumeSelfPlayerId ? player.hand : [],
         })),
-        you: selfPlayerId,
+        you: resumeSelfPlayerId,
         hostId: room.hostId,
       };
 
@@ -267,6 +266,24 @@ export class JoinRoomGatewayEffectsService {
       room,
       events,
     };
+  }
+
+  private resolveSelfRoomPlayer(
+    room: JoinRoomSuccess['room'],
+    normalizedUser: SessionUser,
+  ): RoomPlayer | undefined {
+    if (normalizedUser.userId) {
+      const playerByUserId = room.players.find(
+        (player) => !player.isCOM && player.userId === normalizedUser.userId,
+      );
+      if (playerByUserId) {
+        return playerByUserId;
+      }
+    }
+
+    return room.players.find(
+      (player) => player.playerId === normalizedUser.playerId,
+    );
   }
 
   private resolveResumeSelfPlayerId(

--- a/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
@@ -291,16 +291,11 @@ export class JoinRoomGatewayEffectsService {
     gamePlayers: DomainPlayer[],
     normalizedUser: SessionUser,
   ): string {
-    const gamePlayerIds = new Set(
-      gamePlayers.map((player) => player.playerId),
-    );
+    const gamePlayerIds = new Set(gamePlayers.map((player) => player.playerId));
 
     const selfRoomPlayer = this.resolveSelfRoomPlayer(room, normalizedUser);
-    if (selfRoomPlayer) {
-      const roomPlayer = selfRoomPlayer;
-      if (roomPlayer && gamePlayerIds.has(roomPlayer.playerId)) {
-        return roomPlayer.playerId;
-      }
+    if (selfRoomPlayer && gamePlayerIds.has(selfRoomPlayer.playerId)) {
+      return selfRoomPlayer.playerId;
     }
 
     if (gamePlayerIds.has(normalizedUser.playerId)) {

--- a/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
@@ -10,7 +10,7 @@ import {
   PreviousRoomNotification,
 } from '../use-cases/interfaces/join-room.use-case.interface';
 import { resolveTransportPlayers } from '../use-cases/helpers/player-resolution.helper';
-import { Team } from '../types/game.types';
+import { DomainPlayer, Team } from '../types/game.types';
 import { SessionUser } from '../types/session.types';
 import { RoomStatus } from '../types/room.types';
 import { IRoomService } from './interfaces/room-service.interface';
@@ -190,6 +190,11 @@ export class JoinRoomGatewayEffectsService {
 
     if (joinData.resumeGame) {
       const roomGameState = await this.roomService.getRoomGameState(roomId);
+      const selfPlayerId = this.resolveResumeSelfPlayerId(
+        room,
+        joinData.resumeGame.gameState.players,
+        normalizedUser,
+      );
       const maskedGameStateForJoiner: GameStatePayload = {
         ...joinData.resumeGame.gameState,
         currentField: joinData.resumeGame.gameState.currentField ?? null,
@@ -203,9 +208,9 @@ export class JoinRoomGatewayEffectsService {
           },
         ).map((player) => ({
           ...player,
-          hand: player.playerId === normalizedUser.playerId ? player.hand : [],
+          hand: player.playerId === selfPlayerId ? player.hand : [],
         })),
-        you: normalizedUser.playerId,
+        you: selfPlayerId,
         hostId: room.hostId,
       };
 
@@ -262,6 +267,31 @@ export class JoinRoomGatewayEffectsService {
       room,
       events,
     };
+  }
+
+  private resolveResumeSelfPlayerId(
+    room: JoinRoomSuccess['room'],
+    gamePlayers: DomainPlayer[],
+    normalizedUser: SessionUser,
+  ): string {
+    const gamePlayerIds = new Set(
+      gamePlayers.map((player) => player.playerId),
+    );
+
+    if (normalizedUser.userId) {
+      const roomPlayer = room.players.find(
+        (player) => player.userId === normalizedUser.userId,
+      );
+      if (roomPlayer && gamePlayerIds.has(roomPlayer.playerId)) {
+        return roomPlayer.playerId;
+      }
+    }
+
+    if (gamePlayerIds.has(normalizedUser.playerId)) {
+      return normalizedUser.playerId;
+    }
+
+    return normalizedUser.playerId;
   }
 
   async buildRoomEntryEvents({

--- a/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
@@ -273,11 +273,11 @@ export class JoinRoomGatewayEffectsService {
     normalizedUser: SessionUser,
   ): RoomPlayer | undefined {
     if (normalizedUser.userId) {
-      const playerByUserId = room.players.find(
+      const playersByUserId = room.players.filter(
         (player) => !player.isCOM && player.userId === normalizedUser.userId,
       );
-      if (playerByUserId) {
-        return playerByUserId;
+      if (playersByUserId.length === 1) {
+        return playersByUserId[0];
       }
     }
 
@@ -295,10 +295,9 @@ export class JoinRoomGatewayEffectsService {
       gamePlayers.map((player) => player.playerId),
     );
 
-    if (normalizedUser.userId) {
-      const roomPlayer = room.players.find(
-        (player) => player.userId === normalizedUser.userId,
-      );
+    const selfRoomPlayer = this.resolveSelfRoomPlayer(room, normalizedUser);
+    if (selfRoomPlayer) {
+      const roomPlayer = selfRoomPlayer;
       if (roomPlayer && gamePlayerIds.has(roomPlayer.playerId)) {
         return roomPlayer.playerId;
       }

--- a/mei-tra-backend/src/services/play.service.ts
+++ b/mei-tra-backend/src/services/play.service.ts
@@ -43,9 +43,22 @@ export class PlayService implements IPlayService {
       field.dealerId = players[0].playerId;
     }
 
-    // field.cards is stored in actual play order, so winner attribution must use
-    // the full seat order, including COM players.
+    const playersById = new Map(
+      players.map((player) => [player.playerId, player]),
+    );
+    const playedByOrder =
+      field.playedBy.length === field.cards.length
+        ? field.playedBy.map((playerId) => playersById.get(playerId))
+        : [];
+
+    // Prefer the explicit card -> player attribution recorded when each card was
+    // played. Fall back to legacy dealer order only for older field snapshots.
     const updatedPlayerOrder = field.cards.map((_, i) => {
+      const playedByPlayer = playedByOrder[i];
+      if (playedByPlayer) {
+        return playedByPlayer;
+      }
+
       const index = (dealerIndex + i) % players.length;
       return players[index];
     });

--- a/mei-tra-backend/src/services/player-connection-manager.service.ts
+++ b/mei-tra-backend/src/services/player-connection-manager.service.ts
@@ -52,14 +52,19 @@ export class PlayerConnectionManager {
     created: boolean;
     changed: boolean;
   } {
+    const matchingUsers = this.users.filter(
+      (user) =>
+        user.playerId === sessionUser.playerId ||
+        (sessionUser.userId != null && user.userId === sessionUser.userId) ||
+        (sessionUser.socketId !== '' && user.socketId === sessionUser.socketId),
+    );
     const existingUser =
-      this.findSessionUserByPlayerId(sessionUser.playerId) ??
-      (sessionUser.userId
-        ? this.findSessionUserByUserId(sessionUser.userId)
-        : null) ??
-      (sessionUser.socketId
-        ? this.findSessionUserBySocketId(sessionUser.socketId)
-        : null);
+      matchingUsers.find((user) => user.playerId === sessionUser.playerId) ??
+      matchingUsers.find(
+        (user) =>
+          sessionUser.userId != null && user.userId === sessionUser.userId,
+      ) ??
+      matchingUsers[0];
 
     if (!existingUser) {
       this.users.push(sessionUser);
@@ -76,6 +81,8 @@ export class PlayerConnectionManager {
     const nextUserId = sessionUser.userId ?? existingUser.userId;
     const nextIsAuthenticated =
       sessionUser.isAuthenticated ?? existingUser.isAuthenticated;
+    const previousPlayerId = existingUser.playerId;
+    const previousUserId = existingUser.userId;
     const changed =
       existingUser.socketId !== sessionUser.socketId ||
       existingUser.playerId !== sessionUser.playerId ||
@@ -91,8 +98,33 @@ export class PlayerConnectionManager {
       existingUser.isAuthenticated = nextIsAuthenticated;
     }
 
+    if (
+      previousUserId &&
+      previousUserId !== sessionUser.userId &&
+      this.playerIds.get(previousUserId) === previousPlayerId
+    ) {
+      this.playerIds.delete(previousUserId);
+    }
+
     if (sessionUser.userId) {
       this.playerIds.set(sessionUser.userId, sessionUser.playerId);
+    }
+
+    for (const duplicateUser of matchingUsers) {
+      if (duplicateUser === existingUser) {
+        continue;
+      }
+      if (
+        duplicateUser.userId &&
+        duplicateUser.userId !== sessionUser.userId &&
+        this.playerIds.get(duplicateUser.userId) === duplicateUser.playerId
+      ) {
+        this.playerIds.delete(duplicateUser.userId);
+      }
+      const duplicateIndex = this.users.indexOf(duplicateUser);
+      if (duplicateIndex !== -1) {
+        this.users.splice(duplicateIndex, 1);
+      }
     }
 
     return {

--- a/mei-tra-backend/src/services/room-join.service.ts
+++ b/mei-tra-backend/src/services/room-join.service.ts
@@ -37,9 +37,7 @@ export class RoomJoinService {
     void roomId;
     const state = gameState.getState();
 
-    const existingPlayer = room.players.find(
-      (player) => player.playerId === user.playerId,
-    );
+    const existingPlayer = this.findExistingRoomPlayer(room.players, user);
     if (existingPlayer) {
       const statePlayer = state.players.find(
         (player) => player.playerId === existingPlayer.playerId,
@@ -53,8 +51,10 @@ export class RoomJoinService {
       const updatedPlayer: RoomPlayer = {
         ...existingPlayer,
         ...user,
+        playerId: existingPlayer.playerId,
         userId: user.userId ?? existingPlayer.userId,
         isAuthenticated: user.isAuthenticated ?? existingPlayer.isAuthenticated,
+        isHost: room.hostId === existingPlayer.playerId,
       };
       Object.assign(existingPlayer, updatedPlayer);
       if (statePlayer) {
@@ -330,6 +330,22 @@ export class RoomJoinService {
 
   private countActualPlayers(players: RoomPlayer[]): number {
     return players.filter((player) => !player.isCOM).length;
+  }
+
+  private findExistingRoomPlayer(
+    players: RoomPlayer[],
+    user: SessionUser,
+  ): RoomPlayer | undefined {
+    if (user.userId) {
+      const playerByUserId = players.find(
+        (player) => !player.isCOM && player.userId === user.userId,
+      );
+      if (playerByUserId) {
+        return playerByUserId;
+      }
+    }
+
+    return players.find((player) => player.playerId === user.playerId);
   }
 
   private advanceBlowTurnPastActedPlayer(state: GameState): boolean {

--- a/mei-tra-backend/src/services/room-join.service.ts
+++ b/mei-tra-backend/src/services/room-join.service.ts
@@ -300,16 +300,22 @@ export class RoomJoinService {
       }
     }
 
+    const seatReferencePlayerIds = new Set<string>();
     if (replacingComId) {
-      this.playerReferenceRemapperService.remapGameStatePlayerIdReferences(
-        state,
-        replacingComId,
-        player.playerId,
-      );
-      if (state.teamAssignments[replacingComId] != null) {
-        delete state.teamAssignments[replacingComId];
-      }
+      seatReferencePlayerIds.add(replacingComId);
     }
+    if (seatRoomSnapshot?.playerId) {
+      seatReferencePlayerIds.add(seatRoomSnapshot.playerId);
+    }
+    if (seatGameSnapshot?.playerId) {
+      seatReferencePlayerIds.add(seatGameSnapshot.playerId);
+    }
+
+    const remappedSeatReferences = this.remapSeatReferences(
+      state,
+      seatReferencePlayerIds,
+      player.playerId,
+    );
     state.teamAssignments[player.playerId] = player.team;
 
     gameState.registerPlayerToken(player.playerId, player.playerId);
@@ -322,7 +328,18 @@ export class RoomJoinService {
       isAuthenticated: player.isAuthenticated,
     });
     await gameState.persistRoster(room.players, room.hostId);
-    if (this.advanceBlowTurnPastActedPlayer(gameState.getState())) {
+    const persistedState = gameState.getState();
+    if (remappedSeatReferences) {
+      this.remapSeatReferences(
+        persistedState,
+        seatReferencePlayerIds,
+        player.playerId,
+      );
+      persistedState.teamAssignments[player.playerId] = player.team;
+    }
+    const advancedBlowTurn =
+      this.advanceBlowTurnPastActedPlayer(persistedState);
+    if (remappedSeatReferences || advancedBlowTurn) {
       await gameState.saveState();
     }
     return true;
@@ -346,6 +363,32 @@ export class RoomJoinService {
     }
 
     return players.find((player) => player.playerId === user.playerId);
+  }
+
+  private remapSeatReferences(
+    state: GameState,
+    seatReferencePlayerIds: Set<string>,
+    playerId: string,
+  ): boolean {
+    let remapped = false;
+
+    seatReferencePlayerIds.forEach((fromPlayerId) => {
+      if (fromPlayerId === playerId) {
+        return;
+      }
+
+      this.playerReferenceRemapperService.remapGameStatePlayerIdReferences(
+        state,
+        fromPlayerId,
+        playerId,
+      );
+      if (state.teamAssignments[fromPlayerId] != null) {
+        delete state.teamAssignments[fromPlayerId];
+      }
+      remapped = true;
+    });
+
+    return remapped;
   }
 
   private advanceBlowTurnPastActedPlayer(state: GameState): boolean {

--- a/mei-tra-backend/src/services/room-membership-reconciler.service.ts
+++ b/mei-tra-backend/src/services/room-membership-reconciler.service.ts
@@ -45,6 +45,26 @@ export class RoomMembershipReconcilerService implements OnModuleInit {
         continue;
       }
 
+      const authenticatedRoomPlayers =
+        room?.players.filter(
+          (candidate) =>
+            !candidate.isCOM && candidate.userId === membership.userId,
+        ) ?? [];
+      if (authenticatedRoomPlayers.length === 1) {
+        const repaired = await this.roomMembershipService.claim(
+          membership.userId,
+          membership.roomId,
+          authenticatedRoomPlayers[0].playerId,
+        );
+        if (repaired.result !== 'conflict') {
+          authoritativeMemberships.set(membership.userId, repaired.membership);
+          this.logger.warn(
+            `[MembershipReconcile] Repaired player identity user=${membership.userId} room=${membership.roomId} from=${membership.playerId} to=${authenticatedRoomPlayers[0].playerId}`,
+          );
+          continue;
+        }
+      }
+
       const result = await this.roomMembershipService.release(
         membership.userId,
         membership.roomId,

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -551,11 +551,12 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     if (!room) {
       return false;
     }
-    const membershipTransition = user.userId
+    const joiningUser = await this.resolveJoiningUser(roomId, room, user);
+    const membershipTransition = joiningUser.userId
       ? await this.roomMembershipService.claim(
-          user.userId,
+          joiningUser.userId,
           roomId,
-          user.playerId,
+          joiningUser.playerId,
         )
       : null;
     if (membershipTransition?.result === 'conflict') {
@@ -570,31 +571,68 @@ export class RoomService implements IRoomService, OnModuleDestroy {
         roomId,
         room,
         gameState,
-        user,
+        user: joiningUser,
         vacantSeats: this.vacantSeats,
       });
       if (
         !joined &&
-        user.userId &&
+        joiningUser.userId &&
         membershipTransition?.result === 'claimed'
       ) {
         await this.rollbackMembershipClaim(
-          user.userId,
+          joiningUser.userId,
           roomId,
           membershipTransition.membership.membershipVersion,
         );
       }
       return joined;
     } catch (error) {
-      if (user.userId && membershipTransition?.result === 'claimed') {
+      if (
+        joiningUser.userId &&
+        membershipTransition?.result === 'claimed'
+      ) {
         await this.rollbackMembershipClaim(
-          user.userId,
+          joiningUser.userId,
           roomId,
           membershipTransition.membership.membershipVersion,
         );
       }
       throw error;
     }
+  }
+
+  private async resolveJoiningUser(
+    roomId: string,
+    room: Room,
+    user: SessionUser,
+  ): Promise<SessionUser> {
+    if (!user.userId) {
+      return user;
+    }
+
+    const roomMatches = room.players.filter(
+      (player) => !player.isCOM && player.userId === user.userId,
+    );
+    if (roomMatches.length === 1) {
+      return { ...user, playerId: roomMatches[0].playerId };
+    }
+
+    const vacantMatches = Object.values(this.vacantSeats[roomId] ?? {}).filter(
+      (seat) => seat.roomPlayer.userId === user.userId,
+    );
+    if (vacantMatches.length === 1) {
+      return {
+        ...user,
+        playerId: vacantMatches[0].roomPlayer.playerId,
+      };
+    }
+
+    const membership = await this.roomMembershipService.get(user.userId);
+    if (membership?.roomId === roomId) {
+      return { ...user, playerId: membership.playerId };
+    }
+
+    return user;
   }
 
   async restorePlayerFromVacantSeat(

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -587,10 +587,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       }
       return joined;
     } catch (error) {
-      if (
-        joiningUser.userId &&
-        membershipTransition?.result === 'claimed'
-      ) {
+      if (joiningUser.userId && membershipTransition?.result === 'claimed') {
         await this.rollbackMembershipClaim(
           joiningUser.userId,
           roomId,
@@ -616,6 +613,11 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     if (roomMatches.length === 1) {
       return { ...user, playerId: roomMatches[0].playerId };
     }
+    if (roomMatches.length > 1) {
+      throw new Error(
+        `Ambiguous room player identity: room=${roomId} user=${user.userId} matches=${roomMatches.length}`,
+      );
+    }
 
     const vacantMatches = Object.values(this.vacantSeats[roomId] ?? {}).filter(
       (seat) => seat.roomPlayer.userId === user.userId,
@@ -625,6 +627,11 @@ export class RoomService implements IRoomService, OnModuleDestroy {
         ...user,
         playerId: vacantMatches[0].roomPlayer.playerId,
       };
+    }
+    if (vacantMatches.length > 1) {
+      throw new Error(
+        `Ambiguous vacant seat identity: room=${roomId} user=${user.userId} matches=${vacantMatches.length}`,
+      );
     }
 
     const membership = await this.roomMembershipService.get(user.userId);

--- a/mei-tra-backend/src/services/seat-restoration.service.ts
+++ b/mei-tra-backend/src/services/seat-restoration.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DomainPlayer } from '../types/game.types';
+import { BlowState, DomainPlayer, GameState } from '../types/game.types';
 import { toDomainPlayer } from '../types/player-adapters';
 import { Room, RoomPlayer } from '../types/room.types';
 import { GameStateService } from './game-state.service';
@@ -107,17 +107,19 @@ export class SeatRestorationService {
       state.players.push(restoredGamePlayerBase);
     }
 
-    this.playerReferenceRemapper.remapGameStatePlayerIdReferences(
-      state,
+    const seatReferencePlayerIds = new Set([
       comPlayerId,
+      seatData.roomPlayer.playerId,
+      seatData.gamePlayer?.playerId,
+    ]);
+    const remappedSeatReferences = this.remapSeatReferences(
+      state,
+      seatReferencePlayerIds,
       playerId,
     );
 
     gameState.registerPlayerToken(playerId, playerId);
     gameState.clearDisconnectTimeout(playerId);
-    if (state.teamAssignments[comPlayerId] != null) {
-      delete state.teamAssignments[comPlayerId];
-    }
     state.teamAssignments[playerId] = restoredRoomPlayer.team;
 
     delete vacantSeatsForRoom[seatIndex];
@@ -126,6 +128,101 @@ export class SeatRestorationService {
     }
 
     await gameState.persistRoster(room.players, room.hostId);
+    const persistedState = gameState.getState();
+    if (remappedSeatReferences) {
+      this.remapSeatReferences(
+        persistedState,
+        seatReferencePlayerIds,
+        playerId,
+      );
+      persistedState.teamAssignments[playerId] = restoredRoomPlayer.team;
+    }
+    const advancedBlowTurn =
+      this.advanceBlowTurnPastActedPlayer(persistedState);
+    if (remappedSeatReferences || advancedBlowTurn) {
+      await gameState.saveState();
+    }
     return true;
+  }
+
+  private remapSeatReferences(
+    state: GameState,
+    seatReferencePlayerIds: Set<string | undefined>,
+    playerId: string,
+  ): boolean {
+    let remapped = false;
+
+    seatReferencePlayerIds.forEach((fromPlayerId) => {
+      if (!fromPlayerId || fromPlayerId === playerId) {
+        return;
+      }
+
+      this.playerReferenceRemapper.remapGameStatePlayerIdReferences(
+        state,
+        fromPlayerId,
+        playerId,
+      );
+      if (state.teamAssignments[fromPlayerId] != null) {
+        delete state.teamAssignments[fromPlayerId];
+      }
+      remapped = true;
+    });
+
+    return remapped;
+  }
+
+  private advanceBlowTurnPastActedPlayer(state: GameState): boolean {
+    if (state.gamePhase !== 'blow' || state.players.length === 0) {
+      return false;
+    }
+
+    const currentIndex = this.resolveCurrentPlayerIndex(state);
+    const currentPlayer = state.players[currentIndex];
+    if (
+      !currentPlayer ||
+      !this.hasActedInBlow(state.blowState, currentPlayer)
+    ) {
+      return false;
+    }
+
+    for (let offset = 1; offset < state.players.length; offset += 1) {
+      const candidateIndex = (currentIndex + offset) % state.players.length;
+      const candidatePlayer = state.players[candidateIndex];
+      if (!this.hasActedInBlow(state.blowState, candidatePlayer)) {
+        state.currentPlayerIndex = candidateIndex;
+        state.currentPlayerId = candidatePlayer.playerId;
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private resolveCurrentPlayerIndex(state: GameState): number {
+    if (state.currentPlayerId) {
+      const index = state.players.findIndex(
+        (player) => player.playerId === state.currentPlayerId,
+      );
+      if (index !== -1) {
+        return index;
+      }
+    }
+
+    return Math.min(
+      Math.max(state.currentPlayerIndex ?? 0, 0),
+      state.players.length - 1,
+    );
+  }
+
+  private hasActedInBlow(blowState: BlowState, player: DomainPlayer): boolean {
+    return (
+      player.isPasser ||
+      blowState.declarations.some(
+        (declaration) => declaration.playerId === player.playerId,
+      ) ||
+      (blowState.actionHistory ?? []).some(
+        (action) => action.playerId === player.playerId,
+      )
+    );
   }
 }

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -27,6 +27,7 @@ import {
   GamePhase,
   TeamScores,
   Field,
+  CompletedField,
   Team,
 } from '../../types/game.types';
 import { ICardService } from '../../services/interfaces/card-service.interface';
@@ -3209,9 +3210,23 @@ describe('Game Use Cases', () => {
           team: 1 as const,
           isPasser: false,
         },
+        {
+          playerId: 'player-3',
+          name: 'Player 3',
+          hand: [],
+          team: 0 as const,
+          isPasser: false,
+        },
+        {
+          playerId: 'player-4',
+          name: 'Player 4',
+          hand: [],
+          team: 1 as const,
+          isPasser: false,
+        },
       ] as DomainPlayer[],
       playState: {
-        fields: [] as Field[],
+        fields: [] as CompletedField[],
         currentField: {
           cards: [],
           playedBy: [],
@@ -3258,7 +3273,7 @@ describe('Game Use Cases', () => {
       );
 
       const state = buildState();
-      state.playState.fields = [{ winnerTeam: 0 } as unknown as Field];
+      state.playState.fields = [{ winnerTeam: 0 } as unknown as CompletedField];
       const completeFieldMock = jest.fn(() => ({
         cards: ['A', 'B', 'C', 'D'],
         winnerId: 'player-1',
@@ -3302,6 +3317,174 @@ describe('Game Use Cases', () => {
         result.events?.find((e) => e.event === 'update-turn'),
       ).toBeDefined();
       expect(result.gameOver).toBeUndefined();
+    });
+
+    it('rejects completing a field when cards and playedBy are not aligned', async () => {
+      const roomService = createRoomServiceMock();
+      const playService = createPlayServiceMock('player-1');
+      const scoreService = createScoreServiceMock(2);
+      const useCase = new CompleteFieldUseCase(
+        roomService,
+        playService,
+        scoreService,
+      );
+
+      const state = buildState();
+      const completeFieldMock = jest.fn();
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        completeField: completeFieldMock,
+      } as unknown as GameStateService;
+
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const result = await useCase.execute({
+        roomId: 'room-1',
+        field: {
+          cards: ['A', 'B', 'C', 'D'],
+          playedBy: ['player-1', 'player-2', 'player-3'],
+          baseCard: 'A',
+          dealerId: 'player-1',
+          isComplete: true,
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Field card/player attribution mismatch');
+      expect(playService.determineFieldWinner).not.toHaveBeenCalled();
+      expect(completeFieldMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects completing a stale field that differs from current field attribution', async () => {
+      const roomService = createRoomServiceMock();
+      const playService = createPlayServiceMock('player-1');
+      const scoreService = createScoreServiceMock(2);
+      const useCase = new CompleteFieldUseCase(
+        roomService,
+        playService,
+        scoreService,
+      );
+
+      const state = buildState();
+      state.playState.currentField = {
+        cards: ['A', 'B', 'C', 'D'],
+        playedBy: ['player-1', 'player-2', 'player-3', 'player-4'],
+        baseCard: 'A',
+        dealerId: 'player-1',
+        isComplete: true,
+      };
+
+      const completeFieldMock = jest.fn();
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        completeField: completeFieldMock,
+      } as unknown as GameStateService;
+
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const result = await useCase.execute({
+        roomId: 'room-1',
+        field: {
+          cards: ['A', 'B', 'C', 'D'],
+          playedBy: ['player-1', 'player-3', 'player-2', 'player-4'],
+          baseCard: 'A',
+          dealerId: 'player-1',
+          isComplete: true,
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        'Field completion request is stale or mismatched',
+      );
+      expect(playService.determineFieldWinner).not.toHaveBeenCalled();
+      expect(completeFieldMock).not.toHaveBeenCalled();
+    });
+
+    it('adds completed sets to the team of the player who actually won the field', async () => {
+      const roomService = createRoomServiceMock();
+      const playService = createPlayRulesService();
+      const scoreService = createScoreServiceMock(2);
+      const useCase = new CompleteFieldUseCase(
+        roomService,
+        playService,
+        scoreService,
+      );
+
+      const state = buildState();
+      state.players.forEach((player) => {
+        player.hand = [];
+      });
+      state.blowState.currentHighestDeclaration = {
+        ...state.blowState.currentHighestDeclaration,
+        playerId: 'player-2',
+        team: 1,
+      };
+
+      const field: Field = {
+        cards: ['5♣', 'A♣', '6♣', 'K♣'],
+        playedBy: ['player-1', 'player-3', 'player-2', 'player-4'],
+        baseCard: '5♣',
+        dealerId: 'player-1',
+        isComplete: true,
+      };
+      state.playState.currentField = {
+        ...field,
+        cards: [...field.cards],
+        playedBy: [...field.playedBy],
+      };
+
+      const roomGameState = {
+        getState: jest.fn(() => state),
+        completeField: jest.fn((completedField: Field, winnerId: string) => {
+          const winner = state.players.find(
+            (player) => player.playerId === winnerId,
+          );
+          if (!winner) {
+            return null;
+          }
+          const persistedField = {
+            cards: [...completedField.cards],
+            winnerId,
+            winnerTeam: winner.team,
+            dealerId: completedField.dealerId,
+          };
+          state.playState.fields.push(persistedField);
+          return persistedField;
+        }),
+        saveState: jest.fn(),
+        resetRoundState: jest.fn(async () => {}),
+        transitionPhase: jest.fn(async () => {}),
+        updateState: jest.fn(async (updates) => {
+          Object.assign(state, updates);
+        }),
+      } as unknown as GameStateService;
+
+      roomService.getRoomGameState.mockResolvedValue(roomGameState);
+
+      const result = await useCase.execute({
+        roomId: 'room-1',
+        field,
+      });
+
+      expect(result.success).toBe(true);
+      expect(roomGameState.completeField).toHaveBeenCalledWith(
+        field,
+        'player-3',
+      );
+      expect(
+        result.events?.find((event) => event.event === 'field-complete')
+          ?.payload,
+      ).toEqual(
+        expect.objectContaining({
+          field: expect.objectContaining({
+            winnerId: 'player-3',
+            winnerTeam: 0,
+          }),
+          winnerId: 'player-3',
+        }),
+      );
+      expect(scoreService.calculatePlayPoints).toHaveBeenCalledWith(6, 0);
     });
 
     it('persists the next round number before starting the next round', async () => {
@@ -3366,7 +3549,7 @@ describe('Game Use Cases', () => {
       const state = buildState();
       state.players[0].hand = [];
       state.players[1].hand = [];
-      state.playState.fields = [{ winnerTeam: 0 } as unknown as Field];
+      state.playState.fields = [{ winnerTeam: 0 } as unknown as CompletedField];
 
       const roomGameState = {
         getState: jest.fn(() => state),
@@ -3421,7 +3604,7 @@ describe('Game Use Cases', () => {
       };
       state.players[0].hand = [];
       state.players[1].hand = [];
-      state.playState.fields = [{ winnerTeam: 1 } as unknown as Field];
+      state.playState.fields = [{ winnerTeam: 1 } as unknown as CompletedField];
 
       const roomGameState = {
         getState: jest.fn(() => state),
@@ -3478,7 +3661,7 @@ describe('Game Use Cases', () => {
       };
       state.players[0].hand = [];
       state.players[1].hand = [];
-      state.playState.fields = [{ winnerTeam: 1 } as unknown as Field];
+      state.playState.fields = [{ winnerTeam: 1 } as unknown as CompletedField];
 
       const roomGameState = {
         getState: jest.fn(() => state),
@@ -3534,7 +3717,7 @@ describe('Game Use Cases', () => {
       };
       state.players[0].hand = [];
       state.players[1].hand = [];
-      state.playState.fields = [{ winnerTeam: 0 } as unknown as Field];
+      state.playState.fields = [{ winnerTeam: 0 } as unknown as CompletedField];
 
       const roomGameState = {
         getState: jest.fn(() => state),

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -240,6 +240,47 @@ describe('Game Use Cases', () => {
       );
     });
 
+    it('returns the room seat id when it differs from the authenticated user id', async () => {
+      const roomService = createRoomServiceMock();
+      const useCase = new JoinRoomUseCase(roomService);
+      const joinedPlayer: RoomPlayer = {
+        ...basePlayers[0],
+        playerId: 'seat-1',
+        userId: 'user-1',
+        isAuthenticated: true,
+      };
+      const room: Room = {
+        ...baseRoom,
+        hostId: 'seat-1',
+        players: [joinedPlayer, basePlayers[1]],
+      };
+      roomService.joinRoom.mockResolvedValue(true);
+      roomService.getRoom.mockResolvedValue(room);
+      roomService.listRooms.mockResolvedValue([room]);
+      roomService.getRoomGameState.mockResolvedValue({
+        getState: jest.fn(() => ({ players: [], gamePhase: null })),
+      } as unknown as GameStateService);
+
+      const result = await useCase.execute({
+        socketId: 'socket-1',
+        targetRoomId: room.id,
+        user: {
+          socketId: 'socket-1',
+          playerId: 'user-1',
+          userId: 'user-1',
+          name: 'Player 1',
+        },
+        authenticatedUser: {
+          id: 'user-1',
+          email: 'user@example.com',
+        } as AuthenticatedUser,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.normalizedUser?.playerId).toBe('seat-1');
+      expect(result.data?.isHost).toBe(true);
+    });
+
     it('returns failure when repository join fails', async () => {
       const roomService = createRoomServiceMock();
       const useCase = new JoinRoomUseCase(roomService);

--- a/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
@@ -217,6 +217,13 @@ describe('ReconnectionUseCase', () => {
       'socket-1',
       'user-1',
     );
+    expect(gameState.upsertSessionUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        socketId: 'socket-1',
+        playerId: 'seat-1',
+        userId: 'user-1',
+      }),
+    );
   });
 
   it('builds an active-game snapshot without reconnecting or mutating state', async () => {

--- a/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
@@ -552,6 +552,89 @@ describe('ReconnectionUseCase', () => {
     );
   });
 
+  it('prefers the unique authenticated room seat over a stale waiting-room session', async () => {
+    const roomPlayers = [
+      {
+        playerId: 'seat-1',
+        socketId: 'stale-socket',
+        userId: 'user-1',
+        isAuthenticated: true,
+        name: 'User 1',
+        hand: [],
+        team: 0 as const,
+        isReady: true,
+        isHost: true,
+        isPasser: false,
+        joinedAt: new Date(),
+      },
+      {
+        playerId: 'seat-2',
+        socketId: 'other-socket',
+        userId: 'user-2',
+        isAuthenticated: true,
+        name: 'User 2',
+        hand: [],
+        team: 1 as const,
+        isReady: true,
+        isHost: false,
+        isPasser: false,
+        joinedAt: new Date(),
+      },
+    ];
+    const roomGameState = {
+      findSessionUserByUserId: jest.fn().mockReturnValue({
+        playerId: 'seat-2',
+      }),
+      findSessionUserByPlayerId: jest.fn().mockReturnValue(null),
+      reconcileWaitingRoomPlayers: jest.fn().mockResolvedValue(undefined),
+      getState: () => ({ players: [], gamePhase: 'waiting' }),
+    };
+    const roomService = {
+      getRoomGameState: jest.fn().mockResolvedValue(roomGameState),
+      getRoom: jest.fn().mockResolvedValue({
+        id: 'room-1',
+        hostId: 'seat-1',
+        status: RoomStatus.WAITING,
+        players: roomPlayers,
+      }),
+      handlePlayerReconnection: jest.fn().mockResolvedValue({ success: true }),
+      listRooms: jest.fn().mockResolvedValue([]),
+      initCOMPlaceholders: jest.fn().mockResolvedValue(undefined),
+    } as Partial<IRoomService> as IRoomService;
+    const gameState = {
+      upsertSessionUser: jest.fn(),
+    } as Partial<IGameStateService> as IGameStateService;
+    const useCase = new ReconnectionUseCase(
+      roomService,
+      gameState,
+      createRoomMembershipService(),
+    );
+
+    const result = await useCase.execute({
+      roomId: 'room-1',
+      socketId: 'socket-new',
+      authenticatedUser: {
+        id: 'user-1',
+        email: 'user@example.com',
+        profile: {} as UserProfile,
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        mode: 'waiting-room',
+        selfPlayerId: 'seat-1',
+      }),
+    );
+    expect(roomService.handlePlayerReconnection).toHaveBeenCalledWith(
+      'room-1',
+      'seat-1',
+      'socket-new',
+      'user-1',
+    );
+  });
+
   it('rejects a stale room reconnect when membership belongs to another room', async () => {
     const roomGameState = {
       getState: jest.fn(() => ({

--- a/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
@@ -343,6 +343,103 @@ describe('ReconnectionUseCase', () => {
     expect(gameState.upsertSessionUser).not.toHaveBeenCalled();
   });
 
+  it('prefers currentPlayerId over a stale currentPlayerIndex in active snapshots', async () => {
+    const roomGameState = {
+      findPlayerByActorId: jest.fn().mockReturnValue(null),
+      getState: () => ({
+        players: [
+          {
+            playerId: 'seat-1',
+            name: 'User 1',
+            team: 0,
+            hand: ['A♠'],
+            isPasser: false,
+            hasBroken: false,
+            hasRequiredBroken: false,
+          },
+          {
+            playerId: 'player-2',
+            name: 'User 2',
+            team: 1,
+            hand: ['K♠'],
+            isPasser: false,
+            hasBroken: false,
+            hasRequiredBroken: false,
+          },
+        ],
+        gamePhase: 'blow',
+        currentPlayerId: 'seat-1',
+        currentPlayerIndex: 1,
+        blowState: {
+          declarations: [],
+          actionHistory: [],
+          currentTrump: null,
+          currentHighestDeclaration: null,
+          lastPasser: null,
+          isRoundCancelled: false,
+          currentBlowIndex: 0,
+        },
+        playState: {
+          currentField: null,
+          negriCard: null,
+          neguri: {},
+          fields: [],
+          lastWinnerId: null,
+          openDeclared: false,
+          openDeclarerId: null,
+        },
+        teamScores: { 0: { play: 0, total: 0 }, 1: { play: 0, total: 0 } },
+        pointsToWin: 10,
+      }),
+    };
+    const roomService = {
+      getRoomGameState: jest.fn().mockResolvedValue(roomGameState),
+      getRoom: jest.fn().mockResolvedValue({
+        id: 'room-1',
+        hostId: 'seat-1',
+        status: RoomStatus.PLAYING,
+        settings: { teamNames: undefined },
+        players: [
+          {
+            playerId: 'seat-1',
+            socketId: 'socket-1',
+            userId: 'user-1',
+            isAuthenticated: true,
+            name: 'User 1',
+            hand: ['A♠'],
+            team: 0,
+            isReady: true,
+            isHost: true,
+            isPasser: false,
+            joinedAt: new Date(),
+          },
+        ],
+      }),
+      handlePlayerReconnection: jest.fn(),
+      listRooms: jest.fn(),
+    } as Partial<IRoomService> as IRoomService;
+    const gameState = {
+      upsertSessionUser: jest.fn(),
+    } as Partial<IGameStateService> as IGameStateService;
+    const useCase = new ReconnectionUseCase(
+      roomService,
+      gameState,
+      createRoomMembershipService(),
+    );
+
+    const snapshot = await useCase.getActiveGameSnapshot({
+      roomId: 'room-1',
+      authenticatedUser: {
+        id: 'user-1',
+        email: 'user@example.com',
+        profile: {} as UserProfile,
+      },
+    });
+
+    expect(snapshot?.currentTurnPlayerId).toBe('seat-1');
+    expect(snapshot?.gameState.currentTurn).toBe('seat-1');
+  });
+
   it('reconciles persisted players before reconnecting to a waiting room', async () => {
     const roomPlayers = [
       {

--- a/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
@@ -164,6 +164,7 @@ describe('UpdateAuthUseCase', () => {
     expect(gameState.upsertSessionUser).toHaveBeenCalledWith(
       expect.objectContaining({
         socketId: 'socket-1',
+        playerId: 'player-1',
         name: 'User Display',
         userId: 'user-1',
         isAuthenticated: true,

--- a/mei-tra-backend/src/use-cases/complete-field.use-case.ts
+++ b/mei-tra-backend/src/use-cases/complete-field.use-case.ts
@@ -17,7 +17,7 @@ import { IGameEventLogService } from '../services/interfaces/game-event-log.serv
 import { IPlayService } from '../services/interfaces/play-service.interface';
 import { IScoreService } from '../services/interfaces/score-service.interface';
 import { GatewayEvent } from './interfaces/gateway-event.interface';
-import { Team, GameState } from '../types/game.types';
+import { Team, GameState, Field } from '../types/game.types';
 import { GameStateService } from '../services/game-state.service';
 import { RoomStatus } from '../types/room.types';
 import {
@@ -43,6 +43,11 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
       const { roomId, field } = request;
       const roomGameState = await this.roomService.getRoomGameState(roomId);
       const state = roomGameState.getState();
+
+      const fieldValidationError = this.validateFieldAttribution(state, field);
+      if (fieldValidationError) {
+        return { success: false, error: fieldValidationError };
+      }
 
       const winner = this.playService.determineFieldWinner(
         field,
@@ -234,6 +239,51 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
     state.players.forEach((player) => {
       player.hand = player.hand.filter((card) => !cards.includes(card));
     });
+  }
+
+  private validateFieldAttribution(
+    state: GameState,
+    field: Field,
+  ): string | null {
+    if (field.cards.length !== field.playedBy.length) {
+      return 'Field card/player attribution mismatch';
+    }
+
+    if (field.cards.length !== 4) {
+      return 'Field is not complete';
+    }
+
+    const playerIds = new Set(state.players.map((player) => player.playerId));
+    if (field.playedBy.some((playerId) => !playerIds.has(playerId))) {
+      return 'Field contains unknown player attribution';
+    }
+
+    if (new Set(field.playedBy).size !== field.playedBy.length) {
+      return 'Field contains duplicate player attribution';
+    }
+
+    const currentField = state.playState?.currentField;
+    if (currentField && currentField.cards.length > 0) {
+      const isSameField =
+        this.isSameSequence(currentField.cards, field.cards) &&
+        this.isSameSequence(currentField.playedBy, field.playedBy) &&
+        currentField.dealerId === field.dealerId &&
+        currentField.baseCard === field.baseCard &&
+        currentField.baseSuit === field.baseSuit;
+
+      if (!isSameField) {
+        return 'Field completion request is stale or mismatched';
+      }
+    }
+
+    return null;
+  }
+
+  private isSameSequence(left: string[], right: string[]): boolean {
+    return (
+      left.length === right.length &&
+      left.every((value, index) => value === right[index])
+    );
   }
 
   private setNextDealer(state: GameState, playerId: string) {

--- a/mei-tra-backend/src/use-cases/join-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/join-room.use-case.ts
@@ -5,6 +5,7 @@ import {
   JoinRoomRequest,
   JoinRoomResponse,
   JoinRoomSuccess,
+  PreviousRoomNotification,
   ResumeGamePayload,
 } from './interfaces/join-room.use-case.interface';
 import { AuthenticatedUser } from '../types/user.types';
@@ -25,6 +26,11 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
       const { currentRoomId, targetRoomId, user, authenticatedUser } = request;
 
       const normalizedUser = this.normalizeUser(user, authenticatedUser);
+      const previousRoomNotification =
+        await this.buildPreviousRoomNotification(
+          currentRoomId,
+          normalizedUser,
+        );
 
       const joinSucceeded = await this.roomService.joinRoom(
         targetRoomId,
@@ -38,12 +44,7 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
           success: false,
           errorMessage: 'Failed to join room',
           normalizedUser,
-          previousRoomNotification: currentRoomId
-            ? {
-                roomId: currentRoomId,
-                playerId: normalizedUser.playerId,
-              }
-            : undefined,
+          previousRoomNotification,
         };
       }
 
@@ -59,9 +60,12 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
         };
       }
 
+      const joinedPlayer = this.resolveJoinedRoomPlayer(room, normalizedUser);
       const data: JoinRoomSuccess = {
         room,
-        isHost: room.hostId === normalizedUser.playerId,
+        isHost: joinedPlayer
+          ? room.hostId === joinedPlayer.playerId
+          : room.hostId === normalizedUser.playerId,
         roomStatus: room.status,
         roomsList: await this.roomService.listRooms(),
         resumeGame: await this.buildResumePayloadIfNeeded(room.id, room),
@@ -70,12 +74,7 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
       return {
         success: true,
         normalizedUser,
-        previousRoomNotification: currentRoomId
-          ? {
-              roomId: currentRoomId,
-              playerId: normalizedUser.playerId,
-            }
-          : undefined,
+        previousRoomNotification,
         data,
       };
     } catch (error) {
@@ -112,6 +111,45 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
       name: displayName || user.name,
       userId: authenticatedUser.id,
       isAuthenticated: true,
+    };
+  }
+
+  private resolveJoinedRoomPlayer(
+    room: JoinRoomSuccess['room'],
+    normalizedUser: SessionUser,
+  ) {
+    if (normalizedUser.userId) {
+      const playerByUserId = room.players.find(
+        (player) => !player.isCOM && player.userId === normalizedUser.userId,
+      );
+      if (playerByUserId) {
+        return playerByUserId;
+      }
+    }
+
+    return (
+      room.players.find(
+        (player) => player.playerId === normalizedUser.playerId,
+      ) ?? null
+    );
+  }
+
+  private async buildPreviousRoomNotification(
+    currentRoomId: string | undefined,
+    normalizedUser: SessionUser,
+  ): Promise<PreviousRoomNotification | undefined> {
+    if (!currentRoomId) {
+      return undefined;
+    }
+
+    const currentRoom = await this.roomService.getRoom(currentRoomId);
+    const currentRoomPlayer = currentRoom
+      ? this.resolveJoinedRoomPlayer(currentRoom, normalizedUser)
+      : null;
+
+    return {
+      roomId: currentRoomId,
+      playerId: currentRoomPlayer?.playerId ?? normalizedUser.playerId,
     };
   }
 

--- a/mei-tra-backend/src/use-cases/join-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/join-room.use-case.ts
@@ -26,11 +26,10 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
       const { currentRoomId, targetRoomId, user, authenticatedUser } = request;
 
       const normalizedUser = this.normalizeUser(user, authenticatedUser);
-      const previousRoomNotification =
-        await this.buildPreviousRoomNotification(
-          currentRoomId,
-          normalizedUser,
-        );
+      const previousRoomNotification = await this.buildPreviousRoomNotification(
+        currentRoomId,
+        normalizedUser,
+      );
 
       const joinSucceeded = await this.roomService.joinRoom(
         targetRoomId,
@@ -137,6 +136,9 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
       );
       if (playersByUserId.length === 1) {
         return playersByUserId[0];
+      }
+      if (playersByUserId.length > 1) {
+        return null;
       }
     }
 

--- a/mei-tra-backend/src/use-cases/join-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/join-room.use-case.ts
@@ -61,11 +61,24 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
       }
 
       const joinedPlayer = this.resolveJoinedRoomPlayer(room, normalizedUser);
+      if (!joinedPlayer) {
+        this.logger.error(
+          `Joined player could not be resolved for user ${normalizedUser.userId ?? normalizedUser.playerId} in room ${targetRoomId}`,
+        );
+        return {
+          success: false,
+          errorMessage: 'Failed to resolve joined player',
+          normalizedUser,
+          previousRoomNotification,
+        };
+      }
+      const resolvedUser: SessionUser = {
+        ...normalizedUser,
+        playerId: joinedPlayer.playerId,
+      };
       const data: JoinRoomSuccess = {
         room,
-        isHost: joinedPlayer
-          ? room.hostId === joinedPlayer.playerId
-          : room.hostId === normalizedUser.playerId,
+        isHost: room.hostId === joinedPlayer.playerId,
         roomStatus: room.status,
         roomsList: await this.roomService.listRooms(),
         resumeGame: await this.buildResumePayloadIfNeeded(room.id, room),
@@ -73,7 +86,7 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
 
       return {
         success: true,
-        normalizedUser,
+        normalizedUser: resolvedUser,
         previousRoomNotification,
         data,
       };
@@ -119,11 +132,11 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
     normalizedUser: SessionUser,
   ) {
     if (normalizedUser.userId) {
-      const playerByUserId = room.players.find(
+      const playersByUserId = room.players.filter(
         (player) => !player.isCOM && player.userId === normalizedUser.userId,
       );
-      if (playerByUserId) {
-        return playerByUserId;
+      if (playersByUserId.length === 1) {
+        return playersByUserId[0];
       }
     }
 

--- a/mei-tra-backend/src/use-cases/reconnection.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reconnection.use-case.ts
@@ -350,8 +350,8 @@ export class ReconnectionUseCase {
         ? state.currentPlayerId
         : state.currentPlayerIndex !== -1 &&
             state.players[state.currentPlayerIndex]
-        ? state.players[state.currentPlayerIndex].playerId
-        : null;
+          ? state.players[state.currentPlayerIndex].playerId
+          : null;
 
     return {
       selfPlayerId: player.playerId,
@@ -431,6 +431,16 @@ export class ReconnectionUseCase {
     roomPlayers: RoomPlayer[],
     authenticatedUserId: string,
   ): RoomPlayer | null {
+    const authenticatedMatches = roomPlayers.filter(
+      (player) => !player.isCOM && player.userId === authenticatedUserId,
+    );
+    if (authenticatedMatches.length === 1) {
+      return authenticatedMatches[0];
+    }
+    if (authenticatedMatches.length > 1) {
+      return null;
+    }
+
     const sessionUser =
       roomGameState.findSessionUserByUserId(authenticatedUserId) ??
       roomGameState.findSessionUserByPlayerId(authenticatedUserId);
@@ -445,12 +455,7 @@ export class ReconnectionUseCase {
       }
     }
 
-    const authenticatedMatches = roomPlayers.filter(
-      (player) =>
-        !player.isCOM && player.userId === authenticatedUserId,
-    );
-
-    return authenticatedMatches.length === 1 ? authenticatedMatches[0] : null;
+    return null;
   }
 
   private resolveAuthenticatedRoomPlayer(
@@ -458,8 +463,7 @@ export class ReconnectionUseCase {
     authenticatedUserId: string,
   ): RoomPlayer | null {
     const matches = roomPlayers.filter(
-      (player) =>
-        !player.isCOM && player.userId === authenticatedUserId,
+      (player) => !player.isCOM && player.userId === authenticatedUserId,
     );
 
     return matches.length === 1 ? matches[0] : null;

--- a/mei-tra-backend/src/use-cases/reconnection.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reconnection.use-case.ts
@@ -337,7 +337,11 @@ export class ReconnectionUseCase {
   ): ActiveGameSnapshot {
     const state = roomGameState.getState();
     const currentTurnPlayerId =
-      state.currentPlayerIndex !== -1 && state.players[state.currentPlayerIndex]
+      state.currentPlayerId &&
+      state.players.some((player) => player.playerId === state.currentPlayerId)
+        ? state.currentPlayerId
+        : state.currentPlayerIndex !== -1 &&
+            state.players[state.currentPlayerIndex]
         ? state.players[state.currentPlayerIndex].playerId
         : null;
 

--- a/mei-tra-backend/src/use-cases/reconnection.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reconnection.use-case.ts
@@ -169,7 +169,11 @@ export class ReconnectionUseCase {
           };
         }
 
-        this.syncGlobalConnectionUser(socketId, authenticatedUser);
+        this.syncGlobalConnectionUser(
+          socketId,
+          authenticatedUser,
+          existingWaitingPlayer.playerId,
+        );
 
         return {
           success: true,
@@ -236,7 +240,11 @@ export class ReconnectionUseCase {
         };
       }
 
-      this.syncGlobalConnectionUser(socketId, authenticatedUser);
+      this.syncGlobalConnectionUser(
+        socketId,
+        authenticatedUser,
+        existingPlayer.playerId,
+      );
 
       return {
         success: true,
@@ -376,6 +384,7 @@ export class ReconnectionUseCase {
   private syncGlobalConnectionUser(
     socketId: string,
     authenticatedUser: AuthenticatedUser,
+    playerId: string,
   ): void {
     const displayName =
       authenticatedUser.profile?.displayName ||
@@ -384,7 +393,7 @@ export class ReconnectionUseCase {
 
     this.gameState.upsertSessionUser({
       socketId,
-      playerId: authenticatedUser.id,
+      playerId,
       name: displayName,
       userId: authenticatedUser.id,
       isAuthenticated: true,
@@ -438,7 +447,7 @@ export class ReconnectionUseCase {
 
     const authenticatedMatches = roomPlayers.filter(
       (player) =>
-        player.isAuthenticated && player.userId === authenticatedUserId,
+        !player.isCOM && player.userId === authenticatedUserId,
     );
 
     return authenticatedMatches.length === 1 ? authenticatedMatches[0] : null;
@@ -450,7 +459,7 @@ export class ReconnectionUseCase {
   ): RoomPlayer | null {
     const matches = roomPlayers.filter(
       (player) =>
-        player.isAuthenticated && player.userId === authenticatedUserId,
+        !player.isCOM && player.userId === authenticatedUserId,
     );
 
     return matches.length === 1 ? matches[0] : null;

--- a/mei-tra-backend/src/use-cases/update-auth.use-case.ts
+++ b/mei-tra-backend/src/use-cases/update-auth.use-case.ts
@@ -136,21 +136,20 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
     const room = await this.roomService.getRoom(currentRoomId);
     const authenticatedRoomPlayers =
       room?.players.filter(
-        (player) =>
-          !player.isCOM && player.userId === authenticatedUser.id,
+        (player) => !player.isCOM && player.userId === authenticatedUser.id,
       ) ?? [];
     const roomPlayer =
       authenticatedRoomPlayers.length === 1
         ? authenticatedRoomPlayers[0]
         : null;
+    const roomStatePlayer = roomPlayer
+      ? (roomGameState
+          .getState()
+          .players.find((player) => player.playerId === roomPlayer.playerId) ??
+        null)
+      : null;
     const currentPlayer =
-      (roomPlayer
-        ? roomGameState
-            .getState()
-            .players.find(
-              (player) => player.playerId === roomPlayer.playerId,
-            ) ?? null
-        : null) ??
+      roomStatePlayer ??
       resolvePlayerByActorId(roomGameState, authenticatedUser.id) ??
       resolvePlayerBySocketId(roomGameState, socketId);
 

--- a/mei-tra-backend/src/use-cases/update-auth.use-case.ts
+++ b/mei-tra-backend/src/use-cases/update-auth.use-case.ts
@@ -41,16 +41,17 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
         return { success: false, error: 'Token validation failed' };
       }
 
+      const roomSync = await this.syncRoomPlayer(
+        request.currentRoomId,
+        request.socketId,
+        authenticatedUser,
+      );
+
       const { clientEvents, broadcastEvents } = this.ensureUserRegistered(
         request.socketId,
         authenticatedUser,
         request.handshakeName,
-      );
-
-      const roomEvents = await this.syncRoomPlayer(
-        request.currentRoomId,
-        request.socketId,
-        authenticatedUser,
+        roomSync?.playerId,
       );
 
       return {
@@ -58,7 +59,7 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
         authenticatedUser,
         clientEvents,
         broadcastEvents,
-        roomEvents,
+        roomEvents: roomSync?.events,
       };
     } catch (error) {
       this.logger.error('Unexpected error in UpdateAuthUseCase', error);
@@ -70,6 +71,7 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
     socketId: string,
     authenticatedUser: AuthenticatedUser,
     handshakeName?: string,
+    playerId?: string,
   ): {
     clientEvents: GatewayEvent[];
     broadcastEvents: GatewayEvent[];
@@ -95,7 +97,7 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
 
     const syncResult = this.gameState.upsertSessionUser({
       socketId,
-      playerId: authenticatedUser.id,
+      playerId: playerId ?? authenticatedUser.id,
       name: displayName,
       userId: authenticatedUser.id,
       isAuthenticated: true,
@@ -124,14 +126,31 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
     currentRoomId: string | undefined,
     socketId: string,
     authenticatedUser: AuthenticatedUser,
-  ): Promise<GatewayEvent[] | undefined> {
+  ): Promise<{ playerId: string; events: GatewayEvent[] } | undefined> {
     if (!currentRoomId) {
       return undefined;
     }
 
     const roomGameState =
       await this.roomService.getRoomGameState(currentRoomId);
+    const room = await this.roomService.getRoom(currentRoomId);
+    const authenticatedRoomPlayers =
+      room?.players.filter(
+        (player) =>
+          !player.isCOM && player.userId === authenticatedUser.id,
+      ) ?? [];
+    const roomPlayer =
+      authenticatedRoomPlayers.length === 1
+        ? authenticatedRoomPlayers[0]
+        : null;
     const currentPlayer =
+      (roomPlayer
+        ? roomGameState
+            .getState()
+            .players.find(
+              (player) => player.playerId === roomPlayer.playerId,
+            ) ?? null
+        : null) ??
       resolvePlayerByActorId(roomGameState, authenticatedUser.id) ??
       resolvePlayerBySocketId(roomGameState, socketId);
 
@@ -176,6 +195,6 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
       );
     }
 
-    return roomEvents;
+    return { playerId: currentPlayer.playerId, events: roomEvents };
   }
 }

--- a/mei-tra-frontend/__tests__/app/socket.test.ts
+++ b/mei-tra-frontend/__tests__/app/socket.test.ts
@@ -1,6 +1,7 @@
 import { io } from 'socket.io-client';
 import {
   disconnectSocket,
+  getExistingSocket,
   getSocket,
   setSocketAuthTokenProvider,
 } from '@/app/socket';
@@ -40,5 +41,23 @@ describe('game socket authentication', () => {
       roomId: 'room-1',
       token: 'fresh-token',
     });
+  });
+
+  it('reuses one browser socket across callers', () => {
+    const firstSocket = getSocket('first-token');
+    const secondSocket = getSocket('second-token');
+
+    expect(secondSocket).toBe(firstSocket);
+    expect(getExistingSocket()).toBe(firstSocket);
+    expect(mockedIo).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the browser socket when disconnected', () => {
+    const currentSocket = getSocket('token');
+
+    disconnectSocket();
+
+    expect(currentSocket.disconnect).toHaveBeenCalledTimes(1);
+    expect(getExistingSocket()).toBeNull();
   });
 });

--- a/mei-tra-frontend/__tests__/lib/playerIdentity.test.ts
+++ b/mei-tra-frontend/__tests__/lib/playerIdentity.test.ts
@@ -1,0 +1,39 @@
+import { resolveSelfPlayerId } from '@/lib/utils/playerIdentity';
+
+describe('resolveSelfPlayerId', () => {
+  const players = [
+    { playerId: 'seat-1', userId: 'user-1' },
+    { playerId: 'seat-2', userId: 'user-2' },
+  ];
+
+  it('prefers an authoritative server player id', () => {
+    expect(
+      resolveSelfPlayerId(players, {
+        userId: 'user-1',
+        serverPlayerId: 'seat-2',
+        fallbackPlayerId: 'stale-seat',
+      }),
+    ).toBe('seat-2');
+  });
+
+  it('resolves the seat from the authenticated user before a stale fallback', () => {
+    expect(
+      resolveSelfPlayerId(players, {
+        userId: 'user-1',
+        fallbackPlayerId: 'seat-2',
+      }),
+    ).toBe('seat-1');
+  });
+
+  it('does not guess from an ambiguous user mapping', () => {
+    expect(
+      resolveSelfPlayerId(
+        [
+          ...players,
+          { playerId: 'seat-3', userId: 'user-1' },
+        ],
+        { userId: 'user-1' },
+      ),
+    ).toBeNull();
+  });
+});

--- a/mei-tra-frontend/__tests__/lib/playerReferenceRemap.test.ts
+++ b/mei-tra-frontend/__tests__/lib/playerReferenceRemap.test.ts
@@ -100,4 +100,44 @@ describe('playerReferenceRemap', () => {
     expect(resolveBlowActionsForRoster(actions, players, replacements)[0])
       .toMatchObject({ playerId: 'new-lead' });
   });
+
+  it('resolves an orphan pass action to the only current roster passer without an action', () => {
+    const players = [
+      createPlayer('player-2', 0, { isPasser: true }),
+      createPlayer('host', 1),
+      createPlayer('com-2', 0, { isCOM: true }),
+      createPlayer('com-3', 1, { isCOM: true, isPasser: true }),
+    ];
+    const actions: BlowAction[] = [
+      {
+        type: 'declare',
+        playerId: 'com-2',
+        trumpType: 'zuppe',
+        numberOfPairs: 6,
+        timestamp: 1,
+      },
+      { type: 'pass', playerId: 'com-3', timestamp: 2 },
+      { type: 'pass', playerId: 'old-player-2', timestamp: 3 },
+    ];
+
+    expect(resolveBlowActionsForRoster(actions, players, new Map())).toEqual([
+      actions[0],
+      actions[1],
+      { type: 'pass', playerId: 'player-2', timestamp: 3 },
+    ]);
+  });
+
+  it('does not guess an orphan pass action when multiple passers are possible', () => {
+    const players = [
+      createPlayer('player-2', 0, { isPasser: true }),
+      createPlayer('host', 1, { isPasser: true }),
+    ];
+    const actions: BlowAction[] = [
+      { type: 'pass', playerId: 'old-player', timestamp: 1 },
+    ];
+
+    expect(resolveBlowActionsForRoster(actions, players, new Map())).toEqual(
+      actions,
+    );
+  });
 });

--- a/mei-tra-frontend/app/socket.ts
+++ b/mei-tra-frontend/app/socket.ts
@@ -5,6 +5,28 @@ let socket: Socket | null = null;
 let latestAuthToken: string | undefined;
 let authTokenProvider: (() => Promise<string | null>) | undefined;
 
+type WindowWithGameSocket = Window & {
+  __MEITRA_GAME_SOCKET__?: Socket;
+};
+
+function getWindowSocket(): Socket | null {
+  if (typeof window === 'undefined') return null;
+
+  return (window as WindowWithGameSocket).__MEITRA_GAME_SOCKET__ ?? null;
+}
+
+function setWindowSocket(nextSocket: Socket | null): void {
+  if (typeof window === 'undefined') return;
+
+  const gameWindow = window as WindowWithGameSocket;
+  if (nextSocket) {
+    gameWindow.__MEITRA_GAME_SOCKET__ = nextSocket;
+    return;
+  }
+
+  delete gameWindow.__MEITRA_GAME_SOCKET__;
+}
+
 export function setSocketAuthTokenProvider(
   provider: (() => Promise<string | null>) | undefined,
 ): void {
@@ -23,6 +45,7 @@ function detectSafari(): boolean {
 
 export function getSocket(authToken?: string): Socket {
   latestAuthToken = authToken ?? latestAuthToken;
+  socket = getWindowSocket() ?? socket;
 
   if (!socket && typeof window !== 'undefined') {
     const socketUrl = getSocketBaseUrl();
@@ -56,6 +79,7 @@ export function getSocket(authToken?: string): Socket {
     };
 
     socket = io(socketUrl, socketOptions);
+    setWindowSocket(socket);
 
     console.log('[Socket] Creating new connection to:', socketUrl);
     console.log('[Socket] Browser:', isSafari ? 'Safari/iOS' : 'Other');
@@ -87,14 +111,16 @@ export function getSocket(authToken?: string): Socket {
 }
 
 export function getExistingSocket(): Socket | null {
+  socket = getWindowSocket() ?? socket;
   return socket;
 }
 
 export function reconnectSocket(authToken?: string): Socket {
   latestAuthToken = authToken ?? latestAuthToken;
+  const existingSocket = getExistingSocket();
 
-  if (socket) {
-    socket.auth = async (cb: (data: { roomId: string; token?: string }) => void) => {
+  if (existingSocket) {
+    existingSocket.auth = async (cb: (data: { roomId: string; token?: string }) => void) => {
       const currentRoomId = sessionStorage.getItem('roomId') || '';
       console.log('[Socket] Reconnect auth callback — roomId from sessionStorage:', currentRoomId || 'none');
       if (authTokenProvider) {
@@ -102,9 +128,9 @@ export function reconnectSocket(authToken?: string): Socket {
       }
       cb({ roomId: currentRoomId, token: latestAuthToken });
     };
-    socket.disconnect();
-    socket.connect();
-    return socket;
+    existingSocket.disconnect();
+    existingSocket.connect();
+    return existingSocket;
   }
 
   const nextSocket = getSocket(authToken);
@@ -113,9 +139,9 @@ export function reconnectSocket(authToken?: string): Socket {
 }
 
 export function disconnectSocket(): void {
-  if (socket) {
-    socket.disconnect();
-    socket = null;
-  }
+  const existingSocket = getExistingSocket();
+  existingSocket?.disconnect();
+  socket = null;
+  setWindowSocket(null);
   latestAuthToken = undefined;
 }

--- a/mei-tra-frontend/components/game/BlowControls/index.tsx
+++ b/mei-tra-frontend/components/game/BlowControls/index.tsx
@@ -288,17 +288,17 @@ export function BlowControls({
           <div className={styles.declarationList}>
             {chronologicalDeclarations.map((entry, index) => {
               const player = playerMap.get(entry.playerId);
-              if (!player) return null;
+              const playerName = player?.name ?? entry.playerId;
 
               if (entry.type === 'pass') {
                 return (
                   <div
                     key={`pass-${entry.playerId}-${index}`}
                     className={`${styles.declarationItem} ${styles.pass}`}
-                    title={`${player.name}: ${t('passed')}`}
+                    title={`${playerName}: ${t('passed')}`}
                   >
                     <span className={styles.declarationPlayerName}>
-                      {player.name}
+                      {playerName}
                     </span>
                     <span className={styles.declarationSeparator}>:</span>
                     <span className={styles.declarationText}>
@@ -319,10 +319,10 @@ export function BlowControls({
                 <div
                   key={`${entry.playerId}-${entry.timestamp}`}
                   className={getDeclarationItemClassName(declaration)}
-                  title={`${player.name}: ${entry.trumpType ? t(entry.trumpType) : ''} ${formatSetOption(declaration.numberOfPairs)}`}
+                  title={`${playerName}: ${entry.trumpType ? t(entry.trumpType) : ''} ${formatSetOption(declaration.numberOfPairs)}`}
                 >
                   <span className={styles.declarationPlayerName}>
-                    {player.name}
+                    {playerName}
                   </span>
                   <span className={styles.declarationSeparator}>:</span>
                   <span className={styles.declarationText}>

--- a/mei-tra-frontend/components/game/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/game/PlayerHand/index.module.scss
@@ -412,13 +412,21 @@
 
 
 .disconnectedBadge {
+  display: block;
+  width: 100%;
+  max-width: 6.75rem;
   font-size: typography.scale(0.72rem);
-  color: var(--mt-warning);
-  background: var(--mt-surface-raised);
-  padding: 0.15rem 0.45rem;
+  color: var(--mt-warning-contrast, var(--mt-text-primary));
+  background: color-mix(in srgb, var(--mt-warning) 34%, var(--mt-surface-raised));
+  border: 1px solid color-mix(in srgb, var(--mt-warning) 70%, var(--mt-border-hairline));
+  padding: 0.1rem 0.34rem;
   border-radius: 999px;
-  font-weight: 700;
-  line-height: 1.3;
+  font-weight: 800;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
 }
 
 .replaceWithComButton {
@@ -941,6 +949,12 @@
     padding: 0.1rem 0.14rem;
     border-radius: var(--mt-radius);
     border: 1px solid var(--mt-border-hairline);
+  }
+
+  .disconnectedBadge {
+    font-size: typography.scale(0.58rem);
+    padding: 0.08rem 0.2rem;
+    max-width: 5.8rem;
   }
 
   .teamBadge {

--- a/mei-tra-frontend/components/game/PlayerHand/index.tsx
+++ b/mei-tra-frontend/components/game/PlayerHand/index.tsx
@@ -416,6 +416,14 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
           </span>
         </div>
       )}
+      {gamePhase && isDisconnected && !player.isCOM && (
+        <span
+          className={styles.disconnectedBadge}
+          title={tStatus('disconnectedNotice', { playerName: player.name })}
+        >
+          {tStatus('reconnecting')}
+        </span>
+      )}
       {gamePhase === 'blow' && canActAsCurrentPlayer && player.hasBroken && (
         <button
           className={styles.brokenButton}

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -279,27 +279,37 @@ export const useGame = () => {
     [],
   );
 
-  const syncCurrentPlayerIdentity = useCallback((
-    nextPlayers: Player[],
+  const resolveCurrentUserPlayerId = useCallback(<T extends { playerId: string; userId?: string }>(
+    nextPlayers: T[],
     fallbackPlayerId?: string | null,
-  ) => {
+  ): string | null => {
+    if (user?.id) {
+      const selfByUserId = nextPlayers.find((player) => player.userId === user.id);
+      if (selfByUserId) {
+        return selfByUserId.playerId;
+      }
+    }
+
     const selfByPlayerId =
       (fallbackPlayerId &&
         nextPlayers.find((player) => player.playerId === fallbackPlayerId)) ||
       null;
 
-    if (selfByPlayerId) {
-      setCurrentPlayerId(selfByPlayerId.playerId);
-      return;
-    }
-
-    if (user?.id) {
-      const selfByUserId = nextPlayers.find((player) => player.userId === user.id);
-      if (selfByUserId) {
-        setCurrentPlayerId(selfByUserId.playerId);
-      }
-    }
+    return selfByPlayerId?.playerId ?? null;
   }, [user?.id]);
+
+  const syncCurrentPlayerIdentity = useCallback((
+    nextPlayers: Player[],
+    fallbackPlayerId?: string | null,
+  ) => {
+    const nextCurrentPlayerId = resolveCurrentUserPlayerId(
+      nextPlayers,
+      fallbackPlayerId,
+    );
+    if (nextCurrentPlayerId) {
+      setCurrentPlayerId(nextCurrentPlayerId);
+    }
+  }, [resolveCurrentUserPlayerId]);
 
   const updatePlayersLocally = useCallback((
     updater: (previousPlayers: Player[]) => Player[],
@@ -551,11 +561,10 @@ export const useGame = () => {
         if (shouldSkipLegacyRoomUpdated(nextRoom.id)) {
           return;
         }
-        const selfPlayerId =
-          currentPlayerId ??
-          nextRoom.players.find((player) => player.userId === user?.id)
-            ?.playerId ??
-          null;
+        const selfPlayerId = resolveCurrentUserPlayerId(
+          nextRoom.players,
+          currentPlayerId,
+        );
         const isCurrentRoom =
           nextRoom.id === currentRoomId ||
           Boolean(
@@ -583,11 +592,10 @@ export const useGame = () => {
         const { room: nextRoom, players: nextPlayers } =
           fromRoomSyncPayload(payload);
         markRoomSyncHandled(nextRoom.id);
-        const selfPlayerId =
-          currentPlayerId ??
-          nextRoom.players.find((player) => player.userId === user?.id)
-            ?.playerId ??
-          null;
+        const selfPlayerId = resolveCurrentUserPlayerId(
+          nextRoom.players,
+          currentPlayerId,
+        );
         const isCurrentRoom =
           nextRoom.id === currentRoomId ||
           Boolean(
@@ -1227,6 +1235,7 @@ export const useGame = () => {
     negriPlayerId,
     markRoomSyncHandled,
     commitPlayers,
+    resolveCurrentUserPlayerId,
     updatePlayersLocally,
     syncCurrentPlayerIdentity,
     shouldSkipLegacyRoomUpdated,

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -975,10 +975,11 @@ export const useGame = () => {
         setRevealedAgari(null);
         setNegriCard(negriCard);
         setNegriPlayerId(startingPlayer);
+        const selfPlayerId = getCurrentUserPlayerId();
         // Remove Negri card from player's hand
         updatePlayersLocally((prev) =>
           prev.map((p) =>
-            p.playerId === currentPlayerId
+            p.playerId === selfPlayerId
               ? { ...p, hand: p.hand.filter((card) => card !== negriCard) }
               : p,
           ),
@@ -1231,6 +1232,7 @@ export const useGame = () => {
     markRoomSyncHandled,
     commitPlayers,
     resolveCurrentUserPlayerId,
+    getCurrentUserPlayerId,
     updatePlayersLocally,
     syncCurrentPlayerIdentity,
     shouldSkipLegacyRoomUpdated,

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -311,6 +311,11 @@ export const useGame = () => {
     }
   }, [resolveCurrentUserPlayerId]);
 
+  const getCurrentUserPlayerId = useCallback(
+    () => resolveCurrentUserPlayerId(playersRef.current, currentPlayerId),
+    [currentPlayerId, resolveCurrentUserPlayerId],
+  );
+
   const updatePlayersLocally = useCallback((
     updater: (previousPlayers: Player[]) => Player[],
   ) => {
@@ -765,27 +770,17 @@ export const useGame = () => {
         resetBlowState({ preservePlayers: true });
         commitPlayers(nextPlayers);
         syncDisconnectedPlayerIdsFromPlayers(nextPlayers);
-        syncCurrentPlayerIdentity(nextPlayers, currentPlayerId);
-
-        // Identify self by playerId (stable across reconnections), not socket.id
-        const index = nextPlayers.findIndex(
-          (player) => player.playerId === currentPlayerId,
+        const selfPlayerId = resolveCurrentUserPlayerId(
+          nextPlayers,
+          currentPlayerId,
         );
-        if (index !== -1) {
-          setCurrentPlayerId(nextPlayers[index].playerId);
-        } else {
-          // Fallback: match by userId for authenticated users
-          console.error('[useGame] Player not found in game-started by playerId', { currentPlayerId });
-          const userIndex = nextPlayers.findIndex(
-            (p) =>
-              p.userId &&
-              usersRef.current.find(
-                (u) => u.userId === p.userId && u.playerId === currentPlayerId,
-              ),
-          );
-          if (userIndex !== -1) {
-            setCurrentPlayerId(nextPlayers[userIndex].playerId);
-          }
+        if (selfPlayerId) {
+          setCurrentPlayerId(selfPlayerId);
+        } else if (currentPlayerId) {
+          console.error('[useGame] Player not found in game-started', {
+            currentPlayerId,
+            userId: user?.id,
+          });
         }
 
         setCurrentRoomId(roomId);
@@ -1250,43 +1245,48 @@ export const useGame = () => {
   ]);
 
   const startGame = () => {
-    if (!currentRoomId || !currentPlayerId) return;
-    socket?.emit('start-game', { roomId: currentRoomId, playerId: currentPlayerId });
+    const selfPlayerId = getCurrentUserPlayerId();
+    if (!currentRoomId || !selfPlayerId) return;
+    socket?.emit('start-game', { roomId: currentRoomId, playerId: selfPlayerId });
   };
 
   const removePlayerFromRoom = (targetPlayerId: string) => {
-    if (!socket || !currentRoomId || !currentPlayerId) return;
+    const selfPlayerId = getCurrentUserPlayerId();
+    if (!socket || !currentRoomId || !selfPlayerId) return;
     socket.emit('moderate-player', {
       roomId: currentRoomId,
-      requesterPlayerId: currentPlayerId,
+      requesterPlayerId: selfPlayerId,
       targetPlayerId,
       action: 'remove',
     });
   };
 
   const replacePlayerWithCOM = (targetPlayerId: string) => {
-    if (!socket || !currentRoomId || !currentPlayerId) return;
+    const selfPlayerId = getCurrentUserPlayerId();
+    if (!socket || !currentRoomId || !selfPlayerId) return;
     socket.emit('moderate-player', {
       roomId: currentRoomId,
-      requesterPlayerId: currentPlayerId,
+      requesterPlayerId: selfPlayerId,
       targetPlayerId,
       action: 'replace-with-com',
     });
   };
 
   const shuffleTeams = () => {
-    if (!socket || !currentRoomId || !currentPlayerId) return;
+    const selfPlayerId = getCurrentUserPlayerId();
+    if (!socket || !currentRoomId || !selfPlayerId) return;
     socket.emit('shuffle-teams', {
       roomId: currentRoomId,
-      playerId: currentPlayerId,
+      playerId: selfPlayerId,
     });
   };
 
   const updateTeamNames = (nextTeamNames: TeamNames) => {
-    if (!socket || !currentRoomId || !currentPlayerId) return;
+    const selfPlayerId = getCurrentUserPlayerId();
+    if (!socket || !currentRoomId || !selfPlayerId) return;
     socket.emit('update-team-names', {
       roomId: currentRoomId,
-      playerId: currentPlayerId,
+      playerId: selfPlayerId,
       teamNames: nextTeamNames,
     });
   };
@@ -1349,9 +1349,13 @@ export const useGame = () => {
       });
     },
     revealBrokenHand: (playerId: string) => {
+      const selfPlayerId = getCurrentUserPlayerId();
+      if (!selfPlayerId || playerId !== selfPlayerId) {
+        return;
+      }
       socket?.emit('reveal-broken-hand', {
         roomId: currentRoomId,
-        playerId,
+        playerId: selfPlayerId,
       });
     }
   };

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -56,6 +56,7 @@ import {
   resolveDeclarationForRoster,
   resolveDeclarationsForRoster,
 } from '../lib/utils/playerReferenceRemap';
+import { resolveSelfPlayerId } from '../lib/utils/playerIdentity';
 
 interface ProfileUpdatedPayload {
   userId: string;
@@ -282,29 +283,24 @@ export const useGame = () => {
   const resolveCurrentUserPlayerId = useCallback(<T extends { playerId: string; userId?: string }>(
     nextPlayers: T[],
     fallbackPlayerId?: string | null,
+    serverPlayerId?: string | null,
   ): string | null => {
-    if (user?.id) {
-      const selfByUserId = nextPlayers.find((player) => player.userId === user.id);
-      if (selfByUserId) {
-        return selfByUserId.playerId;
-      }
-    }
-
-    const selfByPlayerId =
-      (fallbackPlayerId &&
-        nextPlayers.find((player) => player.playerId === fallbackPlayerId)) ||
-      null;
-
-    return selfByPlayerId?.playerId ?? null;
+    return resolveSelfPlayerId(nextPlayers, {
+      userId: user?.id,
+      serverPlayerId,
+      fallbackPlayerId,
+    });
   }, [user?.id]);
 
   const syncCurrentPlayerIdentity = useCallback((
     nextPlayers: Player[],
     fallbackPlayerId?: string | null,
+    serverPlayerId?: string | null,
   ) => {
     const nextCurrentPlayerId = resolveCurrentUserPlayerId(
       nextPlayers,
       fallbackPlayerId,
+      serverPlayerId,
     );
     if (nextCurrentPlayerId) {
       setCurrentPlayerId(nextCurrentPlayerId);
@@ -655,7 +651,7 @@ export const useGame = () => {
         commitPlayers(nextPlayers);
         syncDisconnectedPlayerIdsFromPlayers(nextPlayers);
         if (!isSpectator) {
-          syncCurrentPlayerIdentity(nextPlayers, you ?? currentPlayerId);
+          syncCurrentPlayerIdentity(nextPlayers, currentPlayerId, you);
         }
         setGamePhase(toUiGamePhase(gamePhase));
         setWhoseTurn(currentTurn);
@@ -683,7 +679,6 @@ export const useGame = () => {
           ),
         );
         setTeamScores(toUiTeamScores(teamScores));
-        if (you !== undefined) setCurrentPlayerId(you);
         setIsSpectator(Boolean(isSpectator));
         setNegriCard(negriCard);
         setCompletedFields(toUiCompletedFields(fields));

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -270,11 +270,10 @@ export const useGame = () => {
 
   const syncDisconnectedPlayerIdsFromPlayers = useCallback(
     (nextPlayers: Array<Pick<Player, 'playerId' | 'isCOM' | 'socketId'>>) => {
-      setDisconnectedPlayerIds((prev) =>
-        prev.filter((playerId) => {
-          const player = nextPlayers.find((candidate) => candidate.playerId === playerId);
-          return Boolean(player && !player.isCOM && !player.socketId);
-        }),
+      setDisconnectedPlayerIds(
+        nextPlayers
+          .filter((player) => !player.isCOM && !player.socketId)
+          .map((player) => player.playerId),
       );
     },
     [],
@@ -310,6 +309,23 @@ export const useGame = () => {
   const getCurrentUserPlayerId = useCallback(
     () => resolveCurrentUserPlayerId(playersRef.current, currentPlayerId),
     [currentPlayerId, resolveCurrentUserPlayerId],
+  );
+
+  const hasPlayerActedInCurrentBlow = useCallback(
+    (playerId: string): boolean => {
+      const player = playersRef.current.find(
+        (candidate) => candidate.playerId === playerId,
+      );
+
+      return (
+        Boolean(player?.isPasser) ||
+        blowDeclarations.some(
+          (declaration) => declaration.playerId === playerId,
+        ) ||
+        blowActionHistory.some((action) => action.playerId === playerId)
+      );
+    },
+    [blowActionHistory, blowDeclarations],
   );
 
   const updatePlayersLocally = useCallback((
@@ -1294,6 +1310,10 @@ export const useGame = () => {
         setNotification({ message: t('errors.notYourTurnDeclare'), type: 'error' });
         return;
       }
+      if (hasPlayerActedInCurrentBlow(currentPlayerId)) {
+        setNotification({ message: t('errors.alreadyActedInBlow'), type: 'error' });
+        return;
+      }
       if (!selectedTrump || numberOfPairs < 1) {
         setNotification({ message: t('errors.selectTrumpAndPairs'), type: 'error' });
         return;
@@ -1309,6 +1329,10 @@ export const useGame = () => {
     passBlow: () => {
       if (!currentPlayerId || whoseTurn !== currentPlayerId) {
         setNotification({ message: t('errors.notYourTurnPass'), type: 'error' });
+        return;
+      }
+      if (hasPlayerActedInCurrentBlow(currentPlayerId)) {
+        setNotification({ message: t('errors.alreadyActedInBlow'), type: 'error' });
         return;
       }
       socket?.emit('pass-blow', {

--- a/mei-tra-frontend/hooks/useRoom.ts
+++ b/mei-tra-frontend/hooks/useRoom.ts
@@ -17,6 +17,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { ConnectionUser, Team } from '../types/game.types';
 import { RoomStatus } from '../types/room.types';
 import { clearPlayerProfileCache } from '../lib/utils/profileUtils';
+import { resolveSelfPlayerId } from '../lib/utils/playerIdentity';
 
 interface UseRoomOptions {
   users?: ConnectionUser[];
@@ -42,6 +43,22 @@ export const useRoom = (options: UseRoomOptions = {}) => {
 
   const users = useMemo(() => options.users ?? [], [options.users]);
   const currentPlayerId = options.currentPlayerId ?? null;
+
+  const resolveSelfRoomPlayer = useCallback(
+    (room: Room | null | undefined): RoomPlayer | null => {
+      if (!room) {
+        return null;
+      }
+      const playerId = resolveSelfPlayerId(room.players, {
+        userId: user?.id,
+        serverPlayerId: currentPlayerId,
+      });
+      return (
+        room.players.find((player) => player.playerId === playerId) ?? null
+      );
+    },
+    [currentPlayerId, user?.id],
+  );
 
   const currentRoomRef = useRef<Room | null>(null);
   const legacyRoomEventSkipRef = useRef<{
@@ -624,7 +641,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
 
     const room = availableRooms.find(r => r.id === roomId) || currentRoom;
     // userId でマッチング（socket.id は再接続で変わるため使わない）
-    const player = room?.players.find(p => user && p.userId === user.id);
+    const player = resolveSelfRoomPlayer(room);
 
     if (!player?.playerId) {
       console.error('[useRoom] Cannot leave room: player not found');
@@ -642,7 +659,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
         setError(response.error || 'Failed to leave room');
       }
     });
-  }, [socket, currentRoom, availableRooms, user]);
+  }, [socket, currentRoom, availableRooms, resolveSelfRoomPlayer]);
 
   // 準備状態の切り替え
   const togglePlayerReady = useCallback(() => {
@@ -657,9 +674,9 @@ export const useRoom = (options: UseRoomOptions = {}) => {
     }
 
     // userId でマッチング（socket.id は再接続で変わるため使わない）
-    const player = currentRoom.players.find(p => user && p.userId === user.id);
+    const player = resolveSelfRoomPlayer(currentRoom);
     if (!player) {
-      setError('Player not found7');
+      setError('Player not found in room');
       return;
     }
     if (!player.playerId) {
@@ -677,7 +694,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
       roomId: currentRoom.id,
       playerId: player.playerId
     });
-  }, [socket, currentRoom, user]);
+  }, [socket, currentRoom, resolveSelfRoomPlayer]);
 
   // ゲーム開始
   const startGameRoom = useCallback(() => {
@@ -687,9 +704,9 @@ export const useRoom = (options: UseRoomOptions = {}) => {
     }
 
     // userId でマッチング（socket.id は再接続で変わるため使わない）
-    const player = currentRoom.players.find(p => user && p.userId === user.id);
+    const player = resolveSelfRoomPlayer(currentRoom);
     if (!player) {
-      setError('Player not found8');
+      setError('Player not found in room');
       return;
     }
 
@@ -697,19 +714,19 @@ export const useRoom = (options: UseRoomOptions = {}) => {
       roomId: currentRoom.id,
       playerId: player.playerId
     });
-  }, [socket, currentRoom, user]);
+  }, [socket, currentRoom, resolveSelfRoomPlayer]);
 
   // COM追加（残席をCOMで埋める）
   const fillWithCOM = useCallback((roomId: string) => {
     if (!socket) return;
     const room = availableRooms.find(r => r.id === roomId) || currentRoom;
-    const player = room?.players.find(p => user && p.userId === user.id);
+    const player = resolveSelfRoomPlayer(room);
     if (!player?.playerId) {
       console.error('[useRoom] Cannot fill with COM: player not found');
       return;
     }
     socket.emit('fill-with-com', { roomId, playerId: player.playerId });
-  }, [socket, currentRoom, availableRooms, user]);
+  }, [socket, currentRoom, availableRooms, resolveSelfRoomPlayer]);
 
   // プレイヤーのチーム変更
   const changePlayerTeam = useCallback((roomId: string, teamChanges: { [key: string]: number }): Promise<boolean> => {
@@ -717,7 +734,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
 
     const room = availableRooms.find(r => r.id === roomId) || currentRoom;
     // userId でマッチング（socket.id は再接続で変わるため使わない）
-    const player = room?.players.find(p => user && p.userId === user.id);
+    const player = resolveSelfRoomPlayer(room);
 
     if (!player?.playerId) {
       console.error('[useRoom] Cannot change team: player not found');
@@ -729,7 +746,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
         resolve(response.success);
       });
     });
-  }, [socket, currentRoom, availableRooms, user]);
+  }, [socket, currentRoom, availableRooms, resolveSelfRoomPlayer]);
 
   if (!isClient) {
     return {

--- a/mei-tra-frontend/hooks/useSocket.ts
+++ b/mei-tra-frontend/hooks/useSocket.ts
@@ -36,6 +36,11 @@ export function useSocket(): UseSocketReturn {
       isInitializingRef.current = true;
       setSocketAuthTokenProvider(getAccessToken);
 
+      const existingSocket = getExistingSocket();
+      if (existingSocket) {
+        socketRef.current = existingSocket;
+      }
+
       // If a socket already exists and is connected, reflect that immediately
       if (socketRef.current?.connected) {
         if (isMounted) {
@@ -71,9 +76,7 @@ export function useSocket(): UseSocketReturn {
         // Initialize or reuse the shared game socket. Multiple hooks can call
         // useSocket on the same page, but only one socket connection should be
         // created and connected.
-        if (!socketRef.current) {
-          socketRef.current = getExistingSocket() ?? getSocket(token);
-        }
+        socketRef.current = getExistingSocket() ?? getSocket(token);
         managedSocket = socketRef.current;
 
         // Set up connection listeners
@@ -144,7 +147,11 @@ export function useSocket(): UseSocketReturn {
           managedSocket.io.on('reconnect_failed', handleReconnectFailed);
 
           // Connect the socket if not already connected
-          if (!managedSocket.connected && !sharedConnectInFlight) {
+          if (
+            !managedSocket.connected
+            && !managedSocket.active
+            && !sharedConnectInFlight
+          ) {
             console.log('[useSocket] Attempting to connect socket with auth token...');
             sharedConnectInFlight = true;
             managedSocket.connect();

--- a/mei-tra-frontend/lib/utils/playerIdentity.ts
+++ b/mei-tra-frontend/lib/utils/playerIdentity.ts
@@ -1,0 +1,38 @@
+export interface PlayerIdentity {
+  playerId: string;
+  userId?: string;
+}
+
+export function resolveSelfPlayerId<T extends PlayerIdentity>(
+  players: T[],
+  options: {
+    userId?: string | null;
+    serverPlayerId?: string | null;
+    fallbackPlayerId?: string | null;
+  },
+): string | null {
+  if (
+    options.serverPlayerId &&
+    players.some((player) => player.playerId === options.serverPlayerId)
+  ) {
+    return options.serverPlayerId;
+  }
+
+  if (options.userId) {
+    const authenticatedMatches = players.filter(
+      (player) => player.userId === options.userId,
+    );
+    if (authenticatedMatches.length === 1) {
+      return authenticatedMatches[0].playerId;
+    }
+  }
+
+  if (
+    options.fallbackPlayerId &&
+    players.some((player) => player.playerId === options.fallbackPlayerId)
+  ) {
+    return options.fallbackPlayerId;
+  }
+
+  return null;
+}

--- a/mei-tra-frontend/lib/utils/playerReferenceRemap.ts
+++ b/mei-tra-frontend/lib/utils/playerReferenceRemap.ts
@@ -84,8 +84,9 @@ export const resolveBlowActionsForRoster = (
   actions: BlowAction[],
   players: Player[],
   replacements: PlayerReplacementMap,
-): BlowAction[] =>
-  actions.map((action) => {
+): BlowAction[] => {
+  const rosterPlayerIds = new Set(players.map((player) => player.playerId));
+  const resolvedActions = actions.map((action) => {
     const resolvedPlayerId = resolvePlayerIdForRoster(
       action.playerId,
       players,
@@ -96,3 +97,29 @@ export const resolveBlowActionsForRoster = (
       ? action
       : { ...action, playerId: resolvedPlayerId };
   });
+
+  const representedPlayerIds = new Set(
+    resolvedActions
+      .map((action) => action.playerId)
+      .filter((playerId) => rosterPlayerIds.has(playerId)),
+  );
+
+  return resolvedActions.map((action) => {
+    if (rosterPlayerIds.has(action.playerId) || action.type !== 'pass') {
+      return action;
+    }
+
+    const passerCandidates = players.filter(
+      (player) => player.isPasser && !representedPlayerIds.has(player.playerId),
+    );
+
+    if (passerCandidates.length !== 1) {
+      return action;
+    }
+
+    const [passer] = passerCandidates;
+    representedPlayerIds.add(passer.playerId);
+
+    return { ...action, playerId: passer.playerId };
+  });
+};

--- a/mei-tra-frontend/messages/en.json
+++ b/mei-tra-frontend/messages/en.json
@@ -324,6 +324,7 @@
     "errors": {
       "notYourTurnDeclare": "It's not your turn to declare",
       "selectTrumpAndPairs": "Please select a trump type and number of sets",
+      "alreadyActedInBlow": "You have already acted in this bid phase",
       "notYourTurnPass": "It's not your turn to pass",
       "notYourTurnPlay": "It's not your turn",
       "notYourTurnBaseSuit": "It's not your turn to select a base suit"
@@ -720,6 +721,7 @@
   },
   "playerStatus": {
     "disconnected": "Disconnected",
+    "reconnecting": "Reconnecting",
     "idle": "Unresponsive",
     "replaceWithCom": "Replace with COM",
     "disconnectedNotice": "{playerName} disconnected. They will be replaced with COM after the timeout.",

--- a/mei-tra-frontend/messages/ja.json
+++ b/mei-tra-frontend/messages/ja.json
@@ -324,6 +324,7 @@
     "errors": {
       "notYourTurnDeclare": "宣言するターンではありません",
       "selectTrumpAndPairs": "キリ（切り札）と組数を選択してください",
+      "alreadyActedInBlow": "この吹きフェーズではすでに行動済みです",
       "notYourTurnPass": "パスするターンではありません",
       "notYourTurnPlay": "あなたのターンではありません",
       "notYourTurnBaseSuit": "ベーススートを選択するターンではありません"
@@ -720,6 +721,7 @@
   },
   "playerStatus": {
     "disconnected": "切断中",
+    "reconnecting": "再接続待ち",
     "idle": "応答なし",
     "replaceWithCom": "COMに切り替え",
     "disconnectedNotice": "{playerName} の接続が切れました。一定時間後にCOMへ切り替わります。",


### PR DESCRIPTION
## Summary
- Resolve reconnect/join identity from the authenticated `userId` to exactly one room seat before accepting a client/session `playerId`.
- Preserve the authoritative room seat `playerId` across join, reconnect, auth refresh, membership claim, gateway actions, and frontend self actions.
- Repair stale same-room memberships to the unique authenticated seat and reject ambiguous duplicate seats instead of guessing.
- Collapse stale connection sessions and remove obsolete `userId -> playerId` indexes when the authenticated socket identity changes.
- Fail closed when game-history access maps one authenticated user to zero or multiple non-COM participants.
- Make `game-state.you` / server player id authoritative in the frontend, with unambiguous `userId` fallback.
- Keep one browser-wide game Socket.IO client across hooks and Next module refreshes so one reload creates one reconnect.
- Add regression coverage for room join, active resume, membership repair, auth sync, gateway actions, history access, connection sessions, and browser socket reuse.

## Why
A player who left/rejoined, changed between player and COM, or retained stale client/session state could reference a different `playerId` from the actual room seat. That could put the self seat in the wrong position, hide the user's hand, send host/player actions with an outdated id, leave duplicate sessions/memberships, or reconnect twice on one page reload.

## Manual validation
- Created a room with one authenticated player and three COM players.
- Started a game, reloaded during the blow phase, and confirmed the same self seat, hand, and turn were restored.
- Passed after reconnect and reached the play phase.
- Reloaded with field cards present, selected and played `5♦`, and confirmed the hand decreased from 10 to 9 while the field received the card.
- Reloaded again after the Socket singleton fix and confirmed the backend handled exactly one game reconnect for the browser reload.

## Validation
- `cd mei-tra-backend && npm test -- --runInBand` — 43 suites / 277 tests passed
- `cd mei-tra-backend && npm run lint`
- `cd mei-tra-backend && npm run build`
- `cd mei-tra-frontend && npm test -- --runInBand` — 28 suites / 97 tests passed
- `cd mei-tra-frontend && npm run lint`
- `cd mei-tra-frontend && npm run build`