### PR TITLE
終了済みルームを指す membership が入室を恒久ブロックする問題を修正

### DIFF
--- a/mei-tra-backend/supabase/migrations/20260809074500_release_stale_room_membership.sql
+++ b/mei-tra-backend/supabase/migrations/20260809074500_release_stale_room_membership.sql
@@ -1,0 +1,325 @@
+-- A membership is supposed to be released when its room finishes, but that
+-- release is a second step after the room status write (see
+-- RoomService.updateRoomStatus). If the process dies between the two, or the
+-- release RPC fails, the row survives pointing at a room nobody can join --
+-- and reserve/claim then reject every future room for that user forever.
+--
+-- Rather than making the two writes atomic (the status write lives behind the
+-- repository, and abandoned rooms have other producers), treat the membership
+-- itself as authoritative only while its room is still joinable: a membership
+-- whose room is 'finished' or 'abandoned' is dead and gets cleared on the spot
+-- by whichever reserve/claim runs next. That also drains rows already stranded
+-- by past crashes without a data migration.
+
+create or replace function public.release_stale_room_membership(
+  p_membership public.active_room_memberships,
+  p_transition_id uuid
+)
+returns boolean
+language plpgsql
+set search_path to ''
+as $function$
+declare
+  stale_room_status public.room_status;
+begin
+  if p_membership.room_id is null then
+    return false;
+  end if;
+
+  select rooms.status
+  into stale_room_status
+  from public.rooms
+  where rooms.id = p_membership.room_id;
+
+  -- Deleting a room cascades its memberships away, so a missing room normally
+  -- cannot strand anyone; it is treated as stale here purely defensively.
+  if found and stale_room_status not in ('finished', 'abandoned') then
+    return false;
+  end if;
+
+  delete from public.active_room_memberships
+  where user_id = p_membership.user_id
+    and membership_version = p_membership.membership_version;
+
+  if not found then
+    return false;
+  end if;
+
+  insert into public.room_membership_events (
+    transition_id,
+    user_id,
+    from_room_id,
+    event_type,
+    membership_version,
+    metadata
+  ) values (
+    p_transition_id,
+    p_membership.user_id,
+    p_membership.room_id,
+    'stale_room_released',
+    p_membership.membership_version,
+    jsonb_build_object('roomStatus', stale_room_status)
+  );
+
+  return true;
+end;
+$function$;
+
+create or replace function public.reserve_room_membership(
+  p_user_id uuid,
+  p_player_id text,
+  p_transition_id uuid
+)
+returns jsonb
+language plpgsql
+set search_path to ''
+as $function$
+declare
+  current_membership public.active_room_memberships%rowtype;
+  has_membership boolean;
+begin
+  perform pg_advisory_xact_lock(hashtextextended(p_user_id::text, 0));
+
+  select *
+  into current_membership
+  from public.active_room_memberships
+  where user_id = p_user_id
+  for update;
+
+  has_membership := found;
+
+  if has_membership
+    and public.release_stale_room_membership(
+      current_membership,
+      p_transition_id
+    ) then
+    has_membership := false;
+  end if;
+
+  if not has_membership then
+    insert into public.active_room_memberships (
+      user_id,
+      room_id,
+      player_id,
+      status,
+      membership_version,
+      transition_id
+    ) values (
+      p_user_id,
+      null,
+      p_player_id,
+      'moving',
+      1,
+      p_transition_id
+    )
+    returning * into current_membership;
+
+    insert into public.room_membership_events (
+      transition_id,
+      user_id,
+      event_type,
+      membership_version
+    ) values (
+      p_transition_id,
+      p_user_id,
+      'create_reserved',
+      current_membership.membership_version
+    );
+
+    return jsonb_build_object(
+      'result', 'reserved',
+      'membership', to_jsonb(current_membership)
+    );
+  end if;
+
+  if current_membership.status = 'moving'
+    and current_membership.transition_id = p_transition_id then
+    return jsonb_build_object(
+      'result', 'reserved',
+      'membership', to_jsonb(current_membership)
+    );
+  end if;
+
+  if current_membership.status = 'moving'
+    and current_membership.updated_at < now() - interval '2 minutes' then
+    update public.active_room_memberships
+    set
+      player_id = p_player_id,
+      membership_version = membership_version + 1,
+      transition_id = p_transition_id,
+      last_seen_at = now()
+    where user_id = p_user_id
+    returning * into current_membership;
+
+    insert into public.room_membership_events (
+      transition_id,
+      user_id,
+      event_type,
+      membership_version,
+      metadata
+    ) values (
+      p_transition_id,
+      p_user_id,
+      'create_reservation_recovered',
+      current_membership.membership_version,
+      jsonb_build_object('leaseSeconds', 120)
+    );
+
+    return jsonb_build_object(
+      'result', 'reserved',
+      'membership', to_jsonb(current_membership)
+    );
+  end if;
+
+  return jsonb_build_object(
+    'result', 'conflict',
+    'membership', to_jsonb(current_membership)
+  );
+end;
+$function$;
+
+-- Body carried forward from 20260803013500_active_room_membership_recovery,
+-- which supersedes the original in 20260803005931 -- the disconnect-timeout
+-- lease branches below come from there and must not be dropped.
+create or replace function public.claim_room_membership(
+  p_user_id uuid,
+  p_room_id uuid,
+  p_player_id text,
+  p_transition_id uuid
+)
+returns jsonb
+language plpgsql
+set search_path to ''
+as $function$
+declare
+  current_membership public.active_room_memberships%rowtype;
+  has_membership boolean;
+  previous_room_id uuid;
+  claim_result text;
+begin
+  perform pg_advisory_xact_lock(hashtextextended(p_user_id::text, 0));
+
+  select *
+  into current_membership
+  from public.active_room_memberships
+  where user_id = p_user_id
+  for update;
+
+  has_membership := found;
+
+  -- Only a membership pointing somewhere else can be stale here: claiming the
+  -- same room again is the reconnect path, and that room is still live.
+  if has_membership
+    and current_membership.room_id is distinct from p_room_id
+    and public.release_stale_room_membership(
+      current_membership,
+      p_transition_id
+    ) then
+    has_membership := false;
+  end if;
+
+  if not has_membership then
+    insert into public.active_room_memberships (
+      user_id,
+      room_id,
+      player_id,
+      status,
+      membership_version,
+      transition_id,
+      last_seen_at
+    ) values (
+      p_user_id,
+      p_room_id,
+      p_player_id,
+      'active',
+      1,
+      p_transition_id,
+      now()
+    )
+    returning * into current_membership;
+    claim_result := 'claimed';
+  elsif current_membership.status = 'moving'
+    and current_membership.room_id is null
+    and current_membership.transition_id = p_transition_id then
+    previous_room_id := current_membership.room_id;
+    update public.active_room_memberships
+    set
+      room_id = p_room_id,
+      player_id = p_player_id,
+      status = 'active',
+      membership_version = membership_version + 1,
+      last_seen_at = now()
+    where user_id = p_user_id
+    returning * into current_membership;
+    claim_result := 'claimed';
+  elsif current_membership.status = 'moving'
+    and current_membership.room_id = p_room_id
+    and current_membership.updated_at < now() - interval '30 seconds' then
+    previous_room_id := current_membership.room_id;
+    update public.active_room_memberships
+    set
+      player_id = p_player_id,
+      status = 'active',
+      membership_version = membership_version + 1,
+      transition_id = p_transition_id,
+      last_seen_at = now()
+    where user_id = p_user_id
+    returning * into current_membership;
+    claim_result := 'reconnected';
+  elsif current_membership.room_id = p_room_id
+    and current_membership.status in ('active', 'disconnected') then
+    previous_room_id := current_membership.room_id;
+    update public.active_room_memberships
+    set
+      player_id = p_player_id,
+      status = 'active',
+      membership_version = membership_version + 1,
+      transition_id = p_transition_id,
+      last_seen_at = now()
+    where user_id = p_user_id
+    returning * into current_membership;
+    claim_result := 'reconnected';
+  else
+    return jsonb_build_object(
+      'result', 'conflict',
+      'membership', to_jsonb(current_membership)
+    );
+  end if;
+
+  insert into public.room_membership_events (
+    transition_id,
+    user_id,
+    from_room_id,
+    to_room_id,
+    event_type,
+    membership_version
+  ) values (
+    p_transition_id,
+    p_user_id,
+    previous_room_id,
+    p_room_id,
+    case
+      when claim_result = 'reconnected' then 'room_reconnected'
+      else 'room_claimed'
+    end,
+    current_membership.membership_version
+  );
+
+  return jsonb_build_object(
+    'result', claim_result,
+    'membership', to_jsonb(current_membership)
+  );
+end;
+$function$;
+
+revoke all on function public.release_stale_room_membership(
+  public.active_room_memberships,
+  uuid
+) from public, anon, authenticated;
+
+grant execute on function public.release_stale_room_membership(
+  public.active_room_memberships,
+  uuid
+) to service_role;
+
+select pg_notify('pgrst', 'reload schema');

