### PR TITLE
モバイル: 手札が画面外に溢れる問題を修正しレイアウトを相対化

### DIFF
--- a/mei-tra-frontend/components/game/BlowControls/index.module.scss
+++ b/mei-tra-frontend/components/game/BlowControls/index.module.scss
@@ -80,7 +80,7 @@
 .trumpLabel[data-trump='daiya'],
 .trumpOption[data-trump='herz'],
 .trumpOption[data-trump='daiya'] {
-  color: var(--mt-card-red);
+  color: var(--mt-suit-red);
 }
 
 .trumpSelect[data-trump='club'],

--- a/mei-tra-frontend/components/game/BlowSpectatorPanel/index.module.scss
+++ b/mei-tra-frontend/components/game/BlowSpectatorPanel/index.module.scss
@@ -142,7 +142,7 @@
 
 .trump[data-trump='herz'],
 .trump[data-trump='daiya'] {
-  color: var(--mt-card-red);
+  color: var(--mt-suit-red);
 }
 
 .trump[data-trump='club'],

--- a/mei-tra-frontend/components/game/GameField/index.module.scss
+++ b/mei-tra-frontend/components/game/GameField/index.module.scss
@@ -165,7 +165,7 @@
 }
 
 .suitButtons button.redSuit {
-  color: var(--mt-card-red);
+  color: var(--mt-suit-red);
 }
 
 .suitButtons button.blackSuit {

--- a/mei-tra-frontend/components/game/GameHistoryDock.module.scss
+++ b/mei-tra-frontend/components/game/GameHistoryDock.module.scss
@@ -142,7 +142,7 @@
 }
 
 .teamZero {
-  background: var(--mt-card-red);
+  background: var(--mt-team-red);
 }
 
 .teamOne {
@@ -474,7 +474,7 @@
 
 .teamRed .roundTeamLabel,
 .teamRed .roundTeamDelta {
-  color: var(--mt-card-red);
+  color: var(--mt-team-red);
 }
 
 .teamBlack .roundTeamLabel,

--- a/mei-tra-frontend/components/game/GameInfo/index.module.scss
+++ b/mei-tra-frontend/components/game/GameInfo/index.module.scss
@@ -84,15 +84,15 @@
 }
 
 .teamRed {
-  color: var(--mt-card-red);
+  color: var(--mt-team-red);
 
   .gameInfoScoreFill {
-    background: color-mix(in srgb, var(--mt-card-red) 88%, var(--mt-text-primary) 12%);
+    background: color-mix(in srgb, var(--mt-team-red) 88%, var(--mt-text-primary) 12%);
   }
 
   .gameInfoScoreTeam,
   .gameInfoScoreStatus {
-    color: var(--mt-card-red);
+    color: var(--mt-team-red);
   }
 }
 

--- a/mei-tra-frontend/components/game/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/game/PlayerHand/index.module.scss
@@ -290,26 +290,26 @@
   height: 1.6rem;
   padding: 0;
   border-radius: 50%;
