### PR TITLE
モバイル: デザイントークン統一と対局ログの簡素化

### DIFF
--- a/mei-tra-mobile/app.json
+++ b/mei-tra-mobile/app.json
@@ -7,7 +7,7 @@
     "orientation": "portrait",
     "scheme": "meitra",
     "userInterfaceStyle": "dark",
-    "backgroundColor": "#082f26",
+    "backgroundColor": "#0e2a21",
     "ios": {
       "supportsTablet": true,
       "icon": "./assets/images/meitra-icon.png",
@@ -16,7 +16,7 @@
     "android": {
       "package": "com.kando1.meitra",
       "adaptiveIcon": {
-        "backgroundColor": "#082f26",
+        "backgroundColor": "#0e2a21",
         "foregroundImage": "./assets/images/meitra-adaptive-foreground.png"
       },
       "permissions": ["POST_NOTIFICATIONS"],
@@ -31,7 +31,7 @@
       [
         "expo-splash-screen",
         {
-          "backgroundColor": "#082f26",
+          "backgroundColor": "#0e2a21",
           "image": "./assets/images/meitra-splash.png",
           "imageWidth": 240
         }

--- a/mei-tra-mobile/src/app/settings.tsx
+++ b/mei-tra-mobile/src/app/settings.tsx
@@ -542,7 +542,7 @@ const styles = StyleSheet.create({
     fontSize: 15,
   },
   profileError: {
-    color: '#ffb0a8',
+    color: colors.dangerText,
     fontSize: 14,
     lineHeight: 20,
   },
@@ -574,7 +574,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   linkError: {
-    color: '#ffb0a8',
+    color: colors.dangerText,
     fontSize: 14,
     lineHeight: 20,
   },
@@ -620,7 +620,7 @@ const styles = StyleSheet.create({
     fontSize: 17,
   },
   deleteError: {
-    color: '#ffb0a8',
+    color: colors.dangerText,
     fontSize: 14,
     lineHeight: 20,
   },

--- a/mei-tra-mobile/src/app/sign-in.tsx
+++ b/mei-tra-mobile/src/app/sign-in.tsx
@@ -252,7 +252,9 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
   },
   error: {
-    color: colors.danger,
+    // dangerText, not danger: `danger` is a fill colour and only reaches ~2.4:1
+    // as text on the felt panel behind this card. See theme/palette.ts.
+    color: colors.dangerText,
     fontSize: 15,
   },
   message: {

--- a/mei-tra-mobile/src/components/game/BlowControls.tsx
+++ b/mei-tra-mobile/src/components/game/BlowControls.tsx
@@ -8,16 +8,15 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { Button } from '@/components/ui/Button';
+import { TRUMP_LABELS } from '@/lib/trump-labels';
 import { colors } from '@/theme/colors';
 import { getValidBlowPairValues } from '@meitra/game-client/blow';
 
-const trumpOptions: { value: TrumpType; label: string }[] = [
-  { value: 'zuppe', label: 'ズッペ ♠' },
-  { value: 'club', label: 'クラブ ♣' },
-  { value: 'daiya', label: 'ダイヤ ♦' },
-  { value: 'herz', label: 'ヘル ♥' },
-  { value: 'tra', label: 'トラ' },
-];
+const TRUMP_ORDER: TrumpType[] = ['zuppe', 'club', 'daiya', 'herz', 'tra'];
+
+const trumpOptions: { value: TrumpType; label: string }[] = TRUMP_ORDER.map(
+  (value) => ({ value, label: TRUMP_LABELS[value] }),
+);
 
 const declarationLabel = (declaration: BlowDeclarationContract | null) => {
   if (!declaration) return 'まだ宣言はありません';

--- a/mei-tra-mobile/src/components/game/GameBoard.tsx
+++ b/mei-tra-mobile/src/components/game/GameBoard.tsx
@@ -659,7 +659,9 @@ export function GameBoard({
             <Text style={styles.modalText}>
               勝者: {gameOver?.winner}
               {'\n'}
-              チーム1 {gameOver?.finalScores[0]?.total ?? 0}点 / チーム2{' '}
+              {getTeamDisplayName(0, game.teamNames)}{' '}
+              {gameOver?.finalScores[0]?.total ?? 0}点 /{' '}
+              {getTeamDisplayName(1, game.teamNames)}{' '}
               {gameOver?.finalScores[1]?.total ?? 0}点
             </Text>
             <Button disabled={actionsDisabled} onPress={onCloseGameOver}>

--- a/mei-tra-mobile/src/components/game/GameBoard.tsx
+++ b/mei-tra-mobile/src/components/game/GameBoard.tsx
@@ -28,6 +28,8 @@ import {
   getSeatOrderWithSelfBottom,
 } from '@/lib/table-order';
 import { getStrengthOrderLabel } from '@/lib/trump-display';
+import { getTeamDisplayName } from '@/lib/team-labels';
+import { TRUMP_LABELS } from '@/lib/trump-labels';
 import { colors, teamColors } from '@/theme/colors';
 import type {
   MobileGameOver,
@@ -59,14 +61,6 @@ interface GameBoardProps {
   history?: GameHistoryData;
   roomId?: string;
 }
-
-const trumpLabels: Record<TrumpType, string> = {
-  tra: 'トラ',
-  herz: 'ヘル ♥',
-  daiya: 'ダイヤ ♦',
-  club: 'クラブ ♣',
-  zuppe: 'ズッペ ♠',
-};
 
 export function GameBoard({
   game,
@@ -267,7 +261,7 @@ export function GameBoard({
           <Text style={styles.phase}>{phaseLabel}</Text>
           {highest ? (
             <Text style={styles.trumpBadge}>
-              {trumpLabels[highest.trumpType]} {highest.numberOfPairs}
+              {TRUMP_LABELS[highest.trumpType]} {highest.numberOfPairs}
             </Text>
           ) : null}
         </View>
@@ -297,7 +291,7 @@ export function GameBoard({
                 agariCard={hasAgari ? game.revealedAgari ?? undefined : undefined}
                 declaration={
                   highest && highest.playerId === player.playerId
-                    ? `${trumpLabels[highest.trumpType]} ${highest.numberOfPairs}`
+                    ? `${TRUMP_LABELS[highest.trumpType]} ${highest.numberOfPairs}`
                     : undefined
                 }
                 isBlowWinner={blowWinnerId === player.playerId}
@@ -480,7 +474,7 @@ export function GameBoard({
                 </Text>
                 <View style={[styles.selfTeamBadge, { borderColor: teamColors[self.team] }]}>
                   <Text style={[styles.selfTeamBadgeText, { color: teamColors[self.team] }]}>
-                    {game.teamNames?.[self.team] ?? `${self.team + 1}組`}
+                    {getTeamDisplayName(self.team, game.teamNames)}
                   </Text>
                 </View>
                 <Text style={styles.selfFieldCountText}>
@@ -777,7 +771,7 @@ export function GameBoard({
           <View style={styles.historyOverlay}>
             <View style={styles.historyCard}>
               <View style={styles.historyHeader}>
-                <Text style={styles.historyTitle}>ゲーム履歴</Text>
+                <Text style={styles.historyTitle}>対局ログ</Text>
                 <Button
                   onPress={() => setShowHistory(false)}
                   variant="ghost"
@@ -789,8 +783,10 @@ export function GameBoard({
                 error={history.error}
                 loading={history.loading}
                 onRefresh={history.refresh}
+                players={game.players}
                 replay={history.replay}
                 summary={history.summary}
+                teamNames={game.teamNames}
               />
             </View>
           </View>

--- a/mei-tra-mobile/src/components/game/GameBoard.tsx
+++ b/mei-tra-mobile/src/components/game/GameBoard.tsx
@@ -28,7 +28,7 @@ import {
   getSeatOrderWithSelfBottom,
 } from '@/lib/table-order';
 import { getStrengthOrderLabel } from '@/lib/trump-display';
-import { colors } from '@/theme/colors';
+import { colors, teamColors } from '@/theme/colors';
 import type {
   MobileGameOver,
   MobileGameSnapshot,
@@ -478,8 +478,8 @@ export function GameBoard({
                 <Text numberOfLines={1} style={styles.selfName}>
                   {self.name}
                 </Text>
-                <View style={[styles.selfTeamBadge, { backgroundColor: self.team === 0 ? '#8b2020' : '#1a2a2a' }]}>
-                  <Text style={styles.selfTeamBadgeText}>
+                <View style={[styles.selfTeamBadge, { borderColor: teamColors[self.team] }]}>
+                  <Text style={[styles.selfTeamBadgeText, { color: teamColors[self.team] }]}>
                     {game.teamNames?.[self.team] ?? `${self.team + 1}組`}
                   </Text>
                 </View>
@@ -934,7 +934,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.danger,
   },
   replacePanelButtonText: {
-    color: '#fff',
+    color: colors.onDanger,
     fontSize: 11,
     fontWeight: '800',
   },
@@ -1041,9 +1041,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 6,
     paddingVertical: 1,
     borderRadius: 4,
+    backgroundColor: colors.panelStrong,
+    borderWidth: 1,
   },
   selfTeamBadgeText: {
-    color: '#fff',
     fontSize: 9,
     fontWeight: '700',
   },
@@ -1123,7 +1124,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.danger,
   },
   pausedReplaceButtonText: {
-    color: '#fff',
+    color: colors.onDanger,
     fontSize: 15,
     fontWeight: '800',
   },

--- a/mei-tra-mobile/src/components/game/GameHistory.tsx
+++ b/mei-tra-mobile/src/components/game/GameHistory.tsx
@@ -1,10 +1,9 @@
+import type { PlayerContract, TeamNames } from '@meitra/contracts/game';
 import type {
-  GameHistoryActionType,
-  GameHistoryReplayEventContract,
   GameHistoryReplayViewContract,
   GameHistorySummaryContract,
 } from '@meitra/contracts/game-history';
-import { useState } from 'react';
+import { useMemo } from 'react';
 import {
   ActivityIndicator,
   Pressable,
@@ -14,22 +13,8 @@ import {
   View,
 } from 'react-native';
 
-import { colors } from '@/theme/colors';
-
-const ACTION_LABELS: Record<GameHistoryActionType, string> = {
-  game_started: '開始',
-  blow_declared: '宣言',
-  blow_passed: 'パス',
-  play_phase_started: 'プレイ開始',
-  card_played: 'カード',
-  field_completed: 'ペア獲得',
-  round_completed: 'ラウンド終了',
-  round_cancelled: 'ラウンド中止',
-  round_reset: 'ラウンドリセット',
-  broken_hand_revealed: '役なし公開',
-  game_over: 'ゲーム終了',
-  player_stats_updated: '成績更新',
-};
+import { buildRoundTableRows, type RoundRow } from '@/lib/game-log-rows';
+import { colors, teamColors } from '@/theme/colors';
 
 interface GameHistoryProps {
   replay: GameHistoryReplayViewContract | null;
@@ -37,25 +22,44 @@ interface GameHistoryProps {
   loading: boolean;
   error: string | null;
   onRefresh: () => void;
+  players?: PlayerContract[];
+  teamNames?: TeamNames;
 }
 
-function EventRow({ event }: { event: GameHistoryReplayEventContract }) {
-  const time = new Date(event.timestamp).toLocaleTimeString('ja-JP', {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  });
+/** Column weights, tuned so the bid cell survives a 320pt screen. */
+const COL = {
+  round: 0.8,
+  blower: 2,
+  bid: 2.4,
+  score: 2.2,
+} as const;
+
+function Row({ row }: { row: RoundRow }) {
   return (
-    <View style={styles.eventRow}>
-      <Text style={styles.eventTime}>{time}</Text>
-      <View style={styles.eventBadge}>
-        <Text style={styles.eventBadgeText}>
-          {ACTION_LABELS[event.actionType]}
-        </Text>
-      </View>
-      <Text numberOfLines={2} style={styles.eventSummary}>
-        {event.summary}
+    <View style={styles.row}>
+      <Text style={[styles.cell, styles.roundCell, { flex: COL.round }]}>
+        {row.roundNumber}
       </Text>
+      <Text numberOfLines={1} style={[styles.cell, { flex: COL.blower }]}>
+        {row.blower}
+      </Text>
+      <Text numberOfLines={2} style={[styles.cell, { flex: COL.bid }]}>
+        {row.bid}
+      </Text>
+      <View style={[styles.scoreCell, { flex: COL.score }]}>
+        {row.inProgress ? (
+          <Text style={styles.inProgress}>進行中</Text>
+        ) : (
+          row.scores.map((score) => (
+            <Text key={score.team} style={styles.scoreLine}>
+              <Text style={{ color: teamColors[score.team] }}>
+                {score.label}
+              </Text>
+              <Text style={styles.scoreValue}> {score.delta}</Text>
+            </Text>
+          ))
+        )}
+      </View>
     </View>
   );
 }
@@ -66,14 +70,19 @@ export function GameHistory({
   loading,
   error,
   onRefresh,
+  players,
+  teamNames,
 }: GameHistoryProps) {
-  const [expandedRound, setExpandedRound] = useState<number | null>(null);
+  const rows = useMemo(
+    () => buildRoundTableRows(replay, players ?? [], teamNames),
+    [replay, players, teamNames],
+  );
 
   if (loading) {
     return (
       <View style={styles.center}>
         <ActivityIndicator color={colors.gold} size="small" />
-        <Text style={styles.loadingText}>履歴を読み込み中</Text>
+        <Text style={styles.loadingText}>ログを読み込み中...</Text>
       </View>
     );
   }
@@ -89,166 +98,122 @@ export function GameHistory({
     );
   }
 
-  if (!replay || !summary) {
-    return (
-      <View style={styles.center}>
-        <Text style={styles.emptyText}>履歴はまだありません</Text>
-      </View>
-    );
-  }
-
   return (
-    <ScrollView
-      contentContainerStyle={styles.container}
-      showsVerticalScrollIndicator={false}
-    >
-      <View style={styles.summaryCard}>
-        <Text style={styles.summaryTitle}>ゲーム概要</Text>
-        <Text style={styles.summaryText}>
-          {summary.status === 'completed' ? '終了' : '進行中'}
-          {summary.winningTeam != null
-            ? ` — 勝者: チーム${summary.winningTeam + 1}`
-            : ''}
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.subtitle}>
+          {rows.length > 0
+            ? `${rows.length}ラウンド / ${summary?.totalEntries ?? 0}件`
+            : 'まだログはありません'}
         </Text>
-        <Text style={styles.summaryText}>
-          ラウンド数: {summary.roundNumbers.length} / アクション数:{' '}
-          {summary.totalEntries}
-        </Text>
+        <Pressable hitSlop={8} onPress={onRefresh}>
+          <Text style={styles.refresh}>更新</Text>
+        </Pressable>
       </View>
 
-      {replay.rounds.map((round, index) => {
-        const roundLabel = round.roundNumber
-          ? `ラウンド ${round.roundNumber}`
-          : `ラウンド ${index + 1}`;
-        const isExpanded = expandedRound === index;
-        return (
-          <View key={index} style={styles.roundCard}>
-            <Pressable
-              onPress={() => setExpandedRound(isExpanded ? null : index)}
-              style={styles.roundHeader}
-            >
-              <Text style={styles.roundTitle}>
-                {isExpanded ? '▼' : '▶'} {roundLabel}
-              </Text>
-              <Text style={styles.roundCount}>
-                {round.events.length}件
-              </Text>
-            </Pressable>
-            {isExpanded ? (
-              <View style={styles.eventList}>
-                {round.events.map((event) => (
-                  <EventRow event={event} key={event.id} />
-                ))}
-              </View>
-            ) : null}
+      {rows.length === 0 ? (
+        <View style={styles.center}>
+          <Text style={styles.emptyText}>表示できる対局ログがありません</Text>
+        </View>
+      ) : (
+        <>
+          <View style={[styles.row, styles.headRow]}>
+            <Text style={[styles.headCell, { flex: COL.round }]}>ラウンド</Text>
+            <Text style={[styles.headCell, { flex: COL.blower }]}>吹き手</Text>
+            <Text style={[styles.headCell, { flex: COL.bid }]}>宣言</Text>
+            <Text style={[styles.headCell, { flex: COL.score }]}>得点</Text>
           </View>
-        );
-      })}
-    </ScrollView>
+          <ScrollView showsVerticalScrollIndicator={false}>
+            {rows.map((row) => (
+              <Row key={row.roundNumber} row={row} />
+            ))}
+          </ScrollView>
+        </>
+      )}
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    gap: 12,
-    padding: 14,
-    paddingBottom: 40,
+    flex: 1,
+    gap: 8,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  subtitle: {
+    color: colors.textMuted,
+    fontSize: 12,
+  },
+  refresh: {
+    color: colors.gold,
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 8,
+  },
+  headRow: {
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    paddingVertical: 6,
+  },
+  headCell: {
+    color: colors.textMuted,
+    fontSize: 11,
+    fontWeight: '700',
+  },
+  cell: {
+    color: colors.text,
+    fontSize: 13,
+  },
+  roundCell: {
+    fontVariant: ['tabular-nums'],
+    fontWeight: '700',
+  },
+  scoreCell: {
+    gap: 2,
+  },
+  scoreLine: {
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  scoreValue: {
+    color: colors.text,
+    fontVariant: ['tabular-nums'],
+  },
+  inProgress: {
+    color: colors.textMuted,
+    fontSize: 12,
   },
   center: {
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 8,
-    padding: 24,
+    gap: 10,
+    paddingVertical: 32,
   },
   loadingText: {
     color: colors.textMuted,
-    fontSize: 14,
+    fontSize: 13,
   },
   errorText: {
-    color: colors.danger,
-    fontSize: 14,
+    color: colors.dangerText,
+    fontSize: 13,
     textAlign: 'center',
   },
   retryText: {
     color: colors.gold,
-    fontSize: 14,
+    fontSize: 13,
     fontWeight: '700',
   },
   emptyText: {
     color: colors.textMuted,
-    fontSize: 14,
-  },
-  summaryCard: {
-    gap: 6,
-    padding: 14,
-    borderRadius: 16,
-    borderWidth: 1,
-    borderColor: colors.border,
-    backgroundColor: colors.panel,
-  },
-  summaryTitle: {
-    color: colors.gold,
-    fontSize: 18,
-    fontWeight: '800',
-  },
-  summaryText: {
-    color: colors.text,
-    fontSize: 14,
-  },
-  roundCard: {
-    borderRadius: 14,
-    borderWidth: 1,
-    borderColor: colors.border,
-    backgroundColor: colors.panel,
-    overflow: 'hidden',
-  },
-  roundHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    padding: 12,
-  },
-  roundTitle: {
-    color: colors.text,
-    fontSize: 15,
-    fontWeight: '700',
-  },
-  roundCount: {
-    color: colors.textMuted,
-    fontSize: 13,
-  },
-  eventList: {
-    gap: 2,
-    paddingHorizontal: 12,
-    paddingBottom: 12,
-  },
-  eventRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    paddingVertical: 6,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: colors.border,
-  },
-  eventTime: {
-    color: colors.textMuted,
-    fontSize: 11,
-    fontVariant: ['tabular-nums'],
-  },
-  eventBadge: {
-    paddingHorizontal: 6,
-    paddingVertical: 2,
-    borderRadius: 6,
-    backgroundColor: colors.backgroundElevated,
-  },
-  eventBadgeText: {
-    color: colors.gold,
-    fontSize: 10,
-    fontWeight: '700',
-  },
-  eventSummary: {
-    flex: 1,
-    color: colors.text,
     fontSize: 13,
   },
 });

--- a/mei-tra-mobile/src/components/game/PlayerSeat.tsx
+++ b/mei-tra-mobile/src/components/game/PlayerSeat.tsx
@@ -2,7 +2,7 @@ import type { PlayerContract, TeamNames } from '@meitra/contracts/game';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { PlayingCard } from '@/components/game/PlayingCard';
-import { colors } from '@/theme/colors';
+import { colors, teamColors } from '@/theme/colors';
 
 interface PlayerSeatProps {
   player: PlayerContract;
@@ -68,8 +68,8 @@ export function PlayerSeat({
         {player.name}
         {isSelf ? '（あなた）' : ''}
       </Text>
-      <View style={[styles.teamBadge, { backgroundColor: player.team === 0 ? '#8b2020' : '#1a2a2a' }]}>
-        <Text style={styles.teamBadgeText}>
+      <View style={[styles.teamBadge, { borderColor: teamColors[player.team] }]}>
+        <Text style={[styles.teamBadgeText, { color: teamColors[player.team] }]}>
           {teamNames?.[player.team] ?? `${player.team + 1}組`}
         </Text>
       </View>
@@ -171,9 +171,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 6,
     paddingVertical: 1,
     borderRadius: 4,
+    backgroundColor: colors.panelStrong,
+    borderWidth: 1,
   },
   teamBadgeText: {
-    color: '#fff',
     fontSize: 9,
     fontWeight: '700',
   },

--- a/mei-tra-mobile/src/components/game/PlayerSeat.tsx
+++ b/mei-tra-mobile/src/components/game/PlayerSeat.tsx
@@ -2,6 +2,7 @@ import type { PlayerContract, TeamNames } from '@meitra/contracts/game';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { PlayingCard } from '@/components/game/PlayingCard';
+import { getTeamDisplayName } from '@/lib/team-labels';
 import { colors, teamColors } from '@/theme/colors';
 
 interface PlayerSeatProps {
@@ -70,7 +71,7 @@ export function PlayerSeat({
       </Text>
       <View style={[styles.teamBadge, { borderColor: teamColors[player.team] }]}>
         <Text style={[styles.teamBadgeText, { color: teamColors[player.team] }]}>
-          {teamNames?.[player.team] ?? `${player.team + 1}組`}
+          {getTeamDisplayName(player.team, teamNames)}
         </Text>
       </View>
       {teamFieldCounts ? (

--- a/mei-tra-mobile/src/components/game/ScoreBoard.tsx
+++ b/mei-tra-mobile/src/components/game/ScoreBoard.tsx
@@ -4,9 +4,7 @@ import type {
 } from '@meitra/contracts/game';
 import { StyleSheet, Text, View } from 'react-native';
 
-import { colors } from '@/theme/colors';
-
-const TEAM_COLORS = ['#c0392b', '#2c3e50'] as const;
+import { colors, teamColors } from '@/theme/colors';
 
 interface ScoreBoardProps {
   scores: TransportTeamScores;
@@ -26,7 +24,7 @@ export function ScoreBoard({
         const score = scores[team]?.total ?? 0;
         const isReach = score >= pointsToWin - 1;
         const width = `${Math.min(100, (score / Math.max(pointsToWin, 1)) * 100)}%` as const;
-        const teamColor = TEAM_COLORS[team];
+        const teamColor = teamColors[team];
 
         return (
           <View

--- a/mei-tra-mobile/src/components/game/ScoreBoard.tsx
+++ b/mei-tra-mobile/src/components/game/ScoreBoard.tsx
@@ -4,6 +4,7 @@ import type {
 } from '@meitra/contracts/game';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { getTeamDisplayName } from '@/lib/team-labels';
 import { colors, teamColors } from '@/theme/colors';
 
 interface ScoreBoardProps {
@@ -20,7 +21,7 @@ export function ScoreBoard({
   return (
     <View style={styles.container}>
       {([0, 1] as const).map((team) => {
-        const name = teamNames?.[team] || `チーム${team + 1}`;
+        const name = getTeamDisplayName(team, teamNames);
         const score = scores[team]?.total ?? 0;
         const isReach = score >= pointsToWin - 1;
         const width = `${Math.min(100, (score / Math.max(pointsToWin, 1)) * 100)}%` as const;

--- a/mei-tra-mobile/src/components/game/WaitingRoom.tsx
+++ b/mei-tra-mobile/src/components/game/WaitingRoom.tsx
@@ -14,6 +14,7 @@ import {
 
 import { ChatPanel } from '@/components/social/ChatPanel';
 import { Button } from '@/components/ui/Button';
+import { getTeamDisplayName } from '@/lib/team-labels';
 import { colors, teamColors } from '@/theme/colors';
 
 interface WaitingRoomProps {
@@ -56,8 +57,8 @@ export function WaitingRoom({
 
   useEffect(() => {
     setDraftTeamNames({
-      0: room.settings.teamNames?.[0] || `チーム1`,
-      1: room.settings.teamNames?.[1] || `チーム2`,
+      0: getTeamDisplayName(0, room.settings.teamNames),
+      1: getTeamDisplayName(1, room.settings.teamNames),
     });
   }, [room.settings.teamNames]);
 
@@ -94,8 +95,7 @@ export function WaitingRoom({
 
       <View style={[styles.teams, width < 380 && styles.teamsNarrow]}>
         {([0, 1] as const).map((team) => {
-          const teamLabel =
-            room.settings.teamNames?.[team] || `チーム${team + 1}`;
+          const teamLabel = getTeamDisplayName(team, room.settings.teamNames);
           const teamColor = teamColors[team];
           return (
           <View key={team} style={styles.team}>
@@ -220,7 +220,7 @@ export function WaitingRoom({
                   onChangeText={(text) =>
                     setDraftTeamNames((prev) => ({ ...prev, [t]: text }))
                   }
-                  placeholder={`チーム${t + 1}`}
+                  placeholder={getTeamDisplayName(t)}
                   placeholderTextColor={colors.textMuted}
                   style={styles.teamNameInput}
                   value={draftTeamNames[t]}
@@ -256,7 +256,7 @@ export function WaitingRoom({
                 ]}
               >
                 <Text style={[styles.teamColorDotText, { color: teamColors[t] }]}>
-                  {(room.settings.teamNames?.[t] || `チーム${t + 1}`).slice(0, 1)}
+                  {getTeamDisplayName(t, room.settings.teamNames).slice(0, 1)}
                 </Text>
               </View>
             ))}

--- a/mei-tra-mobile/src/components/game/WaitingRoom.tsx
+++ b/mei-tra-mobile/src/components/game/WaitingRoom.tsx
@@ -14,9 +14,7 @@ import {
 
 import { ChatPanel } from '@/components/social/ChatPanel';
 import { Button } from '@/components/ui/Button';
-import { colors } from '@/theme/colors';
-
-const TEAM_COLORS = ['#c0392b', '#2c3e50'] as const;
+import { colors, teamColors } from '@/theme/colors';
 
 interface WaitingRoomProps {
   room: RoomContract;
@@ -98,12 +96,14 @@ export function WaitingRoom({
         {([0, 1] as const).map((team) => {
           const teamLabel =
             room.settings.teamNames?.[team] || `チーム${team + 1}`;
-          const teamColor = TEAM_COLORS[team];
+          const teamColor = teamColors[team];
           return (
           <View key={team} style={styles.team}>
             <View style={styles.teamHeader}>
-              <View style={[styles.teamBadge, { backgroundColor: teamColor }]}>
-                <Text style={styles.teamBadgeText}>{teamLabel}</Text>
+              <View style={[styles.teamBadge, { borderColor: teamColor }]}>
+                <Text style={[styles.teamBadgeText, { color: teamColor }]}>
+                  {teamLabel}
+                </Text>
               </View>
             </View>
             {[0, 1].map((seat) => {
@@ -191,10 +191,10 @@ export function WaitingRoom({
                   key={t}
                   style={[
                     styles.teamColorDot,
-                    { backgroundColor: TEAM_COLORS[t] },
+                    { borderColor: teamColors[t] },
                   ]}
                 >
-                  <Text style={styles.teamColorDotText}>
+                  <Text style={[styles.teamColorDotText, { color: teamColors[t] }]}>
                     {draftTeamNames[t].slice(0, 1) || `${t + 1}`}
                   </Text>
                 </View>
@@ -208,10 +208,10 @@ export function WaitingRoom({
                 <View
                   style={[
                     styles.teamColorLabel,
-                    { backgroundColor: TEAM_COLORS[t] },
+                    { borderColor: teamColors[t] },
                   ]}
                 >
-                  <Text style={styles.teamColorLabelText}>
+                  <Text style={[styles.teamColorLabelText, { color: teamColors[t] }]}>
                     {t === 0 ? '赤' : '黒'}
                   </Text>
                 </View>
@@ -252,10 +252,10 @@ export function WaitingRoom({
                 key={t}
                 style={[
                   styles.teamColorDot,
-                  { backgroundColor: TEAM_COLORS[t] },
+                  { borderColor: teamColors[t] },
                 ]}
               >
-                <Text style={styles.teamColorDotText}>
+                <Text style={[styles.teamColorDotText, { color: teamColors[t] }]}>
                   {(room.settings.teamNames?.[t] || `チーム${t + 1}`).slice(0, 1)}
                 </Text>
               </View>
@@ -380,9 +380,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 3,
     borderRadius: 8,
+    backgroundColor: colors.panelStrong,
+    borderWidth: 1,
   },
   teamBadgeText: {
-    color: '#fff',
     fontSize: 14,
     fontWeight: '800',
   },
@@ -414,9 +415,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     borderRadius: 12,
+    backgroundColor: colors.panelStrong,
+    borderWidth: 1.5,
   },
   teamColorDotText: {
-    color: '#fff',
     fontSize: 11,
     fontWeight: '800',
   },
@@ -456,9 +458,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     borderRadius: 6,
+    backgroundColor: colors.panelStrong,
+    borderWidth: 1.5,
   },
   teamColorLabelText: {
-    color: '#fff',
     fontSize: 13,
     fontWeight: '800',
   },

--- a/mei-tra-mobile/src/components/ui/ConnectionBanner.tsx
+++ b/mei-tra-mobile/src/components/ui/ConnectionBanner.tsx
@@ -69,11 +69,11 @@ const styles = StyleSheet.create({
   },
   pending: {
     borderColor: colors.gold,
-    backgroundColor: 'rgba(196, 154, 58, 0.14)',
+    backgroundColor: colors.goldSubtle,
   },
   offline: {
     borderColor: colors.danger,
-    backgroundColor: 'rgba(214, 107, 98, 0.16)',
+    backgroundColor: colors.dangerSubtle,
   },
   dot: {
     width: 9,

--- a/mei-tra-mobile/src/lib/__tests__/game-log-rows.test.ts
+++ b/mei-tra-mobile/src/lib/__tests__/game-log-rows.test.ts
@@ -1,0 +1,159 @@
+import type {
+  GameHistoryReplayEventContract,
+  GameHistoryReplayViewContract,
+} from '@meitra/contracts/game-history';
+
+import { buildRoundTableRows, formatBid } from '../game-log-rows';
+
+type AnyEvent = GameHistoryReplayEventContract;
+
+const event = (
+  over: Partial<AnyEvent> & Pick<AnyEvent, 'id' | 'actionType'>,
+): AnyEvent =>
+  ({
+    timestamp: '2026-01-01T00:00:00.000Z',
+    kind: 'round',
+    playerId: null,
+    roundNumber: 1,
+    gamePhase: null,
+    summary: '',
+    details: {},
+    detailItems: [],
+    actionData: {},
+    ...over,
+  }) as AnyEvent;
+
+const scoresEvent = (
+  id: string,
+  timestamp: string,
+  team0: number,
+  team1: number,
+): AnyEvent =>
+  event({
+    id,
+    actionType: 'round_completed',
+    timestamp,
+    detailItems: [
+      {
+        labelKey: 'scores',
+        value: {
+          kind: 'scores',
+          scores: { '0': { total: team0 }, '1': { total: team1 } },
+        },
+      },
+    ],
+  } as Partial<AnyEvent> as never);
+
+const replay = (
+  rounds: GameHistoryReplayViewContract['rounds'],
+): GameHistoryReplayViewContract => ({
+  roomId: 'room-1',
+  totalEntries: rounds.reduce((n, r) => n + r.events.length, 0),
+  rounds,
+});
+
+const round = (
+  roundNumber: number | null,
+  events: AnyEvent[],
+): GameHistoryReplayViewContract['rounds'][number] =>
+  ({
+    roundNumber,
+    startedAt: null,
+    endedAt: null,
+    actionTypes: [],
+    playerIds: [],
+    entries: [],
+    events,
+  }) as GameHistoryReplayViewContract['rounds'][number];
+
+describe('formatBid', () => {
+  it('reformats the backend English bid into the web wording', () => {
+    expect(formatBid('6 pair(s) / herz')).toBe('6組 / ヘル (♥)');
+    expect(formatBid('5 pairs / tra')).toBe('5組 / ノートラ');
+    expect(formatBid('4 / zuppe')).toBe('4組 / ズッペ (♠)');
+  });
+
+  it('falls back to 不明 when there is no declaration', () => {
+    expect(formatBid(null)).toBe('不明');
+  });
+});
+
+describe('buildRoundTableRows', () => {
+  it('returns rounds newest-first and drops the pre-game bucket', () => {
+    const rows = buildRoundTableRows(
+      replay([
+        round(null, [event({ id: 'pre', actionType: 'game_started' })]),
+        round(1, []),
+        round(2, []),
+      ]),
+    );
+
+    expect(rows.map((r) => r.roundNumber)).toEqual([2, 1]);
+  });
+
+  it('turns cumulative totals into per-round deltas', () => {
+    const rows = buildRoundTableRows(
+      replay([
+        round(1, [scoresEvent('c1', '2026-01-01T00:01:00.000Z', 3, 0)]),
+        round(2, [scoresEvent('c2', '2026-01-01T00:02:00.000Z', 3, 4)]),
+        round(3, [scoresEvent('c3', '2026-01-01T00:03:00.000Z', 8, 4)]),
+      ]),
+    );
+
+    // rows are newest-first: round 3, 2, 1
+    expect(rows[0].scores.map((s) => s.delta)).toEqual(['+5', '0']);
+    expect(rows[1].scores.map((s) => s.delta)).toEqual(['0', '+4']);
+    expect(rows[2].scores.map((s) => s.delta)).toEqual(['+3', '0']);
+  });
+
+  it('marks a round with no round_completed as in progress', () => {
+    const rows = buildRoundTableRows(
+      replay([round(1, [event({ id: 'a', actionType: 'blow_declared' })])]),
+    );
+
+    expect(rows[0].inProgress).toBe(true);
+    expect(rows[0].scores.every((s) => s.delta === null)).toBe(true);
+  });
+
+  it('resolves the blower from the declaration playerNames', () => {
+    const rows = buildRoundTableRows(
+      replay([
+        round(1, [
+          event({
+            id: 'd',
+            actionType: 'blow_declared',
+            playerId: 'p1',
+            actionData: { playerNames: { p1: 'あかり' } },
+          }),
+        ]),
+      ]),
+    );
+
+    expect(rows[0].blower).toBe('あかり');
+  });
+
+  it('falls back to プレイヤー when nothing identifies the blower', () => {
+    const rows = buildRoundTableRows(replay([round(1, [])]));
+    expect(rows[0].blower).toBe('プレイヤー');
+  });
+
+  it('uses custom team names when supplied, else 赤 / 黒', () => {
+    const base = replay([
+      round(1, [scoresEvent('c1', '2026-01-01T00:01:00.000Z', 1, 2)]),
+    ]);
+
+    expect(buildRoundTableRows(base)[0].scores.map((s) => s.label)).toEqual([
+      '赤',
+      '黒',
+    ]);
+    expect(
+      buildRoundTableRows(base, [], { 0: 'A班', 1: 'B班' })[0].scores.map(
+        (s) => s.label,
+      ),
+    ).toEqual(['A班', 'B班']);
+  });
+
+  it('returns an empty table for a null replay', () => {
+    expect(buildRoundTableRows(null)).toEqual([]);
+  });
+});

--- a/mei-tra-mobile/src/lib/game-log-rows.ts
+++ b/mei-tra-mobile/src/lib/game-log-rows.ts
@@ -1,0 +1,192 @@
+import type {
+  GameHistoryReplayEventContract,
+  GameHistoryReplayViewContract,
+} from '@meitra/contracts/game-history';
+import type { PlayerContract, Team, TeamNames } from '@meitra/contracts/game';
+
+import { getTeamDisplayName } from './team-labels';
+import { trumpLabel } from './trump-labels';
+
+/**
+ * Derives the round-summary table shown in 対局ログ, mirroring the web dock
+ * (mei-tra-frontend/components/game/GameHistoryDock.tsx).
+ *
+ * Kept as a pure function, separate from the renderer, so the interesting parts
+ * — score deltas, the blower fallback chain, bid reformatting — are unit
+ * testable. The mobile test setup cannot render React Native components.
+ */
+export interface RoundScoreCell {
+  team: Team;
+  label: string;
+  /** Formatted delta: '+3', '-1', '—', or null while the round is unfinished. */
+  delta: string | null;
+}
+
+export interface RoundRow {
+  roundNumber: number;
+  blower: string;
+  bid: string;
+  scores: RoundScoreCell[];
+  inProgress: boolean;
+}
+
+const UNKNOWN = '不明';
+const PARTICIPANT = 'プレイヤー';
+
+function getTextDetail(
+  event: GameHistoryReplayEventContract | undefined,
+  labelKey: string,
+): string | null {
+  if (!event) return null;
+  const item = event.detailItems.find((detail) => detail.labelKey === labelKey);
+  if (!item) return null;
+  const value = item.value as { kind?: string; text?: string; name?: string };
+  return value?.text ?? value?.name ?? null;
+}
+
+function playerNamesOf(
+  event: GameHistoryReplayEventContract | undefined,
+): Record<string, string> {
+  const names = event?.actionData?.playerNames;
+  return typeof names === 'object' && names !== null
+    ? (names as Record<string, string>)
+    : {};
+}
+
+/**
+ * Cumulative per-team totals carried on a `round_completed` event, keyed by
+ * team. Ported from `extractScoreTotals`.
+ */
+function extractScoreTotals(
+  event: GameHistoryReplayEventContract,
+): Record<string, number> | null {
+  const item = event.detailItems.find((detail) => detail.labelKey === 'scores');
+  if (!item) return null;
+  const value = item.value as {
+    kind?: string;
+    scores?: Record<string, { total?: number }>;
+  };
+  if (!value?.scores) return null;
+
+  const totals: Record<string, number> = {};
+  for (const [team, score] of Object.entries(value.scores)) {
+    if (typeof score?.total === 'number') totals[team] = score.total;
+  }
+  return Object.keys(totals).length > 0 ? totals : null;
+}
+
+/**
+ * Walks every `round_completed` event in chronological order and turns the
+ * cumulative totals into per-round deltas.
+ *
+ * NOTE: the contract types `timestamp` as an ISO string (web maps it to a
+ * `Date` first), so this parses rather than calling `.getTime()`.
+ */
+function buildScoreDeltas(
+  replay: GameHistoryReplayViewContract,
+): Map<string, Record<string, number>> {
+  const completions = replay.rounds
+    .flatMap((round) => round.events)
+    .filter((event) => event.actionType === 'round_completed')
+    .sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp));
+
+  const deltas = new Map<string, Record<string, number>>();
+  let previous: Record<string, number> = {};
+
+  for (const event of completions) {
+    const totals = extractScoreTotals(event);
+    if (!totals) continue;
+
+    const delta: Record<string, number> = {};
+    for (const [team, total] of Object.entries(totals)) {
+      delta[team] = total - (previous[team] ?? 0);
+    }
+    deltas.set(event.id, delta);
+    previous = totals;
+  }
+
+  return deltas;
+}
+
+/** '6 pair(s) / herz' → '6組 / ヘル (♥)' */
+export function formatBid(rawBid: string | null): string {
+  if (!rawBid) return UNKNOWN;
+
+  const [countPart, trumpPart] = rawBid.split(' / ');
+  const match = countPart
+    ?.trim()
+    .match(/^(\d+(?:\.\d+)?)\s*(?:pairs?|pair\(s\)|sets?|set\(s\)|組)?$/i);
+
+  const count = match ? `${match[1]}組` : countPart?.trim();
+  const trump = trumpPart ? trumpLabel(trumpPart.trim()) : null;
+
+  if (count && trump) return `${count} / ${trump}`;
+  return count || trump || UNKNOWN;
+}
+
+function formatDelta(delta: number | undefined): string {
+  if (delta === undefined) return '—';
+  if (delta > 0) return `+${delta}`;
+  return String(delta);
+}
+
+export function buildRoundTableRows(
+  replay: GameHistoryReplayViewContract | null,
+  players: PlayerContract[] = [],
+  teamNames?: TeamNames,
+): RoundRow[] {
+  if (!replay) return [];
+
+  const scoreDeltas = buildScoreDeltas(replay);
+
+  return replay.rounds
+    // The pre-game bucket has no round number; web filters it out of the table.
+    .filter((round) => round.roundNumber !== null)
+    .slice()
+    .sort((a, b) => (b.roundNumber ?? 0) - (a.roundNumber ?? 0))
+    .map((round) => {
+      const declarations = round.events.filter(
+        (event) => event.actionType === 'blow_declared',
+      );
+      const declaration = declarations[declarations.length - 1];
+      const playStarted = round.events.find(
+        (event) => event.actionType === 'play_phase_started',
+      );
+      const completions = round.events.filter(
+        (event) => event.actionType === 'round_completed',
+      );
+      const completion = completions[completions.length - 1];
+
+      // Blower fallback chain, matching web.
+      const blower =
+        (declaration?.playerId
+          ? playerNamesOf(declaration)[declaration.playerId]
+          : null) ??
+        getTextDetail(playStarted, 'winner') ??
+        (playStarted?.playerId
+          ? playerNamesOf(playStarted)[playStarted.playerId]
+          : null) ??
+        players.find((player) => player.playerId === declaration?.playerId)
+          ?.name ??
+        PARTICIPANT;
+
+      const bid = formatBid(
+        getTextDetail(declaration, 'highestDeclaration') ??
+          getTextDetail(declaration, 'declaration'),
+      );
+
+      const delta = completion ? scoreDeltas.get(completion.id) : undefined;
+
+      return {
+        roundNumber: round.roundNumber as number,
+        blower,
+        bid,
+        inProgress: !completion,
+        scores: ([0, 1] as Team[]).map((team) => ({
+          team,
+          label: getTeamDisplayName(team, teamNames),
+          delta: completion ? formatDelta(delta?.[String(team)]) : null,
+        })),
+      };
+    });
+}

--- a/mei-tra-mobile/src/lib/team-labels.ts
+++ b/mei-tra-mobile/src/lib/team-labels.ts
@@ -1,0 +1,17 @@
+import type { Team, TeamNames } from '@meitra/contracts/game';
+
+/**
+ * Team display names, ported from mei-tra-frontend/lib/utils/teamLabels.ts so
+ * both platforms agree.
+ *
+ * Mobile previously defaulted to `{n+1}組` / `チーム{n+1}` in four different
+ * components; web has always used 赤 / 黒.
+ */
+const DEFAULT_TEAM_NAMES: Record<Team, string> = {
+  0: '赤',
+  1: '黒',
+};
+
+export function getTeamDisplayName(team: Team, teamNames?: TeamNames): string {
+  return teamNames?.[team]?.trim() || DEFAULT_TEAM_NAMES[team];
+}

--- a/mei-tra-mobile/src/lib/trump-labels.ts
+++ b/mei-tra-mobile/src/lib/trump-labels.ts
@@ -1,0 +1,22 @@
+import type { TrumpType } from '@meitra/contracts/game';
+
+/**
+ * Trump display names, matching the web app verbatim
+ * (mei-tra-frontend/messages/ja.json → `blowControls`).
+ *
+ * Mobile previously spelled these differently in two places (`トラ` instead of
+ * `ノートラ`, and bare suit glyphs rather than parenthesised ones), which meant
+ * the same trump had two names inside one app.
+ */
+export const TRUMP_LABELS: Record<TrumpType, string> = {
+  tra: 'ノートラ',
+  herz: 'ヘル (♥)',
+  daiya: 'ダイヤ (♦)',
+  club: 'クラブ (♣)',
+  zuppe: 'ズッペ (♠)',
+};
+
+export function trumpLabel(trump: TrumpType | string | null | undefined): string {
+  if (!trump) return '';
+  return TRUMP_LABELS[trump as TrumpType] ?? String(trump);
+}

--- a/mei-tra-mobile/src/theme/cards.ts
+++ b/mei-tra-mobile/src/theme/cards.ts
@@ -1,0 +1,33 @@
+/**
+ * Card geometry, derived from the artwork rather than guessed.
+ *
+ * The card SVGs use `viewBox="0 0 210 315"` — exactly 2:3 — and round their
+ * own corners with `rx="15"`. Deriving height and radius from width keeps every
+ * card variant consistent with the art instead of drifting the way the previous
+ * three hard-coded sizes did (they were 0.690 / 0.700 / 0.714, none of them 2:3).
+ */
+export const CARD_ASPECT = 3 / 2;
+export const CARD_RADIUS_RATIO = 15 / 210;
+
+export type CardSize = 'hand' | 'field' | 'seat';
+
+export const CARD_BASE_WIDTHS: Record<CardSize, number> = {
+  hand: 60,
+  field: 44,
+  seat: 30,
+};
+
+/**
+ * Accessibility multiplier mirroring the web `--mt-card-scale`
+ * (mei-tra-frontend/app/globals.scss). Wired through every card dimension so a
+ * settings toggle can be added later without touching components.
+ */
+export const CARD_SCALES = {
+  normal: 1,
+  large: 1.1,
+  xlarge: 1.2,
+} as const;
+
+export const cardHeight = (width: number): number => width * CARD_ASPECT;
+export const cardRadius = (width: number): number =>
+  Math.round(width * CARD_RADIUS_RATIO);

--- a/mei-tra-mobile/src/theme/colors.ts
+++ b/mei-tra-mobile/src/theme/colors.ts
@@ -1,18 +1,70 @@
+import { palette } from './palette';
+
+/**
+ * Component-facing colour surface.
+ *
+ * Every value is derived from `palette.ts` (the semantic layer mirroring the
+ * web app's `--mt-*` tokens) — nothing is hard-coded here. Keeping these flat
+ * names means the ~250 existing call sites did not have to churn, while the
+ * values themselves now match the web design system exactly.
+ *
+ * Prefer `palette` (or `theme` from './index') in new code; this object exists
+ * so that components read a short name at the point of use.
+ */
 export const colors = {
-  background: '#082f26',
-  backgroundElevated: '#0d3b31',
-  panel: '#123f35',
-  panelStrong: '#184b3f',
-  border: '#326357',
-  text: '#f4f0df',
-  textMuted: '#acb9ad',
-  gold: '#c49a3a',
-  goldPressed: '#a77f28',
-  danger: '#d66b62',
-  warning: '#d4a839',
-  success: '#6bb995',
-  card: '#fffdf4',
-  cardText: '#15201b',
-  redSuit: '#c63832',
-  overlay: 'rgba(3, 22, 18, 0.76)',
+  // Surfaces
+  background: palette.surface.felt,
+  backgroundElevated: palette.surface.raised,
+  panel: palette.surface.raised,
+  panelStrong: palette.surface.raised2,
+
+  // Lines
+  border: palette.border.hairline,
+
+  // Text
+  text: palette.text.primary,
+  textMuted: palette.text.secondary,
+  /** Text on a brass fill. Replaces the seven hard-coded `#fff` sites. */
+  onAccent: palette.text.onAccent,
+  /** Text on a danger fill. */
+  onDanger: palette.text.onDanger,
+
+  // Accent (brass)
+  gold: palette.accent.base,
+  goldPressed: palette.accent.pressed,
+  goldStrong: palette.accent.strong,
+  goldSubtle: palette.accent.subtle,
+
+  // Status
+  danger: palette.status.danger,
+  dangerSubtle: palette.status.dangerSubtle,
+  dangerText: palette.status.dangerText,
+  warning: palette.status.warning,
+  success: palette.status.success,
+
+  // Physical card chrome (the artwork carries its own colours)
+  card: palette.card.face,
+  cardText: palette.card.ink,
+  redSuit: palette.card.red,
+  cardBack: palette.card.back,
+  cardDisabled: palette.overlay.cardDisabled,
+
+  overlay: palette.overlay.scrim,
 } as const;
+
+/**
+ * Team identity, indexed by the `Team` value (0 | 1) used across the contracts,
+ * so `teamColors[player.team]` reads naturally.
+ *
+ * This replaces three conflicting palettes that previously coexisted
+ * (`['#c0392b','#2c3e50']` in ScoreBoard/WaitingRoom, and an inline
+ * `'#8b2020' / '#1a2a2a'` in GameBoard/PlayerSeat), which is why team badges
+ * and the scoreboard did not agree.
+ *
+ * NOTE: team 1 is deliberately LIGHT — the web uses these as text colours, not
+ * fills. Render team badges as outline-style (tinted border + matching text on
+ * a raised surface), never as a solid fill with white text.
+ */
+export const teamColors = palette.team;
+
+export const trumpColors = palette.trump;

--- a/mei-tra-mobile/src/theme/index.ts
+++ b/mei-tra-mobile/src/theme/index.ts
@@ -1,0 +1,29 @@
+import { palette } from './palette';
+import { radius } from './radius';
+import { shadows } from './shadows';
+import { spacing } from './spacing';
+import { typography } from './typography';
+
+export { palette } from './palette';
+export { radius } from './radius';
+export { shadows } from './shadows';
+export { spacing } from './spacing';
+export { typography } from './typography';
+export { raw } from './raw';
+export {
+  CARD_ASPECT,
+  CARD_BASE_WIDTHS,
+  CARD_RADIUS_RATIO,
+  CARD_SCALES,
+  cardHeight,
+  cardRadius,
+} from './cards';
+export type { CardSize } from './cards';
+
+export const theme = {
+  color: palette,
+  spacing,
+  radius,
+  type: typography,
+  shadow: shadows,
+} as const;

--- a/mei-tra-mobile/src/theme/palette.ts
+++ b/mei-tra-mobile/src/theme/palette.ts
@@ -1,0 +1,95 @@
+import { raw } from './raw';
+
+/**
+ * Layer 2 — semantic colour roles, mirrored from the web app's `--mt-*` tokens.
+ *
+ * Only the DARK values are defined; the mobile app ships a single theme
+ * (`app.json` pins `userInterfaceStyle: "dark"`). Adding a light theme later
+ * means duplicating this one file and swapping the exported object — no
+ * component needs to change, because components only ever reference roles.
+ */
+export const palette = {
+  surface: {
+    felt: raw.felt900,
+    raised: raw.felt800,
+    raised2: raw.felt700,
+    raised3: raw.felt600,
+  },
+
+  text: {
+    primary: raw.ivory,
+    secondary: raw.sage,
+    muted: 'rgba(169, 183, 166, 0.6)',
+    // Text sitting on an accent (brass) fill.
+    onAccent: raw.felt800,
+    // Text sitting on a danger fill. Mode-stable on web.
+    onDanger: raw.ivory,
+    onSuccess: raw.felt900,
+  },
+
+  accent: {
+    base: raw.brass500,
+    strong: raw.brass300,
+    pressed: raw.brass600,
+    subtle: 'rgba(201, 163, 78, 0.14)',
+  },
+
+  border: {
+    hairline: 'rgba(236, 230, 214, 0.12)',
+    focus: raw.brass500,
+  },
+
+  status: {
+    danger: '#c0362c',
+    dangerSubtle: 'rgba(192, 54, 44, 0.16)',
+    success: '#6fb98f',
+    warning: '#e0c784',
+    /**
+     * Danger used as TEXT on the felt background.
+     *
+     * Deliberately lighter than `danger`. The web app colours error text with
+     * `--mt-danger` (#c0362c) directly, which is ~3.2:1 against felt — below
+     * WCAG AA. Matching web exactly here would be an accessibility regression,
+     * so mobile keeps the ~7:1 tint. Revisit if web fixes its own contrast.
+     */
+    dangerText: '#ffb0a8',
+  },
+
+  /**
+   * Physical card tokens — mode-stable on web ("a card's identity must not
+   * shift with chrome theme"). These describe card *chrome* (chips, borders,
+   * placeholders); the card artwork itself carries its own colours inside the
+   * SVG and is deliberately left untouched.
+   */
+  card: {
+    face: '#f4f0e3',
+    ink: '#23281f',
+    red: '#c0362c',
+    back: '#173d30',
+  },
+
+  /**
+   * Team identity. Indexed by the `Team` value (0 | 1) used across the
+   * contracts, so `team[player.team]` reads naturally at call sites.
+   *
+   * NOTE: team[1] is intentionally LIGHT (web uses these as text colours, not
+   * fills). Badges must therefore be outline-style — a tinted border and
+   * matching text on a raised surface — never a solid fill with white text.
+   */
+  team: [raw.cardRed, '#c8d1c8'] as const,
+
+  trump: {
+    tra: '#e0b24a',
+    herz: '#e07264',
+    daiya: '#6fa0d6',
+    club: '#86be6e',
+    zuppe: '#c9c1b0',
+  },
+
+  overlay: {
+    scrim: 'rgba(0, 0, 0, 0.7)',
+    // Laid over a disabled card. Web uses `filter: brightness(.45) saturate(.3)`,
+    // which React Native has no dependable cross-platform equivalent for.
+    cardDisabled: 'rgba(14, 42, 33, 0.55)',
+  },
+} as const;

--- a/mei-tra-mobile/src/theme/radius.ts
+++ b/mei-tra-mobile/src/theme/radius.ts
@@ -1,0 +1,12 @@
+/**
+ * `base` is the web app's signature `--mt-radius: 6px`; the rest mirror the
+ * `$radius-*` scale.
+ */
+export const radius = {
+  sm: 4,
+  base: 6,
+  md: 8,
+  lg: 16,
+  xl: 24,
+  pill: 999,
+} as const;

--- a/mei-tra-mobile/src/theme/raw.ts
+++ b/mei-tra-mobile/src/theme/raw.ts
@@ -1,0 +1,32 @@
+/**
+ * Layer 1 — the raw palette, mirrored from the web app's `--mt-raw-*` tokens
+ * (mei-tra-frontend/styles/base/variables.scss).
+ *
+ * These are theme-independent hex values. Components must never import from
+ * here; consume `palette.ts` instead so a light theme can be added later by
+ * swapping one file.
+ */
+export const raw = {
+  felt900: '#0e2a21',
+  felt800: '#12352a',
+  felt700: '#173d30',
+  felt600: '#1b4a3a',
+
+  pale100: '#f4f0e3',
+  pale200: '#e9e5d5',
+  pale300: '#dad5c2',
+
+  brass300: '#e0c784',
+  brass500: '#c9a34e',
+  brass600: '#a9863b',
+  brass700: '#8a6c2e',
+
+  ivory: '#ece6d6',
+  sage: '#a9b7a6',
+
+  ink900: '#23281f',
+  ink600: '#4a5142',
+
+  cardRed: '#c0362c',
+  cardRedDark: '#9e2a22',
+} as const;

--- a/mei-tra-mobile/src/theme/shadows.ts
+++ b/mei-tra-mobile/src/theme/shadows.ts
@@ -1,0 +1,32 @@
+import type { ViewStyle } from 'react-native';
+
+/**
+ * React Native shadow objects mirroring the web shadow tokens.
+ *
+ * CSS blur maps to iOS `shadowRadius` at roughly half its value; `elevation`
+ * approximates the same weight on Android. Do NOT use the web `boxShadow`
+ * string form here — it does not render consistently across platforms.
+ */
+const shadow = (
+  offsetY: number,
+  blur: number,
+  opacity: number,
+  elevation: number,
+): ViewStyle => ({
+  shadowColor: '#000',
+  shadowOffset: { width: 0, height: offsetY },
+  shadowOpacity: opacity,
+  shadowRadius: blur / 2,
+  elevation,
+});
+
+export const shadows = {
+  /** --mt-shadow-panel: 0 8px 24px rgba(0,0,0,.35) */
+  panel: shadow(8, 24, 0.35, 8),
+  /** --mt-shadow-btn: 0 4px 10px rgba(0,0,0,.28) */
+  button: shadow(4, 10, 0.28, 4),
+  /** $shadow-card: 0 2px 4px rgba(0,0,0,.2) */
+  card: shadow(2, 4, 0.2, 3),
+  /** --shadow-selected: 0 8px 20px rgba(0,0,0,.5) */
+  cardSelected: shadow(8, 20, 0.5, 10),
+} as const;

--- a/mei-tra-mobile/src/theme/spacing.ts
+++ b/mei-tra-mobile/src/theme/spacing.ts
@@ -1,0 +1,10 @@
+/**
+ * 4pt grid, matching the web `$spacing-*` scale (rem values at a 16px root).
+ */
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 32,
+  xl: 48,
+} as const;

--- a/mei-tra-mobile/src/theme/typography.ts
+++ b/mei-tra-mobile/src/theme/typography.ts
@@ -1,0 +1,20 @@
+/**
+ * Type scale mirroring the web `$font-size-*` tokens (rem at a 16px root),
+ * rounded to whole points.
+ */
+export const typography = {
+  size: {
+    xs: 11,
+    sm: 14,
+    base: 16,
+    lg: 22,
+    xl: 32,
+    xxl: 35,
+  },
+  weight: {
+    regular: '400',
+    medium: '500',
+    bold: '700',
+    heavy: '900',
+  },
+} as const;


### PR DESCRIPTION
モバイル版デザイン刷新の第1弾です。ネイティブ依存の追加は無く、純粋なJS/TS変更のみです。

## 1. デザイントークンをWeb版の `--mt-*` 体系に統一

モバイルは18個のフラットな色定数のみで、Webの51個のセマンティックトークン体系と乖離していました。

`src/theme/` を2層構造に再編しました。

- `raw.ts` — Webの `--mt-raw-*` をそのまま写した生パレット
- `palette.ts` — セマンティックロール（dark値のみ）
- `spacing` / `radius` / `typography` / `shadows` / `cards` / `index`

将来 light テーマを足す場合は `palette.ts` 1枚を複製して差し替えるだけで済み、コンポーネントは触らずに済む構造にしています。

### チームカラーの不一致を解消

**3系統が併存していて、スコアボードと席バッジの色が食い違っていました。**

| 場所 | 旧 |
|---|---|
| ScoreBoard / WaitingRoom | `['#c0392b', '#2c3e50']` |
| GameBoard / PlayerSeat | インライン `'#8b2020' / '#1a2a2a'` |

`teamColors` に集約しました。なお Web の `--mt-team-black` (`#c8d1c8`) は**明色でテキスト色として使われている**ため、バッジは塗りつぶし＋白文字ではなく**アウトライン形式**（枠線＋同色文字）に変更しています。これに伴い白文字7箇所のうち5箇所が不要になりました。

### その他

- 残る白文字2箇所は danger 塗りの上なので `onDanger` へ
- `ConnectionBanner` の手作りアルファを `goldSubtle` / `dangerSubtle` へ
- `app.json` の起動時カラー3箇所を `#082f26` → `#0e2a21`（コールドスタート時に旧配色が一瞬見える問題の解消）

## 2. 対局ログをWeb版と同じ4列表に

モバイルは全イベントの生フィードを表示しており、しかも各行の本文は**バックエンドが生成した英語文字列**をそのまま出していたため、日本語バッジの横に英文が並ぶ状態でした。

Webのドック相当（ラウンド / 吹き手 / 宣言 / 得点）に作り直しました。ラウンド降順で、`roundNumber` が null のプレギャクは除外します（従来はこれを「ラウンド1」と誤表示していました）。

派生ロジックは `src/lib/game-log-rows.ts` に純粋関数として切り出しました。モバイルにはコンポーネントを描画するテスト基盤が無いため、得点デルタの算出・吹き手のフォールバック連鎖・宣言文字列の整形をレンダラ抜きで検証できる形にしています。

`GameHistory` に `players` と `teamNames` を渡すよう配線しました（従来は未接続で、カスタムチーム名を解決できませんでした）。

## 3. 表記をWebへ統一

- トランプ名: 「トラ」→「ノートラ」、「ヘル ♥」→「ヘル (♥)」等。`BlowControls` と `GameBoard` の重複定義も解消
- チーム名の既定値: 「1組」「チーム1」→「赤」「黒」
- モーダル表題:「ゲーム履歴」→「対局ログ」

## 検証

| 項目 | 結果 |
|---|---|
| `npm run typecheck` | 通過 |
| `npm run lint` | 通過 |
| `npm test` | 18 suites / 86 tests 通過（回帰テスト9件を追加） |
| `npm run validate:eas-monorepo` | 通過 |

## 判断を2点、明示しておきます

**`colors.ts` は残しました。** 当初は削除して約250箇所の参照名をリネームする想定でしたが、コンポーネントテストがほぼ無い状態での250箇所の機械的変更はリスクに見合わないと判断しました。値は全て `palette.ts` 由来なので、見た目の統一という目的は達成しています。参照名の形は後から安全に変えられます。

**`settings.tsx` の `#ffb0a8` はWebに追随していません。** Webは同用途に `--mt-danger` (`#c0362c`) を直接使っていますが、フェルト背景でコントラスト比が約3.2:1と WCAG AA 未満です。値を保ったまま `dangerText` トークンとして切り出し、理由をコードコメントに残しました。Web側も本来直すべき箇所だと思います。

## 未実施

視覚確認（シミュレータ）は行っていません。後続PRでカード描画を入れる際に `react-native-svg` のためdev-clientの再ビルドが必要になるので、そのタイミングでまとめて確認する想定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)