### PR TITLE
migration中の旧host identityを保持

### DIFF
--- a/mei-tra-backend/supabase/migrations/20260811105000_preserve_legacy_host_alias.sql
+++ b/mei-tra-backend/supabase/migrations/20260811105000_preserve_legacy_host_alias.sql
@@ -1,0 +1,52 @@
+create or replace function public.sync_room_host_seat_identity()
+returns trigger
+language plpgsql
+security invoker
+set search_path = public
+as $function$
+declare
+  resolved_seat_id uuid;
+begin
+  if new.host_seat_id is null and new.host_id is null then
+    return new;
+  end if;
+
+  if tg_op = 'INSERT' and new.host_seat_id is not null then
+    new.host_id := new.host_seat_id::text;
+    return new;
+  end if;
+
+  if tg_op = 'UPDATE'
+    and new.host_seat_id is distinct from old.host_seat_id then
+    if old.host_seat_id is null
+      and new.host_seat_id is not null
+      and new.host_id is not distinct from old.host_id then
+      return new;
+    end if;
+
+    new.host_id := new.host_seat_id::text;
+    return new;
+  end if;
+
+  if new.host_id is not null then
+    resolved_seat_id := meitra_private.resolve_room_seat_id(
+      new.id,
+      new.host_id,
+      null
+    );
+  end if;
+
+  if resolved_seat_id is not null then
+    new.host_seat_id := resolved_seat_id;
+    new.host_id := resolved_seat_id::text;
+    return new;
+  end if;
+
+  if new.host_seat_id is not null and new.host_id is null then
+    new.host_id := new.host_seat_id::text;
+    return new;
+  end if;
+
+  return new;
+end;
+$function$;


### PR DESCRIPTION
## Summary

`host_seat_id`のbackfill中だけ旧`host_id`を保持し、続く履歴変換が旧hostを席UUIDへ解決できるようにします。

## User-facing change

旧hostを含む過去ログでも席identity cleanupが停止しなくなります。

## User benefit

履歴を失わずに本番DBを新しい席UUID設計へ移行できます。

## Validation

- cleanup直前まで`supabase db reset`
- membership eventなしの旧host、timeout COM、退出COM fixtureを投入
- `supabase migration up --local --include-all`
- actor、host、JSON参照が期待するseat UUIDへ変換されることをSQL確認