-  background: var(--mt-surface-raised);
-  // The badge deliberately overhangs the seat corner. Without a defined edge it
-  // reads as the card's fill bleeding past the border-radius — very visible in
-  // light mode, where surface-raised is near-white against the sage felt.
-  border: 1px solid var(--mt-border-hairline);
-  box-shadow: 0 1px 3px var(--mt-accent-subtle);
-  color: var(--mt-accent-strong);
+  // Inverted on purpose: a solid brass disc with an ivory dial. A light disc
+  // sat on a light card in light mode and read as the card's fill bleeding past
+  // its border-radius, and no amount of outline fixed that — the fill itself
+  // was the problem. Brass also carries the "your turn" accent semantics.
+  background: var(--mt-accent);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  color: var(--mt-raw-pale-100);
   line-height: 1;
   box-sizing: border-box;
 }
 
 .turnBadge svg {
   display: block;
-  width: 100%;
-  height: 100%;
+  width: 78%;
+  height: 78%;
   fill: none;
   stroke: currentColor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2.6;
+  stroke-width: 2;
 }
 
 .clockHand {

--- a/mei-tra-frontend/components/game/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/game/PlayerHand/index.module.scss
@@ -289,12 +289,16 @@
   width: 1.6rem;
   height: 1.6rem;
   padding: 0;
-  border: 0;
   border-radius: 50%;
   background: var(--mt-surface-raised);
+  // The badge deliberately overhangs the seat corner. Without a defined edge it
+  // reads as the card's fill bleeding past the border-radius — very visible in
+  // light mode, where surface-raised is near-white against the sage felt.
+  border: 1px solid var(--mt-border-hairline);
   box-shadow: 0 1px 3px var(--mt-accent-subtle);
   color: var(--mt-accent-strong);
   line-height: 1;
+  box-sizing: border-box;
 }
 
 .turnBadge svg {

--- a/mei-tra-frontend/components/game/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/game/PlayerHand/index.module.scss
@@ -275,7 +275,9 @@
 }
 
 .teamRedBadge {
-  color: var(--mt-danger);
+  // Was --mt-danger, which is an error-state role that happened to share the
+  // dark theme's hex with the card red. Team identity is its own role.
+  color: var(--mt-team-red);
 }
 
 .teamBlackBadge {
@@ -303,8 +305,13 @@
 
 .turnBadge svg {
   display: block;
-  width: 78%;
-  height: 78%;
+  // Full-bleed, with the ring's outer edge (r 11 + half of stroke-width 2)
+  // landing exactly on the 12-unit viewBox radius, so the dial rim and the
+  // brass disc read as one shape. At 78% the dial floated inside the disc.
+  // Kept in step with mei-tra-mobile TurnClock.tsx, which uses the same
+  // geometry — changing one without the other makes the platforms diverge.
+  width: 100%;
+  height: 100%;
   fill: none;
   stroke: currentColor;
   stroke-linecap: round;

--- a/mei-tra-frontend/components/game/PlayerHand/index.module.scss
+++ b/mei-tra-frontend/components/game/PlayerHand/index.module.scss
@@ -197,7 +197,7 @@
 
 .declarationSuit[data-trump='herz'],
 .declarationSuit[data-trump='daiya'] {
-  color: var(--mt-card-red);
+  color: var(--mt-suit-red);
 }
 
 .declarationSuit[data-trump='club'],

--- a/mei-tra-frontend/components/game/PlayerHand/index.tsx
+++ b/mei-tra-frontend/components/game/PlayerHand/index.tsx
@@ -384,7 +384,7 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
       title={t('currentTurn')}
     >
       <svg viewBox="0 0 24 24" aria-hidden="true">
-        <circle cx="12" cy="12" r="10.25" />
+        <circle cx="12" cy="12" r="11" />
         <path className={styles.clockHand} d="M12 12V5.75" />
         <circle className={styles.clockCenter} cx="12" cy="12" r="1.1" />
         <path d="M12 4.5v1M19.5 12h-1M12 19.5v-1M4.5 12h1" />

--- a/mei-tra-frontend/components/game/PreGameTable/index.module.scss
+++ b/mei-tra-frontend/components/game/PreGameTable/index.module.scss
@@ -121,9 +121,9 @@
 }
 
 .teamRedPill {
-  border: 1px solid color-mix(in srgb, var(--mt-card-red) 48%, transparent);
-  background: color-mix(in srgb, var(--mt-card-red) 14%, var(--mt-surface-raised));
-  color: var(--mt-card-red);
+  border: 1px solid color-mix(in srgb, var(--mt-team-red) 48%, transparent);
+  background: color-mix(in srgb, var(--mt-team-red) 14%, var(--mt-surface-raised));
+  color: var(--mt-team-red);
 }
 
 .teamBlackPill {
@@ -189,7 +189,7 @@
 }
 
 .teamRedField {
-  color: var(--mt-card-red);
+  color: var(--mt-team-red);
 }
 
 .teamBlackField {
@@ -277,9 +277,9 @@
 }
 
 .teamRed .teamBadge {
-  border: 1px solid color-mix(in srgb, var(--mt-card-red) 48%, transparent);
-  background: color-mix(in srgb, var(--mt-card-red) 14%, var(--mt-surface-raised));
-  color: var(--mt-card-red);
+  border: 1px solid color-mix(in srgb, var(--mt-team-red) 48%, transparent);
+  background: color-mix(in srgb, var(--mt-team-red) 14%, var(--mt-surface-raised));
+  color: var(--mt-team-red);
 }
 
 .teamBlack .teamBadge {

--- a/mei-tra-frontend/styles/base/variables.scss
+++ b/mei-tra-frontend/styles/base/variables.scss
@@ -163,6 +163,7 @@ $z-index-tooltip: 50;
   --mt-raw-ink-600: #4a5142;
   --mt-raw-card-red: #c0362c;
   --mt-raw-card-red-dk: #9e2a22;
+  --mt-raw-card-red-md: #e88b80;
   --mt-raw-card-red-lt: #eda79d;
 
   // Font stacks — JP fallback ordering is load-bearing (Latin faces render no CJK)
@@ -216,6 +217,12 @@ $z-index-tooltip: 50;
   --mt-team-red: var(--mt-raw-card-red-lt);
   --mt-team-black: #c8d1c8;
 
+  // A red suit glyph drawn on felt rather than on a card. Same reasoning as
+  // --mt-team-red: --mt-card-red is ink for the ivory card face (4.84:1 there),
+  // and only reaches 2.18:1 once the same glyph is lifted onto
+  // --mt-surface-raised-2. Anything rendered ON a card keeps --mt-card-red.
+  --mt-suit-red: var(--mt-raw-card-red-md);
+
   // Shadows
   --mt-shadow-panel: 0 8px 24px rgba(0, 0, 0, 0.35);
   --mt-shadow-btn: 0 4px 10px rgba(0, 0, 0, 0.28);
@@ -257,6 +264,7 @@ html[data-theme='light'] {
   --mt-on-success: var(--mt-raw-pale-100);
   --mt-team-red: var(--mt-raw-card-red-dk);
   --mt-team-black: var(--mt-raw-ink-900);
+  --mt-suit-red: var(--mt-raw-card-red-dk);
 
   --mt-shadow-panel: 0 6px 20px rgba(35, 40, 31, 0.2), 0 1px 2px rgba(35, 40, 31, 0.14);
   --mt-shadow-btn: 0 3px 8px rgba(35, 40, 31, 0.18);

--- a/mei-tra-frontend/styles/base/variables.scss
+++ b/mei-tra-frontend/styles/base/variables.scss
@@ -163,6 +163,7 @@ $z-index-tooltip: 50;
   --mt-raw-ink-600: #4a5142;
   --mt-raw-card-red: #c0362c;
   --mt-raw-card-red-dk: #9e2a22;
+  --mt-raw-card-red-lt: #eda79d;
 
   // Font stacks — JP fallback ordering is load-bearing (Latin faces render no CJK)
   --mt-font-heading: var(--font-fraunces), var(--font-shippori-mincho), 'Shippori Mincho', serif;
@@ -205,6 +206,14 @@ $z-index-tooltip: 50;
   --mt-card-ink: #23281f;
   --mt-card-red: #c0362c;
   --mt-card-back: #173d30;
+
+  // Team identity ink. NOT the same role as --mt-card-red: these are read as
+  // TEXT on felt, so both sides are chosen for legibility rather than for
+  // matching the card artwork. --mt-team-black has always been light for that
+  // reason; --mt-team-red is its counterpart (--mt-card-red as text on
+  // --mt-surface-raised-2 is 2.18:1, against 7.68:1 for the black side).
+  // Unlike the card tokens above these flip per theme — see the light block.
+  --mt-team-red: var(--mt-raw-card-red-lt);
   --mt-team-black: #c8d1c8;
 
   // Shadows
@@ -246,6 +255,7 @@ html[data-theme='light'] {
   --mt-success: #3b7a57;
   --mt-warning: #8a6c2e;
   --mt-on-success: var(--mt-raw-pale-100);
+  --mt-team-red: var(--mt-raw-card-red-dk);
   --mt-team-black: var(--mt-raw-ink-900);
 
   --mt-shadow-panel: 0 6px 20px rgba(35, 40, 31, 0.2), 0 1px 2px rgba(35, 40, 31, 0.14);

--- a/mei-tra-mobile/src/components/game/GameBoard.tsx
+++ b/mei-tra-mobile/src/components/game/GameBoard.tsx
@@ -357,8 +357,13 @@ export function GameBoard({
               player.playerId,
             );
             const isIdle = game.idlePlayerIds.includes(player.playerId);
+            // Matches the web condition (PlayerHand/index.tsx): the host never
+            // sees the control on their own seat.
             const showReplacePanel =
-              isHost && !player.isCOM && (isDisconnected || isIdle);
+              isHost &&
+              !player.isCOM &&
+              player.playerId !== game.you &&
+              (isDisconnected || isIdle);
             return (
               <View key={player.playerId} style={posStyle}>
                 {wrapped}

--- a/mei-tra-mobile/src/components/game/GameBoard.tsx
+++ b/mei-tra-mobile/src/components/game/GameBoard.tsx
@@ -21,6 +21,7 @@ import { GameHistory } from '@/components/game/GameHistory';
 import { PlayerSeat } from '@/components/game/PlayerSeat';
 import { PlayingCard } from '@/components/game/PlayingCard';
 import { useHandFanMetrics } from '@/hooks/useHandFanMetrics';
+import { CARD_BASE_WIDTHS, cardStackMargin } from '@/theme/cards';
 import { ScoreBoard } from '@/components/game/ScoreBoard';
 import { ChatPanel } from '@/components/social/ChatPanel';
 import { Button } from '@/components/ui/Button';
@@ -580,6 +581,16 @@ export function GameBoard({
 
             {game.gamePhase === 'play' && selectedCard ? (
               <View style={styles.selectedActions}>
+                {/* Cancel sits left, confirm right — the destructive/back action
+                    on the outside, the primary action under the thumb. */}
+                <Button
+                  disabled={actionsDisabled || Boolean(pendingAction)}
+                  onPress={() => setSelectedCard(null)}
+                  style={styles.actionButton}
+                  variant="secondary"
+                >
+                  キャンセル
+                </Button>
                 <Button
                   disabled={
                     actionsDisabled ||
@@ -591,14 +602,6 @@ export function GameBoard({
                   style={styles.actionButton}
                 >
                   {mustSelectNegri ? 'ネグリにする' : 'プレイ'}
-                </Button>
-                <Button
-                  disabled={actionsDisabled || Boolean(pendingAction)}
-                  onPress={() => setSelectedCard(null)}
-                  style={styles.actionButton}
-                  variant="secondary"
-                >
-                  キャンセル
                 </Button>
               </View>
             ) : null}
@@ -999,7 +1002,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.backgroundElevated,
   },
   completedCardOverlap: {
-    marginLeft: -12,
+    marginLeft: cardStackMargin(CARD_BASE_WIDTHS.seat),
   },
   handSection: {
     gap: 8,

--- a/mei-tra-mobile/src/components/game/GameBoard.tsx
+++ b/mei-tra-mobile/src/components/game/GameBoard.tsx
@@ -1204,12 +1204,15 @@ const styles = StyleSheet.create({
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
     backgroundColor: colors.background,
+    paddingHorizontal: 16,
+    paddingBottom: 16,
   },
   historyHeader: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    paddingHorizontal: 18,
+    // Horizontal inset lives on historyCard so the header, the table and the
+    // sheet edge all line up.
     paddingTop: 16,
     paddingBottom: 8,
   },

--- a/mei-tra-mobile/src/components/game/GameBoard.tsx
+++ b/mei-tra-mobile/src/components/game/GameBoard.tsx
@@ -12,6 +12,7 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  useWindowDimensions,
   View,
 } from 'react-native';
 
@@ -19,6 +20,7 @@ import { BlowControls } from '@/components/game/BlowControls';
 import { GameHistory } from '@/components/game/GameHistory';
 import { PlayerSeat } from '@/components/game/PlayerSeat';
 import { PlayingCard } from '@/components/game/PlayingCard';
+import { useHandFanMetrics } from '@/hooks/useHandFanMetrics';
 import { ScoreBoard } from '@/components/game/ScoreBoard';
 import { ChatPanel } from '@/components/social/ChatPanel';
 import { Button } from '@/components/ui/Button';
@@ -112,6 +114,14 @@ export function GameBoard({
   const self = game.players.find(
     (player) => player.playerId === perspectivePlayerId,
   );
+  const { width: windowWidth } = useWindowDimensions();
+  const selfHandCount = game.players.find(
+    (player) => player.playerId === game.you,
+  )?.hand.length ?? 0;
+  // board padding (20) + self panel (~86) + fan padding (20)
+  const fanAvailableWidth = windowWidth - 126;
+  const { cardWidth: handCardWidth, cardMargin: handCardMargin } =
+    useHandFanMetrics(fanAvailableWidth, selfHandCount);
   const orderedPlayers = useMemo(
     () => getSeatOrderWithSelfBottom(game.players, perspectivePlayerId),
     [game.players, perspectivePlayerId],
@@ -535,7 +545,7 @@ export function GameBoard({
                     key={`${card}-${index}`}
                     style={[
                       styles.fanCard,
-                      total > 1 && { marginHorizontal: -6 },
+                      total > 1 && { marginHorizontal: handCardMargin },
                       {
                         transform: [
                           { rotate: `${rotation}deg` },
@@ -546,6 +556,7 @@ export function GameBoard({
                   >
                     <PlayingCard
                       card={card}
+                      width={handCardWidth}
                       disabled={
                         isPlayPhase &&
                         (actionsDisabled ||
@@ -998,7 +1009,9 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   selfCard: {
-    width: 80,
+    minWidth: 64,
+    maxWidth: 92,
+    flexBasis: '22%',
     alignItems: 'center',
     gap: 3,
     padding: 6,
@@ -1070,6 +1083,7 @@ const styles = StyleSheet.create({
   },
   fanContainer: {
     minHeight: 104,
+    flexShrink: 1,
     flexDirection: 'row',
     alignItems: 'flex-end',
     justifyContent: 'center',

--- a/mei-tra-mobile/src/components/game/GameBoard.tsx
+++ b/mei-tra-mobile/src/components/game/GameBoard.tsx
@@ -116,9 +116,10 @@ export function GameBoard({
     (player) => player.playerId === perspectivePlayerId,
   );
   const { width: windowWidth } = useWindowDimensions();
-  const selfHandCount = game.players.find(
-    (player) => player.playerId === game.you,
-  )?.hand.length ?? 0;
+  // Size the fan from the hand it actually renders. Spectators have no
+  // `game.you`, so keying off that collapsed the count to 0 and the metrics
+  // fell through to the single-card branch (max width, zero overlap).
+  const selfHandCount = self?.hand.length ?? 0;
   // board padding (20) + self panel (~86) + fan padding (20)
   const fanAvailableWidth = windowWidth - 126;
   const { cardWidth: handCardWidth, cardMargin: handCardMargin } =

--- a/mei-tra-mobile/src/components/game/GameBoard.tsx
+++ b/mei-tra-mobile/src/components/game/GameBoard.tsx
@@ -19,6 +19,7 @@ import {
 import { BlowControls } from '@/components/game/BlowControls';
 import { GameHistory } from '@/components/game/GameHistory';
 import { PlayerSeat } from '@/components/game/PlayerSeat';
+import { MiniCard } from '@/components/game/MiniCard';
 import { PlayingCard } from '@/components/game/PlayingCard';
 import { useHandFanMetrics } from '@/hooks/useHandFanMetrics';
 import { CARD_BASE_WIDTHS, cardStackMargin } from '@/theme/cards';
@@ -626,7 +627,7 @@ export function GameBoard({
                           key={ci}
                           style={ci > 0 ? styles.completedCardOverlap : undefined}
                         >
-                          <PlayingCard card={card} size="seat" />
+                          <MiniCard card={card} />
                         </View>
                       ))}
                     </View>

--- a/mei-tra-mobile/src/components/game/GameBoard.tsx
+++ b/mei-tra-mobile/src/components/game/GameBoard.tsx
@@ -22,7 +22,6 @@ import { PlayerSeat } from '@/components/game/PlayerSeat';
 import { MiniCard } from '@/components/game/MiniCard';
 import { PlayingCard } from '@/components/game/PlayingCard';
 import { useHandFanMetrics } from '@/hooks/useHandFanMetrics';
-import { CARD_BASE_WIDTHS, cardStackMargin } from '@/theme/cards';
 import { ScoreBoard } from '@/components/game/ScoreBoard';
 import { ChatPanel } from '@/components/social/ChatPanel';
 import { Button } from '@/components/ui/Button';
@@ -623,12 +622,7 @@ export function GameBoard({
                   {myFields.map((field, idx) => (
                     <View key={idx} style={styles.completedChip}>
                       {field.cards.map((card, ci) => (
-                        <View
-                          key={ci}
-                          style={ci > 0 ? styles.completedCardOverlap : undefined}
-                        >
-                          <MiniCard card={card} />
-                        </View>
+                        <MiniCard card={card} key={ci} />
                       ))}
                     </View>
                   ))}
@@ -1006,9 +1000,6 @@ const styles = StyleSheet.create({
     padding: 2,
     borderRadius: 4,
     backgroundColor: colors.backgroundElevated,
-  },
-  completedCardOverlap: {
-    marginLeft: cardStackMargin(CARD_BASE_WIDTHS.seat),
   },
   handSection: {
     gap: 8,

--- a/mei-tra-mobile/src/components/game/GameHistory.tsx
+++ b/mei-tra-mobile/src/components/game/GameHistory.tsx
@@ -26,12 +26,17 @@ interface GameHistoryProps {
   teamNames?: TeamNames;
 }
 
-/** Column weights, tuned so the bid cell survives a 320pt screen. */
+/**
+ * Column weights, tuned so the "ラウンド" heading fits on one line down to 320pt
+ * (it needs ~44pt at 11px). It was 0.8, which left ~34pt and wrapped it to two
+ * lines. The cell itself only ever holds a one or two digit number, so the
+ * heading is what sets this column's width.
+ */
 const COL = {
-  round: 0.8,
-  blower: 2,
-  bid: 2.4,
-  score: 2.2,
+  round: 1.3,
+  blower: 1.8,
+  bid: 2.3,
+  score: 2.0,
 } as const;
 
 function Row({ row, index }: { row: RoundRow; index: number }) {
@@ -113,10 +118,18 @@ export function GameHistory({
       ) : (
         <>
           <View style={[styles.row, styles.headRow]}>
-            <Text style={[styles.headCell, { flex: COL.round }]}>ラウンド</Text>
-            <Text style={[styles.headCell, { flex: COL.blower }]}>吹き手</Text>
-            <Text style={[styles.headCell, { flex: COL.bid }]}>宣言</Text>
-            <Text style={[styles.headCell, { flex: COL.score }]}>得点</Text>
+            <Text numberOfLines={1} style={[styles.headCell, { flex: COL.round }]}>
+              ラウンド
+            </Text>
+            <Text numberOfLines={1} style={[styles.headCell, { flex: COL.blower }]}>
+              吹き手
+            </Text>
+            <Text numberOfLines={1} style={[styles.headCell, { flex: COL.bid }]}>
+              宣言
+            </Text>
+            <Text numberOfLines={1} style={[styles.headCell, { flex: COL.score }]}>
+              得点
+            </Text>
           </View>
           <ScrollView showsVerticalScrollIndicator={false}>
             {rows.map((row, index) => (

--- a/mei-tra-mobile/src/components/game/GameHistory.tsx
+++ b/mei-tra-mobile/src/components/game/GameHistory.tsx
@@ -34,9 +34,9 @@ const COL = {
   score: 2.2,
 } as const;
 
-function Row({ row }: { row: RoundRow }) {
+function Row({ row, index }: { row: RoundRow; index: number }) {
   return (
-    <View style={styles.row}>
+    <View style={[styles.row, index % 2 === 1 && styles.rowAlt]}>
       <Text style={[styles.cell, styles.roundCell, { flex: COL.round }]}>
         {row.roundNumber}
       </Text>
@@ -101,11 +101,6 @@ export function GameHistory({
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.subtitle}>
-          {rows.length > 0
-            ? `${rows.length}ラウンド / ${summary?.totalEntries ?? 0}件`
-            : 'まだログはありません'}
-        </Text>
         <Pressable hitSlop={8} onPress={onRefresh}>
           <Text style={styles.refresh}>更新</Text>
         </Pressable>
@@ -124,8 +119,8 @@ export function GameHistory({
             <Text style={[styles.headCell, { flex: COL.score }]}>得点</Text>
           </View>
           <ScrollView showsVerticalScrollIndicator={false}>
-            {rows.map((row) => (
-              <Row key={row.roundNumber} row={row} />
+            {rows.map((row, index) => (
+              <Row index={index} key={row.roundNumber} row={row} />
             ))}
           </ScrollView>
         </>
@@ -142,11 +137,7 @@ const styles = StyleSheet.create({
   header: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  subtitle: {
-    color: colors.textMuted,
-    fontSize: 12,
+    justifyContent: 'flex-end',
   },
   refresh: {
     color: colors.gold,
@@ -157,12 +148,19 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-    paddingVertical: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  rowAlt: {
+    backgroundColor: colors.panelStrong,
   },
   headRow: {
     borderBottomWidth: 1,
-    borderBottomColor: colors.border,
-    paddingVertical: 6,
+    borderBottomColor: colors.gold,
+    paddingVertical: 8,
+    backgroundColor: 'transparent',
   },
   headCell: {
     color: colors.textMuted,
@@ -172,6 +170,7 @@ const styles = StyleSheet.create({
   cell: {
     color: colors.text,
     fontSize: 13,
+    lineHeight: 18,
   },
   roundCell: {
     fontVariant: ['tabular-nums'],

--- a/mei-tra-mobile/src/components/game/GameHistory.tsx
+++ b/mei-tra-mobile/src/components/game/GameHistory.tsx
@@ -149,7 +149,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 8,
     paddingVertical: 10,
-    paddingHorizontal: 6,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: colors.border,
   },

--- a/mei-tra-mobile/src/components/game/MiniCard.tsx
+++ b/mei-tra-mobile/src/components/game/MiniCard.tsx
@@ -1,0 +1,53 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+import { parseCard } from '@/lib/cards';
+import { palette } from '@/theme/palette';
+import { radius } from '@/theme/radius';
+
+/**
+ * A rank+suit chip, mirroring the web app's completed-field cards
+ * (mei-tra-frontend/components/game/CompletedFields: .cardCorner).
+ *
+ * Won tricks are a tally, not something you read card by card, so web
+ * deliberately drops the artwork here. Rendering full SVG faces at this size
+ * was both noisier and more expensive than the information warranted.
+ */
+export function MiniCard({ card }: { card: string }) {
+  const { rank, suit, isRed } = parseCard(card);
+  const ink = isRed ? palette.card.red : palette.card.ink;
+
+  return (
+    <View accessibilityLabel={card} style={styles.chip}>
+      <Text style={[styles.rank, { color: ink }]}>{rank}</Text>
+      <Text style={[styles.suit, { color: ink }]}>{suit || '★'}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  chip: {
+    width: 22,
+    height: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radius.sm,
+    borderWidth: 1,
+    borderColor: palette.border.hairline,
+    backgroundColor: palette.card.face,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.25,
+    shadowRadius: 1,
+    elevation: 1,
+  },
+  rank: {
+    fontSize: 11,
+    fontWeight: '900',
+    lineHeight: 12,
+  },
+  suit: {
+    fontSize: 12,
+    fontWeight: '900',
+    lineHeight: 13,
+  },
+});

--- a/mei-tra-mobile/src/components/game/MiniCard.tsx
+++ b/mei-tra-mobile/src/components/game/MiniCard.tsx
@@ -16,10 +16,21 @@ export function MiniCard({ card }: { card: string }) {
   const { rank, suit, isRed } = parseCard(card);
   const ink = isRed ? palette.card.red : palette.card.ink;
 
+  // parseCard gives JOKER the five-character rank "JOKER", which overflows a
+  // 22pt chip. Web sidesteps this by falling back to the artwork; a text chip
+  // needs its own compact mark.
+  if (card === 'JOKER') {
+    return (
+      <View accessibilityLabel="ジョーカー" style={styles.chip}>
+        <Text style={[styles.joker, { color: ink }]}>★</Text>
+      </View>
+    );
+  }
+
   return (
     <View accessibilityLabel={card} style={styles.chip}>
       <Text style={[styles.rank, { color: ink }]}>{rank}</Text>
-      <Text style={[styles.suit, { color: ink }]}>{suit || '★'}</Text>
+      <Text style={[styles.suit, { color: ink }]}>{suit}</Text>
     </View>
   );
 }
@@ -53,5 +64,10 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: '900',
     lineHeight: 13,
+  },
+  joker: {
+    fontSize: 15,
+    fontWeight: '900',
+    lineHeight: 17,
   },
 });

--- a/mei-tra-mobile/src/components/game/MiniCard.tsx
+++ b/mei-tra-mobile/src/components/game/MiniCard.tsx
@@ -1,5 +1,7 @@
+import { Image } from 'expo-image';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { resolveCardArt } from '@/lib/card-art-assets';
 import { parseCard } from '@/lib/cards';
 import { palette } from '@/theme/palette';
 import { radius } from '@/theme/radius';
@@ -9,20 +11,30 @@ import { radius } from '@/theme/radius';
  * (mei-tra-frontend/components/game/CompletedFields: .cardCorner).
  *
  * Won tricks are a tally, not something you read card by card, so web
- * deliberately drops the artwork here. Rendering full SVG faces at this size
- * was both noisier and more expensive than the information warranted.
+ * deliberately drops the artwork for ordinary cards. JOKER is its one
+ * exception, and this follows it — see below.
  */
 export function MiniCard({ card }: { card: string }) {
   const { rank, suit, isRed } = parseCard(card);
   const ink = isRed ? palette.card.red : palette.card.ink;
 
-  // parseCard gives JOKER the five-character rank "JOKER", which overflows a
-  // 22pt chip. Web sidesteps this by falling back to the artwork; a text chip
-  // needs its own compact mark.
+  // JOKER has no rank/suit pair to print, so web drops the text treatment and
+  // stretches the artwork across the chip instead (TakenCardPreview ->
+  // .jokerCardFace, an <img> at 100%/100%, i.e. object-fit: fill).
+  // preserveAspectRatio="none" is what reproduces that fill on the SVG side.
   if (card === 'JOKER') {
+    const art = resolveCardArt(card);
     return (
       <View accessibilityLabel="ジョーカー" style={styles.chip}>
-        <Text style={[styles.joker, { color: ink }]}>★</Text>
+        {art.kind === 'vector' ? (
+          <art.Svg height="100%" preserveAspectRatio="none" width="100%" />
+        ) : (
+          <Image
+            contentFit="fill"
+            source={art.source}
+            style={StyleSheet.absoluteFill}
+          />
+        )}
       </View>
     );
   }
@@ -45,6 +57,9 @@ const styles = StyleSheet.create({
     marginHorizontal: -2,
     alignItems: 'center',
     justifyContent: 'center',
+    // Web's .cardCorner clips with overflow: hidden so the joker artwork takes
+    // the chip's rounded corners instead of squaring them off.
+    overflow: 'hidden',
     borderRadius: radius.sm,
     borderWidth: 1,
     borderColor: palette.border.hairline,
@@ -64,10 +79,5 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: '900',
     lineHeight: 13,
-  },
-  joker: {
-    fontSize: 15,
-    fontWeight: '900',
-    lineHeight: 17,
   },
 });

--- a/mei-tra-mobile/src/components/game/MiniCard.tsx
+++ b/mei-tra-mobile/src/components/game/MiniCard.tsx
@@ -28,6 +28,10 @@ const styles = StyleSheet.create({
   chip: {
     width: 22,
     height: 28,
+    // Web's .cardCorner uses margin: 0 -0.16rem — barely overlapping, so every
+    // card in a won set stays readable. A face-down-style stack would hide all
+    // but the last one.
+    marginHorizontal: -2,
     alignItems: 'center',
     justifyContent: 'center',
     borderRadius: radius.sm,

--- a/mei-tra-mobile/src/components/game/MiniCard.tsx
+++ b/mei-tra-mobile/src/components/game/MiniCard.tsx
@@ -26,15 +26,20 @@ export function MiniCard({ card }: { card: string }) {
     const art = resolveCardArt(card);
     return (
       <View accessibilityLabel="ジョーカー" style={styles.chip}>
-        {art.kind === 'vector' ? (
-          <art.Svg height="100%" preserveAspectRatio="none" width="100%" />
-        ) : (
-          <Image
-            contentFit="fill"
-            source={art.source}
-            style={StyleSheet.absoluteFill}
-          />
-        )}
+        {/* The clip lives on an inner view, as in PlayingCard: `overflow:
+            hidden` on the chip itself would set masksToBounds and swallow the
+            iOS layer shadow, which is painted outside the layer bounds. */}
+        <View style={styles.artClip}>
+          {art.kind === 'vector' ? (
+            <art.Svg height="100%" preserveAspectRatio="none" width="100%" />
+          ) : (
+            <Image
+              contentFit="fill"
+              source={art.source}
+              style={StyleSheet.absoluteFill}
+            />
+          )}
+        </View>
       </View>
     );
   }
@@ -57,9 +62,6 @@ const styles = StyleSheet.create({
     marginHorizontal: -2,
     alignItems: 'center',
     justifyContent: 'center',
-    // Web's .cardCorner clips with overflow: hidden so the joker artwork takes
-    // the chip's rounded corners instead of squaring them off.
-    overflow: 'hidden',
     borderRadius: radius.sm,
     borderWidth: 1,
     borderColor: palette.border.hairline,
@@ -69,6 +71,13 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.25,
     shadowRadius: 1,
     elevation: 1,
+  },
+  artClip: {
+    ...StyleSheet.absoluteFillObject,
+    // Web's .cardCorner clips with overflow: hidden so the joker artwork takes
+    // the chip's rounded corners instead of squaring them off.
+    overflow: 'hidden',
+    borderRadius: radius.sm,
   },
   rank: {
     fontSize: 11,

--- a/mei-tra-mobile/src/components/game/PlayerSeat.tsx
+++ b/mei-tra-mobile/src/components/game/PlayerSeat.tsx
@@ -124,7 +124,8 @@ export function PlayerSeat({
 
 const styles = StyleSheet.create({
   container: {
-    minWidth: 88,
+    minWidth: 0,
+    flex: 1,
     maxWidth: 110,
     flexShrink: 1,
     alignItems: 'center',

--- a/mei-tra-mobile/src/components/game/PlayerSeat.tsx
+++ b/mei-tra-mobile/src/components/game/PlayerSeat.tsx
@@ -61,11 +61,15 @@ export function PlayerSeat({
           <Text style={styles.declarationBadgeText}>アゲ: {declaration}</Text>
         </View>
       ) : null}
+      {isTurn ? (
+        <View style={styles.turnBadgeSlot}>
+          <TurnClock size={22} />
+        </View>
+      ) : null}
       <View style={styles.avatarRow}>
         <View style={[styles.avatar, player.isCOM && styles.comAvatar]}>
           <Text style={styles.avatarText}>{player.isCOM ? '🤖' : '●'}</Text>
         </View>
-        {isTurn ? <TurnClock size={22} /> : null}
       </View>
       <Text numberOfLines={1} style={styles.name}>
         {player.name}
@@ -125,6 +129,14 @@ export function PlayerSeat({
 }
 
 const styles = StyleSheet.create({
+  turnBadgeSlot: {
+    // Overhangs the seat's top-right corner, matching web's .avatarTurnBadge
+    // (top: -0.32rem; right: -0.4rem).
+    position: 'absolute',
+    top: -6,
+    right: -7,
+    zIndex: 4,
+  },
   container: {
     minWidth: 0,
     flex: 1,

--- a/mei-tra-mobile/src/components/game/PlayerSeat.tsx
+++ b/mei-tra-mobile/src/components/game/PlayerSeat.tsx
@@ -3,6 +3,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { PlayingCard } from '@/components/game/PlayingCard';
 import { getTeamDisplayName } from '@/lib/team-labels';
+import { CARD_BASE_WIDTHS, cardStackMargin } from '@/theme/cards';
 import { colors, teamColors } from '@/theme/colors';
 
 interface PlayerSeatProps {
@@ -225,6 +226,6 @@ const styles = StyleSheet.create({
     marginTop: 2,
   },
   faceDownOverlap: {
-    marginLeft: -16,
+    marginLeft: cardStackMargin(CARD_BASE_WIDTHS.seat),
   },
 });

--- a/mei-tra-mobile/src/components/game/PlayerSeat.tsx
+++ b/mei-tra-mobile/src/components/game/PlayerSeat.tsx
@@ -2,6 +2,7 @@ import type { PlayerContract, TeamNames } from '@meitra/contracts/game';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { PlayingCard } from '@/components/game/PlayingCard';
+import { TurnClock } from '@/components/game/TurnClock';
 import { getTeamDisplayName } from '@/lib/team-labels';
 import { CARD_BASE_WIDTHS, cardStackMargin } from '@/theme/cards';
 import { colors, teamColors } from '@/theme/colors';
@@ -64,7 +65,7 @@ export function PlayerSeat({
         <View style={[styles.avatar, player.isCOM && styles.comAvatar]}>
           <Text style={styles.avatarText}>{player.isCOM ? '🤖' : '●'}</Text>
         </View>
-        {isTurn ? <Text style={styles.turnIcon}>⏱</Text> : null}
+        {isTurn ? <TurnClock size={22} /> : null}
       </View>
       <Text numberOfLines={1} style={styles.name}>
         {player.name}
@@ -160,9 +161,6 @@ const styles = StyleSheet.create({
   avatarText: {
     color: colors.text,
     fontSize: 17,
-  },
-  turnIcon: {
-    fontSize: 14,
   },
   name: {
     maxWidth: 96,

--- a/mei-tra-mobile/src/components/game/TurnClock.tsx
+++ b/mei-tra-mobile/src/components/game/TurnClock.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useRef } from 'react';
+import { Animated, Easing, StyleSheet, View } from 'react-native';
+import Svg, { Circle, G, Path } from 'react-native-svg';
+
+import { palette } from '@/theme/palette';
+import { radius } from '@/theme/radius';
+
+const AnimatedG = Animated.createAnimatedComponent(G);
+
+/**
+ * The "it's your turn" clock, matching the web badge
+ * (mei-tra-frontend/components/game/PlayerHand: .turnBadge + inline svg):
+ * a brass clock on a raised disc, with the hand sweeping once every 3s.
+ *
+ * Replaces the previous ⏱ emoji, which rendered in the system font and did not
+ * match web on either platform.
+ */
+export function TurnClock({ size = 26 }: { size?: number }) {
+  const spin = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.timing(spin, {
+        toValue: 1,
+        duration: 3000,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      }),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [spin]);
+
+  const rotation = spin.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0deg', '360deg'],
+  });
+
+  return (
+    <View
+      accessibilityLabel="現在の手番"
+      accessibilityRole="image"
+      style={[
+        styles.badge,
+        { width: size, height: size, borderRadius: size / 2 },
+      ]}
+    >
+      <Svg height="100%" viewBox="0 0 24 24" width="100%">
+        <G
+          fill="none"
+          stroke={palette.accent.strong}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2.6}
+        >
+          <Circle cx={12} cy={12} r={10.25} />
+          {/* Tick marks at 12 / 3 / 6 / 9. */}
+          <Path d="M12 4.5v1M19.5 12h-1M12 19.5v-1M4.5 12h1" />
+          {/* The hand pivots on the dial centre, as transform-origin does on web. */}
+          <AnimatedG
+            originX={12}
+            originY={12}
+            rotation={rotation as unknown as number}
+          >
+            <Path d="M12 12V5.75" />
+          </AnimatedG>
+          <Circle
+            cx={12}
+            cy={12}
+            fill={palette.accent.strong}
+            r={1.1}
+            stroke="none"
+          />
+        </G>
+      </Svg>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: palette.surface.raised,
+    // Web adds the same hairline so the disc keeps a defined edge where it
+    // overhangs the seat corner.
+    borderWidth: 1,
+    borderColor: palette.border.hairline,
+    borderCurve: 'circular',
+    padding: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.2,
+    shadowRadius: radius.sm / 2,
+    elevation: 2,
+  },
+});

--- a/mei-tra-mobile/src/components/game/TurnClock.tsx
+++ b/mei-tra-mobile/src/components/game/TurnClock.tsx
@@ -5,15 +5,18 @@ import Svg, { Circle, G, Path } from 'react-native-svg';
 import { palette } from '@/theme/palette';
 import { radius } from '@/theme/radius';
 
-const AnimatedG = Animated.createAnimatedComponent(G);
+const DIAL = palette.text.primary;
 
 /**
  * The "it's your turn" clock, matching the web badge
  * (mei-tra-frontend/components/game/PlayerHand: .turnBadge + inline svg):
- * a brass clock on a raised disc, with the hand sweeping once every 3s.
+ * a brass disc with an ivory dial, the hand sweeping once every 3s.
  *
- * Replaces the previous ⏱ emoji, which rendered in the system font and did not
- * match web on either platform.
+ * The hand lives in its own layer rotated by an Animated.View rather than an
+ * animated <G>. Wrapping G in createAnimatedComponent leaks `collapsable` and
+ * `transform-origin` into the DOM on react-native-web ("Invalid DOM property
+ * transform-origin"), and a View transform rotates about its centre on both
+ * platforms — which is exactly the pivot the dial needs.
  */
 export function TurnClock({ size = 26 }: { size?: number }) {
   const spin = useRef(new Animated.Value(0)).current;
@@ -24,22 +27,19 @@ export function TurnClock({ size = 26 }: { size?: number }) {
         toValue: 1,
         duration: 3000,
         easing: Easing.linear,
-        // The native driver only handles style props; this animates an SVG
-        // `rotation` prop, so it has to run on the JS driver or the hand
-        // never moves.
-        useNativeDriver: false,
+        useNativeDriver: true,
       }),
     );
     loop.start();
     return () => loop.stop();
   }, [spin]);
 
-  // SVG's rotate() takes a bare number — a 'deg' suffix is a parse error
-  // ("Expected ')'"), which silently killed the animation.
-  const rotation = spin.interpolate({
+  const rotate = spin.interpolate({
     inputRange: [0, 1],
-    outputRange: [0, 360],
+    outputRange: ['0deg', '360deg'],
   });
+
+  const inner = Math.round(size * 0.78);
 
   return (
     <View
@@ -50,34 +50,37 @@ export function TurnClock({ size = 26 }: { size?: number }) {
         { width: size, height: size, borderRadius: size / 2 },
       ]}
     >
-      <Svg height="78%" viewBox="0 0 24 24" width="78%">
+      <Svg height={inner} viewBox="0 0 24 24" width={inner}>
         <G
           fill="none"
-          stroke={palette.text.primary}
+          stroke={DIAL}
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth={2}
         >
           <Circle cx={12} cy={12} r={10.25} />
-          {/* Tick marks at 12 / 3 / 6 / 9. */}
+          {/* Ticks at 12 / 3 / 6 / 9. */}
           <Path d="M12 4.5v1M19.5 12h-1M12 19.5v-1M4.5 12h1" />
-          {/* The hand pivots on the dial centre, as transform-origin does on web. */}
-          <AnimatedG
-            originX={12}
-            originY={12}
-            rotation={rotation}
-          >
-            <Path d="M12 12V5.75" />
-          </AnimatedG>
-          <Circle
-            cx={12}
-            cy={12}
-            fill={palette.text.primary}
-            r={1.1}
-            stroke="none"
-          />
         </G>
+        <Circle cx={12} cy={12} fill={DIAL} r={1.1} />
       </Svg>
+
+      <Animated.View
+        pointerEvents="none"
+        style={[
+          styles.hand,
+          { width: inner, height: inner, transform: [{ rotate }] },
+        ]}
+      >
+        <Svg height={inner} viewBox="0 0 24 24" width={inner}>
+          <Path
+            d="M12 12V5.75"
+            stroke={DIAL}
+            strokeLinecap="round"
+            strokeWidth={2}
+          />
+        </Svg>
+      </Animated.View>
     </View>
   );
 }
@@ -95,5 +98,11 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.25,
     shadowRadius: radius.sm / 2,
     elevation: 2,
+  },
+  hand: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    margin: 'auto',
   },
 });

--- a/mei-tra-mobile/src/components/game/TurnClock.tsx
+++ b/mei-tra-mobile/src/components/game/TurnClock.tsx
@@ -24,16 +24,21 @@ export function TurnClock({ size = 26 }: { size?: number }) {
         toValue: 1,
         duration: 3000,
         easing: Easing.linear,
-        useNativeDriver: true,
+        // The native driver only handles style props; this animates an SVG
+        // `rotation` prop, so it has to run on the JS driver or the hand
+        // never moves.
+        useNativeDriver: false,
       }),
     );
     loop.start();
     return () => loop.stop();
   }, [spin]);
 
+  // SVG's rotate() takes a bare number — a 'deg' suffix is a parse error
+  // ("Expected ')'"), which silently killed the animation.
   const rotation = spin.interpolate({
     inputRange: [0, 1],
-    outputRange: ['0deg', '360deg'],
+    outputRange: [0, 360],
   });
 
   return (
@@ -45,13 +50,13 @@ export function TurnClock({ size = 26 }: { size?: number }) {
         { width: size, height: size, borderRadius: size / 2 },
       ]}
     >
-      <Svg height="100%" viewBox="0 0 24 24" width="100%">
+      <Svg height="78%" viewBox="0 0 24 24" width="78%">
         <G
           fill="none"
-          stroke={palette.accent.strong}
+          stroke={palette.text.primary}
           strokeLinecap="round"
           strokeLinejoin="round"
-          strokeWidth={2.6}
+          strokeWidth={2}
         >
           <Circle cx={12} cy={12} r={10.25} />
           {/* Tick marks at 12 / 3 / 6 / 9. */}
@@ -60,14 +65,14 @@ export function TurnClock({ size = 26 }: { size?: number }) {
           <AnimatedG
             originX={12}
             originY={12}
-            rotation={rotation as unknown as number}
+            rotation={rotation}
           >
             <Path d="M12 12V5.75" />
           </AnimatedG>
           <Circle
             cx={12}
             cy={12}
-            fill={palette.accent.strong}
+            fill={palette.text.primary}
             r={1.1}
             stroke="none"
           />
@@ -81,16 +86,13 @@ const styles = StyleSheet.create({
   badge: {
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: palette.surface.raised,
-    // Web adds the same hairline so the disc keeps a defined edge where it
-    // overhangs the seat corner.
-    borderWidth: 1,
-    borderColor: palette.border.hairline,
+    // Solid brass disc with an ivory dial, matching web. A light disc on a
+    // light card read as the card's fill bleeding past its border-radius.
+    backgroundColor: palette.accent.base,
     borderCurve: 'circular',
-    padding: 2,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.2,
+    shadowOpacity: 0.25,
     shadowRadius: radius.sm / 2,
     elevation: 2,
   },

--- a/mei-tra-mobile/src/components/game/TurnClock.tsx
+++ b/mei-tra-mobile/src/components/game/TurnClock.tsx
@@ -42,7 +42,10 @@ export function TurnClock({ size = 26 }: { size?: number }) {
     outputRange: ['0deg', '360deg'],
   });
 
-  const inner = Math.round(size * 0.78);
+  // The dial fills the disc: its outer stroke is the badge's visible edge, so
+  // the ring and the brass circle read as one shape rather than a small clock
+  // floating inside a larger button.
+  const inner = size;
 
   return (
     <View
@@ -61,7 +64,8 @@ export function TurnClock({ size = 26 }: { size?: number }) {
           strokeLinejoin="round"
           strokeWidth={2}
         >
-          <Circle cx={12} cy={12} r={10.25} />
+          {/* r + half the stroke = 12, so the ring sits flush with the disc. */}
+          <Circle cx={12} cy={12} r={11} />
           {/* Ticks at 12 / 3 / 6 / 9. */}
           <Path d="M12 4.5v1M19.5 12h-1M12 19.5v-1M4.5 12h1" />
         </G>

--- a/mei-tra-mobile/src/components/game/TurnClock.tsx
+++ b/mei-tra-mobile/src/components/game/TurnClock.tsx
@@ -27,7 +27,10 @@ export function TurnClock({ size = 26 }: { size?: number }) {
         toValue: 1,
         duration: 3000,
         easing: Easing.linear,
-        useNativeDriver: true,
+        // JS driver on purpose: the native driver does not reliably drive this
+        // on react-native-web, and the hand simply never moved. One small icon
+        // is not worth a platform fork.
+        useNativeDriver: false,
       }),
     );
     loop.start();
@@ -100,9 +103,8 @@ const styles = StyleSheet.create({
     elevation: 2,
   },
   hand: {
-    ...StyleSheet.absoluteFillObject,
+    position: 'absolute',
     alignItems: 'center',
     justifyContent: 'center',
-    margin: 'auto',
   },
 });

--- a/mei-tra-mobile/src/components/game/WaitingRoom.tsx
+++ b/mei-tra-mobile/src/components/game/WaitingRoom.tsx
@@ -14,6 +14,7 @@ import {
 
 import { ChatPanel } from '@/components/social/ChatPanel';
 import { Button } from '@/components/ui/Button';
+import { getTeamDisplayName } from '@/lib/team-labels';
 import { colors, teamColors } from '@/theme/colors';
 
 interface WaitingRoomProps {
@@ -94,8 +95,7 @@ export function WaitingRoom({
 
       <View style={[styles.teams, width < 380 && styles.teamsNarrow]}>
         {([0, 1] as const).map((team) => {
-          const teamLabel =
-            room.settings.teamNames?.[team] || `チーム${team + 1}`;
+          const teamLabel = getTeamDisplayName(team, room.settings.teamNames);
           const teamColor = teamColors[team];
           return (
           <View key={team} style={styles.team}>

--- a/mei-tra-mobile/src/context/GameContext.tsx
+++ b/mei-tra-mobile/src/context/GameContext.tsx
@@ -1272,9 +1272,15 @@ export function GameProvider({ children }: PropsWithChildren) {
     () => resolvePlayerId(state.game, state.currentRoom, user?.id),
     [state.currentRoom, state.game, user?.id],
   );
+  // Prefer the room's hostId: room-sync/room-updated keep it current, while
+  // game.hostId is captured once at game start and never refreshed. Without
+  // this, a host transfer (e.g. the host disconnects) leaves every client
+  // believing the departed player is still host, so nobody can replace them
+  // with a COM. The web client reads a single currentHostId that both room and
+  // game events write, which is the behaviour mirrored here.
   const isHost =
     Boolean(currentPlayerId) &&
-    (state.game?.hostId ?? state.currentRoom?.hostId) === currentPlayerId;
+    (state.currentRoom?.hostId ?? state.game?.hostId) === currentPlayerId;
 
   const value = useMemo<GameContextValue>(
     () => ({

--- a/mei-tra-mobile/src/hooks/__tests__/useHandFanMetrics.test.ts
+++ b/mei-tra-mobile/src/hooks/__tests__/useHandFanMetrics.test.ts
@@ -1,0 +1,52 @@
+import { computeHandFanMetrics } from '../useHandFanMetrics';
+
+const metrics = computeHandFanMetrics;
+
+/** Total horizontal span the row occupies, mirroring the RN box model. */
+const spanOf = (
+  { cardWidth, cardMargin }: { cardWidth: number; cardMargin: number },
+  count: number,
+) => count * (cardWidth + cardMargin * 2);
+
+describe('computeHandFanMetrics', () => {
+  it('keeps a ten-card hand inside a 375pt phone', () => {
+    // 375 - 126 of chrome, per GameBoard.
+    const m = metrics(249, 10);
+    expect(spanOf(m, 10)).toBeLessThanOrEqual(249);
+    // and the cards stay large enough to read
+    expect(m.cardWidth).toBeGreaterThanOrEqual(44);
+  });
+
+  it('does not exceed the base width when there is room to spare', () => {
+    const m = metrics(1200, 3);
+    expect(m.cardWidth).toBeLessThanOrEqual(60);
+  });
+
+  it('never overlaps more than the readable limit', () => {
+    const m = metrics(120, 12);
+    // exposure bottoms out at 26%, so the margin cannot eat more than 37% a side
+    expect(Math.abs(m.cardMargin)).toBeLessThanOrEqual(m.cardWidth * 0.37 + 0.01);
+  });
+
+  it('shrinks the card only after exposure has bottomed out', () => {
+    const roomy = metrics(600, 8);
+    const tight = metrics(160, 8);
+    expect(roomy.cardWidth).toBeGreaterThan(tight.cardWidth);
+  });
+
+  it('does not overlap a single card', () => {
+    expect(metrics(300, 1).cardMargin).toBe(0);
+  });
+
+  it('survives a zero-width measurement pass', () => {
+    const m = metrics(0, 5);
+    expect(m.cardWidth).toBeGreaterThan(0);
+    expect(Number.isFinite(m.cardMargin)).toBe(true);
+  });
+
+  it('honours the accessibility scale', () => {
+    expect(metrics(1200, 3, 1.2).cardWidth).toBeGreaterThan(
+      metrics(1200, 3, 1).cardWidth,
+    );
+  });
+});

--- a/mei-tra-mobile/src/hooks/useHandFanMetrics.ts
+++ b/mei-tra-mobile/src/hooks/useHandFanMetrics.ts
@@ -1,0 +1,81 @@
+import { useMemo } from 'react';
+
+import { CARD_BASE_WIDTHS } from '@/theme/cards';
+
+/**
+ * Sizes the player's hand so it fits the screen.
+ *
+ * The web app advances each card by a fixed 62.5% of its width (80px card,
+ * -15px overlap). Applied verbatim on a 375pt phone that needs ~525pt for a
+ * ten-card hand, so cards ran off both edges.
+ *
+ * Instead of shrinking the cards until they are unreadable, this compresses the
+ * *exposure* — how much of each card the next one leaves visible. The rank
+ * index sits in the top-left ~21% of the artwork (the SVGs put it at x≈11-45 of
+ * 210), so cards stay identifiable down to roughly a quarter exposed. Width is
+ * only reduced once exposure has bottomed out.
+ */
+const MIN_WIDTH = 44;
+const MAX_WIDTH = CARD_BASE_WIDTHS.hand;
+/** Web's ratio: (80 - 15) / 80. */
+const MAX_EXPOSE = 0.625;
+/** Below this the rank index starts to be covered. */
+const MIN_EXPOSE = 0.26;
+/** Slack for the ±15° rotation widening the row's bounding box. */
+const ROTATION_SLACK = 0.94;
+
+const clamp = (min: number, max: number, value: number) =>
+  Math.min(max, Math.max(min, value));
+
+export interface HandFanMetrics {
+  /** Width to render each card at. */
+  cardWidth: number;
+  /** marginHorizontal for each card, negative to overlap. */
+  cardMargin: number;
+}
+
+/** Pure geometry, split out so it can be tested without a renderer. */
+export function computeHandFanMetrics(
+  availableWidth: number,
+  cardCount: number,
+  scale = 1,
+): HandFanMetrics {
+  const usable = Math.max(0, availableWidth) * ROTATION_SLACK;
+
+  if (cardCount <= 1 || usable <= 0) {
+    return { cardWidth: MAX_WIDTH * scale, cardMargin: 0 };
+  }
+
+  // Try the largest card first, then compress exposure to make it fit.
+  let cardWidth = MAX_WIDTH * scale;
+  let expose = (usable / cardWidth - 1) / (cardCount - 1);
+
+  if (expose < MIN_EXPOSE) {
+    // Exposure has bottomed out; shrink the card instead.
+    cardWidth = clamp(
+      MIN_WIDTH * scale,
+      MAX_WIDTH * scale,
+      usable / (1 + (cardCount - 1) * MIN_EXPOSE),
+    );
+    expose = MIN_EXPOSE;
+  }
+
+  expose = clamp(MIN_EXPOSE, MAX_EXPOSE, expose);
+
+  return {
+    cardWidth,
+    // RN applies marginHorizontal to both sides, so halve the overlap.
+    cardMargin: -(cardWidth * (1 - expose)) / 2,
+  };
+}
+
+export function useHandFanMetrics(
+  availableWidth: number,
+  cardCount: number,
+  scale = 1,
+): HandFanMetrics {
+  return useMemo(
+    () => computeHandFanMetrics(availableWidth, cardCount, scale),
+    [availableWidth, cardCount, scale],
+  );
+}

--- a/mei-tra-mobile/src/theme/cards.ts
+++ b/mei-tra-mobile/src/theme/cards.ts
@@ -28,6 +28,23 @@ export const CARD_SCALES = {
   xlarge: 1.2,
 } as const;
 
+/**
+ * How much of a card the next one covers in an overlapped row, matching the web
+ * app's face-down stack (margin-left -0.7rem on a 1.55rem card).
+ */
+export const CARD_STACK_OVERLAP = 0.45;
+
 export const cardHeight = (width: number): number => width * CARD_ASPECT;
+
+/**
+ * The artwork rounds its own corners at 15/210, but at seat sizes (~30pt) that
+ * is barely 2px and reads as a sharp rectangle. Web compensates the same way —
+ * its face-down card uses a 0.25rem radius on a 1.55rem card — so enforce a
+ * floor that keeps small cards looking like cards.
+ */
 export const cardRadius = (width: number): number =>
-  Math.round(width * CARD_RADIUS_RATIO);
+  Math.max(4, Math.round(width * CARD_RADIUS_RATIO));
+
+/** Negative margin that overlaps stacked cards by CARD_STACK_OVERLAP. */
+export const cardStackMargin = (width: number): number =>
+  -Math.round(width * CARD_STACK_OVERLAP);

--- a/mei-tra-mobile/src/theme/palette.ts
+++ b/mei-tra-mobile/src/theme/palette.ts
@@ -72,11 +72,17 @@ export const palette = {
    * Team identity. Indexed by the `Team` value (0 | 1) used across the
    * contracts, so `team[player.team]` reads naturally at call sites.
    *
-   * NOTE: team[1] is intentionally LIGHT (web uses these as text colours, not
-   * fills). Badges must therefore be outline-style — a tinted border and
-   * matching text on a raised surface — never a solid fill with white text.
+   * NOTE: BOTH entries are intentionally LIGHT (web uses these as text
+   * colours, not fills). Badges must therefore be outline-style — a tinted
+   * border and matching text on a raised surface — never a solid fill with
+   * white text.
+   *
+   * team[0] is raw.cardRedLight, not raw.cardRed: the card ink reads at 2.18:1
+   * as text on surface.raised2, against 7.68:1 for the black side. Team
+   * identity and card ink are separate roles — web splits them the same way,
+   * as --mt-team-red vs --mt-card-red.
    */
-  team: [raw.cardRed, '#c8d1c8'] as const,
+  team: [raw.cardRedLight, '#c8d1c8'] as const,
 
   trump: {
     tra: '#e0b24a',

--- a/mei-tra-mobile/src/theme/raw.ts
+++ b/mei-tra-mobile/src/theme/raw.ts
@@ -29,4 +29,5 @@ export const raw = {
 
   cardRed: '#c0362c',
   cardRedDark: '#9e2a22',
+  cardRedLight: '#eda79d',
 } as const;


### PR DESCRIPTION
モバイル版デザイン刷新の第3弾です。#187 の上に積んでいます。

## きっかけ

#187 を Web で実機確認したところ、**375pt幅で手札が画面外に大きくはみ出し、左右が切れていました。**

原因はカード幅60pt固定・重なり-6pt固定で、`GameBoard` / `PlayerSeat` / `PlayingCard` が `useWindowDimensions` を一切使っていなかったことです（アプリ全体で唯一使っていたのは `WaitingRoom` のみ）。

## 露出率ベースの扇形

Webは1枚あたり幅の62.5%ずつ送る固定比率（80pt幅・-15pt重なり）です。これをそのまま375ptに適用すると10枚で約525pt必要になり破綻します。

カードを読めなくなるまで縮めるのではなく、**次のカードが見せる「露出率」を先に圧縮**する方式にしました。ランクの隅文字は絵柄の左上約21%（SVGで `x≈11〜45` / 210）にあるため、4分の1程度まで詰めても札は判別できます。露出が下限（26%）に達して初めて幅を縮めます。

| 端末 | 手札 | カード幅 | 露出 | 合計幅 / 利用可 |
|---|---|---|---|---|
| iPhone SE (320pt) | 10枚 | 55pt | 26% | 142pt / 194pt |
| iPhone 14 (390pt) | 10枚 | 60pt | 35% | 209pt / 264pt |
| iPad (768pt) | 10枚 | 60pt | 63% | 375pt / 642pt |

計算は `computeHandFanMetrics` として純粋関数に切り出し、hook はその `useMemo` ラッパにしました。モバイルには hook を描画するテスト基盤が無いため、この形ならレンダラ無しで境界値を検証できます。

## 固定幅の相対化

- `selfCard`: `width: 80` 固定 → `minWidth 64` / `maxWidth 92` / `flexBasis 22%`
- `PlayerSeat` container: `minWidth: 88` → `minWidth 0` + `flex: 1`。3席で264pt必要だったため320pt端末で溢れていました
- `fanContainer` に `flexShrink`

## 併せて

実機確認で `WaitingRoom` のチーム見出しが「チーム1/チーム2」のまま残っているのを見つけたので `getTeamDisplayName` に統一しました。これでチーム名の既定値が全画面で赤/黒に揃います。

## 検証

| 項目 | 結果 |
|---|---|
| `npm run typecheck` | 通過 |
| `npm run lint` | 通過 |
| `npm test` | 20 suites / 99 tests 通過（回帰テスト7件を追加） |

Web版（`expo start --web`）で盤面を目視確認済み。カードのSVG絵柄、扇形の弧、裏面、赤/黒バッジ、切札のWeb表記がすべて意図通り出ることを確認しました。

## 未実施

**iOSシミュレータでの確認はできていません。** このMacにXcode本体が入っておらず（Command Line Toolsのみ、`simctl` 無し）、`react-native-svg` はネイティブモジュールのため dev-client のビルドも必要です。Web版はレイアウトの当たりは付きますが、native の最終確認にはなりません。

以下が完了したら確認できます。

```
# Xcode を App Store からインストール後
sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
cd mei-tra-mobile && npx expo run:ios
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)