### PR TITLE
宣言を引き継いだCOMが合法手を失い卓が固まる問題を修正

### DIFF
--- a/mei-tra-backend/src/services/__tests__/com-strategy-inherited-declaration.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy-inherited-declaration.spec.ts
@@ -1,0 +1,129 @@
+import { ComStrategyService } from '../com-strategy.service';
+import { IBlowService } from '../interfaces/blow-service.interface';
+import { ICardService } from '../interfaces/card-service.interface';
+import { IPlayService } from '../interfaces/play-service.interface';
+import { BlowDeclaration, DomainPlayer, GameState } from '../../types/game.types';
+
+/**
+ * A COM that replaces a human inherits that human's blow declaration — the
+ * player-reference remap deliberately moves the bid to the seat.
+ *
+ * Both declare-blow and pass-blow reject a player who has already declared
+ * (hasPlayerDeclaredInBlow), so such a seat has NO legal action. If the
+ * strategy returns 'pass' there, ComAutoPlayRecoveryService retries the
+ * rejected action forever and the table wedges — which is exactly what
+ * happened in production.
+ */
+const comPlayer = (over: Partial<DomainPlayer> = {}): DomainPlayer =>
+  ({
+    playerId: 'com-timeout-0-123',
+    name: 'COM',
+    hand: ['A♠', 'K♠', 'Q♠', 'J♠', '10♠', '9♠', '8♠', '7♠', '6♠', '5♠'],
+    team: 0,
+    isPasser: false,
+    isCOM: true,
+    hasBroken: false,
+    hasRequiredBroken: false,
+    ...over,
+  }) as DomainPlayer;
+
+const declaration = (playerId: string): BlowDeclaration => ({
+  playerId,
+  trumpType: 'herz',
+  numberOfPairs: 8,
+  timestamp: 1,
+});
+
+const stateWith = (
+  declarations: BlowDeclaration[],
+  players: DomainPlayer[],
+): GameState =>
+  ({
+    players,
+    blowState: {
+      currentTrump: null,
+      currentHighestDeclaration: declarations[declarations.length - 1] ?? null,
+      declarations,
+      actionHistory: [],
+      lastPasser: null,
+      isRoundCancelled: false,
+      currentBlowIndex: 0,
+    },
+  }) as unknown as GameState;
+
+const buildService = () =>
+  new ComStrategyService(
+    {
+      // Enough of the surface for evaluateHandForTrump to run on the
+      // not-yet-declared control case.
+      getCardSuit: (card: string) => card.slice(-1),
+      getCardStrength: () => 1,
+      generateDeck: () => [],
+      compareCards: () => 0,
+      generateScoringCards: () => [],
+    } as unknown as ICardService,
+    { getLegalPlayCards: jest.fn(() => []) } as unknown as IPlayService,
+    { isValidDeclaration: () => true } as unknown as IBlowService,
+  );
+
+describe('ComStrategyService.chooseBlowAction — inherited declaration', () => {
+  it('skips instead of passing when the seat has already declared', () => {
+    const com = comPlayer();
+    const service = buildService();
+
+    const action = service.chooseBlowAction(
+      stateWith([declaration(com.playerId)], [com]),
+      com,
+    );
+
+    // 'pass' here is rejected by pass-blow and retried forever.
+    expect(action.type).toBe('skip');
+  });
+
+  it('skips even when the hand is too weak to bid', () => {
+    const com = comPlayer({ hand: ['5♠', '6♥', '7♦'] });
+    const service = buildService();
+
+    const action = service.chooseBlowAction(
+      stateWith([declaration(com.playerId)], [com]),
+      com,
+    );
+
+    expect(action.type).toBe('skip');
+  });
+
+  it('skips even when broken, which would otherwise pass', () => {
+    const com = comPlayer({ hasBroken: true });
+    const service = buildService();
+
+    const action = service.chooseBlowAction(
+      stateWith([declaration(com.playerId)], [com]),
+      com,
+    );
+
+    expect(action.type).toBe('skip');
+  });
+
+  it('does not treat its own bid as a partner bid', () => {
+    // Regression guard: currentHighestPlayer.team === comPlayer.team is true
+    // for the COM itself, which made it "defer to its partner" and pass.
+    const com = comPlayer();
+    const service = buildService();
+    const state = stateWith([declaration(com.playerId)], [com]);
+
+    expect(service.chooseBlowAction(state, com).type).not.toBe('pass');
+  });
+
+  it('still acts normally when it has not declared', () => {
+    const com = comPlayer();
+    const partner = comPlayer({ playerId: 'com-1', team: 0 });
+    const service = buildService();
+
+    const action = service.chooseBlowAction(
+      stateWith([declaration(partner.playerId)], [com, partner]),
+      com,
+    );
+
+    expect(action.type).not.toBe('skip');
+  });
+});