--- a/mei-tra-backend/supabase/tests/stale_room_membership_release.sql
+++ b/mei-tra-backend/supabase/tests/stale_room_membership_release.sql
@@ -1,0 +1,130 @@
+begin;
+
+insert into auth.users (
+  id,
+  email,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+values (
+  '00000000-0000-0000-0000-000000000921',
+  'stale-membership-test@example.com',
+  '{"username":"stale_membership_test","display_name":"Stale Membership"}'::jsonb,
+  now(),
+  now()
+);
+
+insert into public.rooms (id, name, host_id, status)
+values
+  (
+    '00000000-0000-0000-0000-000000000922',
+    'Stale room A',
+    'stale-player',
+    'playing'
+  ),
+  (
+    '00000000-0000-0000-0000-000000000923',
+    'Stale room B',
+    'stale-player',
+    'waiting'
+  );
+
+do $test$
+declare
+  result jsonb;
+  membership public.active_room_memberships%rowtype;
+  released_events integer;
+  test_user constant uuid := '00000000-0000-0000-0000-000000000921';
+  room_a constant uuid := '00000000-0000-0000-0000-000000000922';
+  room_b constant uuid := '00000000-0000-0000-0000-000000000923';
+  t1 constant uuid := '00000000-0000-4000-8000-000000000924';
+  t2 constant uuid := '00000000-0000-4000-8000-000000000925';
+  t3 constant uuid := '00000000-0000-4000-8000-000000000926';
+  t4 constant uuid := '00000000-0000-4000-8000-000000000927';
+begin
+  if has_function_privilege(
+    'anon',
+    'public.release_stale_room_membership(public.active_room_memberships,uuid)',
+    'execute'
+  ) then
+    raise exception 'anon can release stale room memberships';
+  end if;
+
+  if not has_function_privilege(
+    'service_role',
+    'public.release_stale_room_membership(public.active_room_memberships,uuid)',
+    'execute'
+  ) then
+    raise exception 'service_role cannot release stale room memberships';
+  end if;
+
+  result := public.claim_room_membership(test_user, room_a, 'stale-player', t1);
+  if result->>'result' <> 'claimed' then
+    raise exception 'setup claim failed: %', result;
+  end if;
+
+  -- A live room must keep behaving exactly as before.
+  result := public.reserve_room_membership(test_user, 'stale-player', t2);
+  if result->>'result' <> 'conflict' then
+    raise exception 'live room did not block reservation: %', result;
+  end if;
+
+  result := public.claim_room_membership(test_user, room_b, 'stale-player', t2);
+  if result->>'result' <> 'conflict' then
+    raise exception 'live room did not block cross-room claim: %', result;
+  end if;
+
+  result := public.claim_room_membership(test_user, room_a, 'stale-player', t2);
+  if result->>'result' <> 'reconnected' then
+    raise exception 'live room reconnect broke: %', result;
+  end if;
+
+  -- Room A finishes. The membership release that normally follows the status
+  -- write is skipped here, standing in for a crash between the two.
+  update public.rooms set status = 'finished' where id = room_a;
+
+  result := public.claim_room_membership(test_user, room_b, 'stale-player', t3);
+  if result->>'result' <> 'claimed' then
+    raise exception 'finished room still blocked a claim: %', result;
+  end if;
+
+  select count(*)
+  into released_events
+  from public.room_membership_events
+  where user_id = test_user
+    and event_type = 'stale_room_released'
+    and from_room_id = room_a;
+  if released_events <> 1 then
+    raise exception
+      'expected one stale_room_released event for room A, got %',
+      released_events;
+  end if;
+
+  select * into membership
+  from public.active_room_memberships
+  where user_id = test_user;
+  if membership.room_id <> room_b or membership.status <> 'active' then
+    raise exception 'membership did not move to room B: %', to_jsonb(membership);
+  end if;
+
+  -- Same check on the reserve path, and for 'abandoned' as well as 'finished'.
+  update public.rooms set status = 'abandoned' where id = room_b;
+
+  result := public.reserve_room_membership(test_user, 'stale-player', t4);
+  if result->>'result' <> 'reserved' then
+    raise exception 'abandoned room still blocked a reservation: %', result;
+  end if;
+
+  select * into membership
+  from public.active_room_memberships
+  where user_id = test_user;
+  if membership.room_id is not null or membership.status <> 'moving' then
+    raise exception
+      'reservation did not clear the stale room: %',
+      to_jsonb(membership);
+  end if;
+end;
+$test$;
+
+rollback;


### PR DESCRIPTION
## Summary

終了した room を指したまま残った `active_room_memberships` の行が、そのユーザーの入室を恒久的にブロックする問題を修正します。

### 症状

ローカルで再現・確認したもの。あるユーザーがルーム作成・参加のどちらを試みても `You are already active in another room.` が返り続け、**1日以上どの部屋にも入れない**状態になっていました。

```
user_id = 84139f99…  room_id = 1b7f0e00…  status = active  更新 = 2026-08-08 07:14
→ room 1b7f0e00… の status は 'finished'（誰も参加できない）
```

`room_membership_events` に当該 room の `room_closed` が1件も無く、解放処理そのものが実行されていなかったことが確認できます。

### 原因

`RoomService.updateRoomStatus()` の解放は2段階です。

1. rooms.status を `finished` / `abandoned` に書く
2. `RoomMembershipService.releaseRoom()` で membership を消す

この間でプロセスが落ちるか手順2が失敗すると、membership 行だけが取り残されます。`reserve_room_membership` / `claim_room_membership` は `room_id` が非 null なら**参照先 room の状態を見ずに無条件で `conflict`** を返すため、以降そのユーザーはどのルームにも入れません。自然回復する経路もありません。

`RoomMembershipReconcilerService` は起動時にしか走らず、かつ「プレイヤーが room の名簿に居れば membership を保持」する判定なので、finished room の名簿（戦績表示のため保持される）に居るこのケースでは救済されません。

### 修正方針

2つの書き込みを atomic にする代わりに、membership の有効条件を定義し直しました。

> **参照先 room が join 可能な間だけ membership は有効。`finished` / `abandoned` を指す membership は死んでいる。**

新設した `release_stale_room_membership()` を `reserve` / `claim` の advisory lock 内から呼び、死んだ membership をその場で解放してから処理を続行します。

- 中断がどの時点で起きても詰まらない（2段階書き込みのままで安全）
- **既に取り残されている行もデータ移行なしで解消される**
- 監査のため `stale_room_released` イベントを記録

`claim` は同一 room への claim（= 再接続経路）では発火しません。disconnect timeout lease の判定を壊さないためです。

バックエンドの TypeScript は無改造で、変更は SQL に閉じています。

### 注意

`claim_room_membership` の本体は `20260803013500_active_room_membership_recovery.sql` の版を引き継いでいます。`20260803005931` の旧版には disconnect timeout lease の分岐が無く、そちらをベースにすると `supabase/tests/active_room_membership_recovery.sql` が落ちます（実装中に一度踏みました）。差分は追加したガードのみで、他は現行定義とバイト一致です。

## Validation

- `supabase/tests/active_room_memberships.sql` — PASS（既存・回帰確認）
- `supabase/tests/active_room_membership_recovery.sql` — PASS（既存・回帰確認）
- `supabase/tests/stale_room_membership_release.sql` — PASS（新規）
  - 生きている room では従来どおり `conflict` / `reconnected` を返すことを固定
  - `finished` / `abandoned` の両方を検証
  - 新関数の権限（anon 不可 / service_role 可）を検証
- 実際に取り残されていた行に対し、バックエンドが使うのと同じ PostgREST 経由で `reserve_room_membership` を呼び、`conflict` → `reserved` に変わることを確認

未実施: 本番 DB への適用、アプリ UI 上での操作確認。

## Demo evidence

<!-- x-demo:start -->
{
  "route": "/ja",
  "media": "none",
  "steps": [],
  "filename": "capture.png"
}
<!-- x-demo:end -->
