### PR TITLE
全員行動済みのblowフェーズが遷移せず卓が固まる問題を修正

### DIFF
--- a/mei-tra-backend/src/use-cases/__tests__/com-autoplay-stall-warning.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/com-autoplay-stall-warning.spec.ts
@@ -43,6 +43,8 @@ const buildUseCase = (options: {
     {} as never,
     {} as never,
     {} as never,
+    {} as never,
+    {} as never,
   );
 };
 

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -1976,6 +1976,8 @@ describe('Game Use Cases', () => {
         playCardUseCase as never,
         declareBlowUseCase as never,
         passBlowUseCase as never,
+        { isValidDeclaration: () => true } as never,
+        { getCardSuit: (c: string) => c.slice(-1) } as never,
         selectNegriUseCase as never,
         revealBrokenHandUseCase as never,
       );
@@ -2112,6 +2114,8 @@ describe('Game Use Cases', () => {
         playCardUseCase as never,
         declareBlowUseCase as never,
         passBlowUseCase as never,
+        { isValidDeclaration: () => true } as never,
+        { getCardSuit: (c: string) => c.slice(-1) } as never,
         selectNegriUseCase as never,
         revealBrokenHandUseCase as never,
       );
@@ -2249,6 +2253,8 @@ describe('Game Use Cases', () => {
         playCardUseCase as never,
         declareBlowUseCase as never,
         passBlowUseCase as never,
+        { isValidDeclaration: () => true } as never,
+        { getCardSuit: (c: string) => c.slice(-1) } as never,
         selectNegriUseCase as never,
         revealBrokenHandUseCase as never,
       );
@@ -2350,6 +2356,8 @@ describe('Game Use Cases', () => {
         playCardUseCase as never,
         declareBlowUseCase as never,
         passBlowUseCase as never,
+        { isValidDeclaration: () => true } as never,
+        { getCardSuit: (c: string) => c.slice(-1) } as never,
         selectNegriUseCase as never,
         revealBrokenHandUseCase as never,
       );

--- a/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
+++ b/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, Logger } from '@nestjs/common';
+import { Injectable, Inject, Logger, Optional } from '@nestjs/common';
 import {
   IComAutoPlayUseCase,
   ComAutoPlayRequest,
@@ -24,6 +24,11 @@ import {
   SelectNegriResponse,
 } from './interfaces/select-negri.use-case.interface';
 import { IRevealBrokenHandUseCase } from './interfaces/reveal-broken-hand.use-case.interface';
+import { transitionToPlayPhase } from './blow-phase-transition.helper';
+import { countPlayersActedInBlow } from './helpers/blow-action.helper';
+import { IBlowService } from '../services/interfaces/blow-service.interface';
+import { ICardService } from '../services/interfaces/card-service.interface';
+import { IGameEventLogService } from '../services/interfaces/game-event-log.service.interface';
 import { DomainPlayer } from '../types/game.types';
 import { GameStateService } from '../services/game-state.service';
 import { GatewayEvent } from './interfaces/gateway-event.interface';
@@ -56,10 +61,17 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
     private readonly declareBlowUseCase: IDeclareBlowUseCase,
     @Inject('IPassBlowUseCase')
     private readonly passBlowUseCase: IPassBlowUseCase,
+    @Inject('IBlowService')
+    private readonly blowService: IBlowService,
+    @Inject('ICardService')
+    private readonly cardService: ICardService,
     @Inject('ISelectNegriUseCase')
     private readonly selectNegriUseCase: ISelectNegriUseCase,
     @Inject('IRevealBrokenHandUseCase')
     private readonly revealBrokenHandUseCase: IRevealBrokenHandUseCase,
+    @Optional()
+    @Inject('IGameEventLogService')
+    private readonly gameEventLogService?: IGameEventLogService,
   ) {}
 
   // Skipping a human's turn is normal, so this stays quiet unless nobody can act:
@@ -316,11 +328,45 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
     comPlayer: DomainPlayer,
     gameState: GameStateService,
   ): Promise<ComAutoPlayResponse> {
+    const state = gameState.getState();
+
+    // Everyone has acted, so there is no turn to move to — the blow phase is
+    // over and simply never transitioned. This is reachable because the
+    // all-acted check lives inside declare-blow/pass-blow, and a COM
+    // replacement changes the roster without either of them running.
+    if (countPlayersActedInBlow(state.players, state.blowState) >=
+      state.players.length) {
+      this.logger.warn(
+        `Blow phase in room ${roomId} had all players acted but never transitioned; completing it`,
+      );
+
+      const room = await this.roomService.getRoom(roomId);
+      if (!room) {
+        return { success: false, events: [], shouldContinue: false, error: 'Room not found' };
+      }
+
+      const transition = await transitionToPlayPhase({
+        roomId,
+        roomGameState: gameState,
+        room,
+        state,
+        blowService: this.blowService,
+        cardService: this.cardService,
+        gameEventLogService: this.gameEventLogService,
+      });
+
+      return {
+        success: true,
+        events: transition.events,
+        delayedEvents: transition.delayedEvents,
+        shouldContinue: false,
+      };
+    }
+
     this.logger.warn(
       `Blow turn sat on ${comPlayer.playerId} in room ${roomId}, which has already declared; advancing the turn`,
     );
 
-    const state = gameState.getState();
     const maxAttempts = state.players.length;
 
     for (let attempt = 0; attempt < maxAttempts; attempt += 1) {


### PR DESCRIPTION
[#189](https://github.com/hikaruendo/mei-tra/pull/189) の追加修正です。

## 前提の訂正

当初「本番が今も止まっている」として緊急扱いで出しましたが、**その前提は誤りでした**。ログを追ったところ、警告は旧ルーム `1f07b8ec` に閉じており、`05:56:38` を最後に停止しています（ログは `06:00:00` まで取得）。ユーザーがそのルームを離れた時点で `clearRoom` が世代を進め、保留タイマーが無効化されたためです。

新しい部屋では正常に動作します。壊れた状態はルーム単位に閉じているためで、想定通りの挙動です。

**したがって緊急性はありません。** ただし問題自体は実在します。

## 残っている問題

| | |
|---|---|
| ノイズが止まる理由 | ルームが破棄されるから |
| 卓が進むか | **進まない**。約2分間空回りして放棄されて終わり |

`shouldContinue` が次のCOMを指し続けるため4秒周期で自走します。**放置しても復帰せず、部屋を作り直すしかありません。**

## #189 で残った穴

#189 でエラーの無限リトライは止まりましたが、新しく入れた warn が同一プレイヤー・同一ルームで4秒間隔で出続けました。手番送りが一周して元の席に戻っていたためです。

**全員が行動済みなら、進むべき手番は存在しません。** 必要なのは手番送りではなく、blowフェーズの終了（playフェーズへの遷移）でした。

この遷移判定は `declare-blow` / `pass-blow` の**中**にあります。COM置換はどちらも通らずロスターを変えるため、「全員行動済みだが遷移していない」状態が取り残されます。

## 修正

`com-autoplay` のスキップ経路で、まず全員行動済みかを判定し、そうであれば `declare-blow` と同じ `transitionToPlayPhase` を呼んでフェーズを終了させます。手番送りは未行動の席が残っている場合のみ行います。

`transitionToPlayPhase` に必要な `IBlowService` / `ICardService` / `IGameEventLogService` を注入しました（`gameEventLogService` は `declare-blow` と同様オプション）。

これにより、同じ再現手順（宣言 → 退出 → COM置換）を踏んだ卓が、放棄されるまで空回りするのではなく、blowフェーズを正しく終えて対局を続けられます。

## 検証

| 項目 | 結果 |
|---|---|
| `npx tsc --noEmit` | 通過 |
| `npx jest` | 60 suites / 368 tests 通過 |

**本番での効果確認は、同じ再現手順を踏まないと検証できません。** デプロイ後のログに `Blow phase in room ... had all players acted but never transitioned; completing it` が出れば、この経路が実際に働いたことになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)