--- a/mei-tra-backend/src/services/com-strategy.service.ts
+++ b/mei-tra-backend/src/services/com-strategy.service.ts
@@ -8,6 +8,7 @@ import {
   Team,
   TrumpType,
 } from '../types/game.types';
+import { hasPlayerDeclaredInBlow } from '../use-cases/helpers/blow-action.helper';
 import { IBlowService } from './interfaces/blow-service.interface';
 import { ICardService } from './interfaces/card-service.interface';
 import { IPlayService } from './interfaces/play-service.interface';
@@ -73,6 +74,16 @@ export class ComStrategyService implements IComStrategyService {
   }
 
   chooseBlowAction(state: GameState, comPlayer: DomainPlayer): ComBlowAction {
+    // A seat that already declared has no legal action left: declare-blow and
+    // pass-blow both reject it (hasPlayerDeclaredInBlow). This is reachable
+    // because a COM inherits the declaration of the human it replaced — the
+    // remap correctly moves the bid to the seat, so the COM sees its own bid.
+    // Returning 'skip' lets the caller advance the turn instead of retrying an
+    // action the rules forbid.
+    if (hasPlayerDeclaredInBlow(state.blowState, comPlayer.playerId)) {
+      return { type: 'skip' };
+    }
+
     if (comPlayer.hasBroken || comPlayer.hasRequiredBroken) {
       return { type: 'pass' };
     }
@@ -81,8 +92,12 @@ export class ComStrategyService implements IComStrategyService {
     const currentHighestPlayer = currentHighest
       ? this.findPlayer(state, currentHighest.playerId)
       : null;
+    // Never treat one's own bid as a partner's — an inherited declaration would
+    // otherwise make the COM defer to itself and pass.
     const currentHighestIsPartner =
-      currentHighestPlayer?.team === comPlayer.team;
+      currentHighestPlayer != null &&
+      currentHighestPlayer.playerId !== comPlayer.playerId &&
+      currentHighestPlayer.team === comPlayer.team;
     const evaluations = TRUMP_TYPES.map((trumpType) =>
       this.evaluateHandForTrump(comPlayer.hand, trumpType),
     ).sort((a, b) => {

--- a/mei-tra-backend/src/services/interfaces/com-strategy-service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/com-strategy-service.interface.ts
@@ -8,7 +8,13 @@ export type ComBlowAction =
         numberOfPairs: number;
       };
     }
-  | { type: 'pass' };
+  | { type: 'pass' }
+  /**
+   * The seat has no legal blow action left — it already declared, so both
+   * declare-blow and pass-blow reject it. The caller must advance the turn
+   * rather than submit an action.
+   */
+  | { type: 'skip' };
 
 export interface IComStrategyService {
   chooseBlowAction(state: GameState, comPlayer: DomainPlayer): ComBlowAction;

--- a/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
+++ b/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
@@ -28,6 +28,10 @@ import { DomainPlayer } from '../types/game.types';
 import { GameStateService } from '../services/game-state.service';
 import { GatewayEvent } from './interfaces/gateway-event.interface';
 import { CompleteFieldTrigger } from './interfaces/play-card.use-case.interface';
+import {
+  hasPlayerDeclaredInBlow,
+  hasPlayerPassedInBlow,
+} from './helpers/blow-action.helper';
 import { getBrokenHandRevealPendingError } from './helpers/broken-hand.helper';
 
 type ResponseWithDelayed<T> = T & {
@@ -264,6 +268,14 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       gameState.getState(),
       comPlayer,
     );
+
+    if (action.type === 'skip') {
+      // The seat already declared, so the rules leave it no action. Move the
+      // turn on instead of submitting one that will be rejected — retrying a
+      // forbidden action is what previously wedged the table.
+      return this.advanceBlowTurnPastActedPlayer(roomId, comPlayer, gameState);
+    }
+
     const result: PassBlowResponse | DeclareBlowResponse =
       action.type === 'declare'
         ? await this.declareBlowUseCase.execute({
@@ -292,6 +304,55 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       delayedEvents,
       shouldContinue,
       error: result.error,
+    };
+  }
+
+  /**
+   * Advances the blow turn past a seat that has already acted, mirroring the
+   * skip loop in declare-blow/pass-blow, and emits the resulting turn.
+   */
+  private async advanceBlowTurnPastActedPlayer(
+    roomId: string,
+    comPlayer: DomainPlayer,
+    gameState: GameStateService,
+  ): Promise<ComAutoPlayResponse> {
+    this.logger.warn(
+      `Blow turn sat on ${comPlayer.playerId} in room ${roomId}, which has already declared; advancing the turn`,
+    );
+
+    const state = gameState.getState();
+    const maxAttempts = state.players.length;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      await gameState.nextTurn();
+      const candidate = gameState.getCurrentPlayer();
+      if (!candidate) break;
+
+      const acted =
+        hasPlayerDeclaredInBlow(state.blowState, candidate.playerId) ||
+        hasPlayerPassedInBlow(state.blowState, candidate);
+      if (!acted) break;
+    }
+
+    await gameState.saveState();
+
+    const nextPlayer = gameState.getCurrentPlayer();
+    const events: GatewayEvent[] = nextPlayer
+      ? [
+          {
+            scope: 'room',
+            roomId,
+            event: 'update-turn',
+            payload: nextPlayer.playerId,
+          },
+        ]
+      : [];
+
+    return {
+      success: true,
+      events,
+      shouldContinue:
+        !!nextPlayer && this.comPlayerService.isComPlayer(nextPlayer),
     };
   }
 


### PR DESCRIPTION
**本番で対局が停止中です。** 現在も60秒間隔（バックオフ上限）でエラーが出続けています。

```
ERROR [ComAutoPlayRecoveryService] COM auto-play failed:
      You have already declared in this blow phase
```

再現手順: ホストが宣言 → 退出 → COM置換 → 停止。

## 原因

COM置換時、リマッパーは `blowState.declarations` を新COMのIDへ付け替えます（[player-reference-remapper.service.ts:56](mei-tra-backend/src/services/player-reference-remapper.service.ts:56)）。**これ自体は正しい挙動**で、入札は席に付いて回るべきものです。

ところが `declare-blow` と `pass-blow` は**どちらも** `hasPlayerDeclaredInBlow` で宣言済みプレイヤーを拒否します。

| | 判定箇所 |
|---|---|
| declare-blow | [use-case.ts:73](mei-tra-backend/src/use-cases/declare-blow.use-case.ts:73) |
| pass-blow | [use-case.ts:85](mei-tra-backend/src/use-cases/pass-blow.use-case.ts:85) |

つまり**宣言済みの席には合法手が存在しません**。`chooseBlowAction` はこれを考慮しておらず `pass` を返すため弾かれ、リカバリが同じ不正アクションを永久にリトライして卓が固定されます。

さらに `chooseBlowAction` は**自分自身の宣言を「味方の最高宣言」と誤認**していました（同一プレイヤーなので `team` が一致）。引き継いだ宣言があると「味方に遠慮してパス」の経路が確実に踏まれます。

## 私の変更が引き金になっています

`e27ec1e` より前はリマップが `persistRoster` に破棄されていたため、宣言は旧プレイヤーIDのまま残り、COMの新IDは「未行動」に見えて `pass` が通っていました。リマップを正しく永続化したことで、この既存の欠陥が露出した形です。

リマップを戻すのではなく、追随できていなかったCOM戦略と手番進行を直します。

## 修正内容

- `ComBlowAction` に `'skip'` を追加。宣言済みで合法手が無い席を表します
- `chooseBlowAction`: 宣言済みなら `'skip'`（**4つある `pass` 経路すべてより前**で判定）
- `chooseBlowAction`: 最高宣言者が自分自身なら「味方」扱いしない
- `com-autoplay`: `'skip'` を受けたら不正アクションを投げず、`declare-blow` / `pass-blow` と同じ要領で行動済みプレイヤーを飛ばして手番を進め、`update-turn` を emit します。想定外の状態なので `warn` も残します

## 検証

| 項目 | 結果 |
|---|---|
| `npx tsc --noEmit` | 通過 |
| `npx jest` | 60 suites / 368 tests 通過 |
| 回帰テスト | 5件追加 |
| **修正を戻すと落ちるか** | ✅ 3件が失敗。対照ケース2件は両状態で通過 |

テストは「書いて緑」で終わらせず、修正を一時的に無効化して赤くなることまで確認しています。

## マージ後

`main` へのマージで Fly へ自動デプロイされます。デプロイ後、`fly logs` で `already declared` が止まることと、`Blow turn sat on ... advancing the turn` の warn が出るか（＝スキップ経路が実際に効いたか）を確認します。

なお**停止中の対局は自動復旧しません**。デプロイ後に該当ルームを作り直していただく必要があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)