### PR TITLE
部分適用済みの旧host参照を復元

### DIFF
--- a/mei-tra-backend/supabase/migrations/20260811115000_recover_overwritten_host_alias.sql
+++ b/mei-tra-backend/supabase/migrations/20260811115000_recover_overwritten_host_alias.sql
@@ -1,0 +1,38 @@
+with legacy_host_actors as (
+  select distinct on (history.room_id)
+    history.room_id,
+    history.actor_key_snapshot as legacy_host_identity,
+    room.host_seat_id
+  from public.game_history as history
+  join public.rooms as room
+    on room.id = history.room_id
+  where history.action_type = 'game_started'
+    and history.actor_seat_id is null
+    and history.actor_key_snapshot
+      ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    and room.host_seat_id is not null
+    and exists (
+      select 1
+      from public.room_membership_events as event
+      where event.user_id = history.actor_key_snapshot::uuid
+        and (
+          event.from_room_id = history.room_id
+          or event.to_room_id = history.room_id
+        )
+    )
+  order by history.room_id, history.timestamp
+)
+update public.room_players as room_player
+set player_id = legacy_host_actors.legacy_host_identity
+from legacy_host_actors
+where room_player.room_id = legacy_host_actors.room_id
+  and room_player.id = legacy_host_actors.host_seat_id;
+
+update public.game_history as history
+set actor_seat_id = meitra_private.resolve_room_seat_id(
+  history.room_id,
+  history.actor_key_snapshot,
+  null
+)
+where history.actor_seat_id is null
+  and history.actor_key_snapshot is not null;


### PR DESCRIPTION
## Summary

先行migrationで旧`host_id`が既に席UUIDへ置換された部屋について、`game_started`履歴とmembership eventを根拠に旧host aliasを一時復元します。

## User-facing change

途中までmigration済みの過去対局も、履歴を保持したままcleanupできます。

## User benefit

本番DBの部分適用状態を安全に解消し、席参照エラーを残しません。

## Validation

- `11110000`まで適用済みの部分migration状態をローカル再現
- 旧host aliasが失われ、actorがnullのfixtureを投入
- `supabase migration up --local --include-all`
- actor列とJSON内3参照が同じhost seat UUIDになることをSQL確認