### PR TITLE
ゲーム操作のDB保存を一回に集約

### DIFF
--- a/mei-tra-backend/src/services/__tests__/game-state-phase.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/game-state-phase.spec.ts
@@ -34,21 +34,25 @@ describe('GameStateService phase transitions', () => {
     jest.restoreAllMocks();
   });
 
-  it('persists a legal transition', async () => {
-    await service.transitionPhase('blow');
+  it('keeps a legal transition in memory until the action is saved', async () => {
+    service.transitionPhase('blow');
 
     expect(service.getState().gamePhase).toBe('blow');
+    expect(repository.update).not.toHaveBeenCalled();
+
+    await service.saveState();
+
     expect(repository.update).toHaveBeenCalledWith(
       'room-1',
-      { gamePhase: 'blow' },
+      expect.objectContaining({ gamePhase: 'blow' }),
       0,
     );
   });
 
-  it('rejects an illegal transition and keeps the previous phase', async () => {
-    await service.transitionPhase('blow');
+  it('rejects an illegal transition and keeps the previous phase', () => {
+    service.transitionPhase('blow');
 
-    await expect(service.transitionPhase('deal')).rejects.toThrow(
+    expect(() => service.transitionPhase('deal')).toThrow(
       'Invalid game phase transition: blow -> deal',
     );
     expect(service.getState().gamePhase).toBe('blow');
@@ -78,7 +82,7 @@ describe('GameStateService phase transitions', () => {
     state.version = 96;
     state.teamAssignments = { 'player-1': 0 };
 
-    await service.resetRoundState();
+    service.resetRoundState();
     expect(service.getState().version).toBe(96);
     expect(service.getState().teamAssignments).toEqual({ 'player-1': 0 });
 
@@ -91,17 +95,54 @@ describe('GameStateService phase transitions', () => {
     );
   });
 
-  it('persists round changes through an explicit state update', async () => {
+  it('keeps explicit state updates in memory until the action is saved', async () => {
     const state = service.getState();
     state.version = 96;
 
-    await service.updateState({ roundNumber: 2 });
+    service.updateState({ roundNumber: 2 });
+
+    expect(service.getState().roundNumber).toBe(2);
+    expect(repository.update).not.toHaveBeenCalled();
+
+    await service.saveState();
 
     expect(repository.update).toHaveBeenCalledWith(
       'room-1',
-      { roundNumber: 2 },
+      expect.objectContaining({ roundNumber: 2 }),
       96,
     );
+  });
+
+  it('advances the turn without persisting an intermediate snapshot', async () => {
+    const state = service.getState();
+    state.players = [
+      {
+        playerId: 'player-1',
+        name: 'Player 1',
+        team: 0,
+        hand: [],
+        isPasser: false,
+      },
+      {
+        playerId: 'player-2',
+        name: 'Player 2',
+        team: 1,
+        hand: [],
+        isPasser: false,
+      },
+    ];
+    state.currentPlayerId = 'player-1';
+    state.currentPlayerIndex = 0;
+
+    service.nextTurn();
+
+    expect(state.currentPlayerId).toBe('player-2');
+    expect(state.currentPlayerIndex).toBe(1);
+    expect(repository.update).not.toHaveBeenCalled();
+
+    await service.saveState();
+
+    expect(repository.update).toHaveBeenCalledTimes(1);
   });
 
   it('records a completed field without persisting an intermediate snapshot', () => {
@@ -182,7 +223,7 @@ describe('GameStateService phase transitions', () => {
     ];
     jest.spyOn(Math, 'random').mockReturnValue(0.6);
 
-    await service.startGame();
+    service.startGame();
 
     const startedState = service.getState();
     expect(startedState.currentPlayerIndex).toBe(2);
@@ -190,5 +231,6 @@ describe('GameStateService phase transitions', () => {
       'player-3',
     );
     expect(startedState.blowState.currentBlowIndex).toBe(2);
+    expect(repository.update).not.toHaveBeenCalled();
   });
 });

--- a/mei-tra-backend/src/services/game-state-manager.service.ts
+++ b/mei-tra-backend/src/services/game-state-manager.service.ts
@@ -1,10 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { IGameStateRepository } from '../repositories/interfaces/game-state.repository.interface';
-import {
-  GamePhase,
-  GameState,
-  PlayerConnectionMetadata,
-} from '../types/game.types';
+import { GameState, PlayerConnectionMetadata } from '../types/game.types';
 import { RoomPlayer } from '../types/room.types';
 import { RosterMembershipMutation } from '../types/room-membership.types';
 import { GamePhaseService } from './game-phase.service';
@@ -18,11 +14,10 @@ export class GameStateManager {
     private readonly gamePhaseService: GamePhaseService,
   ) {}
 
-  async updateState(
-    roomId: string | null,
+  applyState(
     currentState: GameState,
     newState: Partial<GameState>,
-  ): Promise<GameState> {
+  ): GameState {
     if (Object.prototype.hasOwnProperty.call(newState, 'gamePhase')) {
       this.gamePhaseService.assertTransition(
         currentState.gamePhase,
@@ -43,6 +38,16 @@ export class GameStateManager {
         : null;
     }
     nextState = normalizeGameStateIdentityAliases(nextState);
+
+    return nextState;
+  }
+
+  async updateState(
+    roomId: string | null,
+    currentState: GameState,
+    newState: Partial<GameState>,
+  ): Promise<GameState> {
+    const nextState = this.applyState(currentState, newState);
 
     if (roomId) {
       const persistencePatch: Partial<GameState> = { ...newState };
@@ -84,14 +89,6 @@ export class GameStateManager {
     }
 
     return nextState;
-  }
-
-  async transitionPhase(
-    roomId: string | null,
-    currentState: GameState,
-    nextPhase: GamePhase,
-  ): Promise<GameState> {
-    return this.updateState(roomId, currentState, { gamePhase: nextPhase });
   }
 
   async loadState(
@@ -188,46 +185,6 @@ export class GameStateManager {
     } catch (error) {
       this.logger.error('Failed to persist player connection update:', error);
     }
-  }
-
-  async persistCurrentPlayerId(
-    roomId: string | null,
-    state: GameState,
-    currentPlayerId: string | null,
-  ): Promise<number | undefined> {
-    if (!roomId) {
-      return state.version;
-    }
-
-    const persistedState = await this.repository.update(
-      roomId,
-      { currentPlayerId },
-      state.version,
-    );
-    if (!persistedState) {
-      throw new Error(`Game state not found for room ${roomId}`);
-    }
-    return persistedState.version;
-  }
-
-  async persistRoundNumber(
-    roomId: string | null,
-    state: GameState,
-    roundNumber: number,
-  ): Promise<number | undefined> {
-    if (!roomId) {
-      return state.version;
-    }
-
-    const persistedState = await this.repository.update(
-      roomId,
-      { roundNumber },
-      state.version,
-    );
-    if (!persistedState) {
-      throw new Error(`Game state not found for room ${roomId}`);
-    }
-    return persistedState.version;
   }
 
   async resetState(roomId: string | null, state: GameState): Promise<void> {

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -234,16 +234,12 @@ export class GameStateService implements IGameStateService {
     return result;
   }
 
-  async updateState(newState: Partial<GameState>): Promise<void> {
-    this.state = await this.enqueuePersistence(() =>
-      this.stateManager.updateState(this.roomId, this.state, newState),
-    );
+  updateState(newState: Partial<GameState>): void {
+    this.state = this.stateManager.applyState(this.state, newState);
   }
 
-  async transitionPhase(nextPhase: GamePhase): Promise<void> {
-    this.state = await this.enqueuePersistence(() =>
-      this.stateManager.transitionPhase(this.roomId, this.state, nextPhase),
-    );
+  transitionPhase(nextPhase: GamePhase): void {
+    this.updateState({ gamePhase: nextPhase });
   }
 
   async loadState(roomId: string): Promise<void> {
@@ -491,7 +487,7 @@ export class GameStateService implements IGameStateService {
     return this.connectionManager.getPlayerConnectionState(playerId);
   }
 
-  async dealCards(): Promise<void> {
+  dealCards(): void {
     if (this.state.players.length === 0) return;
 
     // Validate deck exists and has correct size
@@ -548,12 +544,9 @@ export class GameStateService implements IGameStateService {
       this.chomboService.checkForBrokenHand(player);
       this.chomboService.checkForRequiredBrokenHand(player);
     });
-
-    // Persist the updated state
-    await this.saveState();
   }
 
-  async nextTurn(): Promise<void> {
+  nextTurn(): void {
     if (this.state.players.length === 0) return;
     const currentIndex = this.resolveCurrentPlayerIndex();
     const nextIndex = (currentIndex + 1) % this.state.players.length;
@@ -563,21 +556,6 @@ export class GameStateService implements IGameStateService {
     this.state.currentSeatId = this.state.currentPlayerId
       ? asSeatId(this.state.currentPlayerId)
       : null;
-
-    // Persist the turn change
-    if (this.roomId) {
-      try {
-        this.state.version = await this.enqueuePersistence(() =>
-          this.stateManager.persistCurrentPlayerId(
-            this.roomId,
-            this.state,
-            this.state.currentPlayerId ?? null,
-          ),
-        );
-      } catch {
-        // Keep in-memory turn changes even if persistence fails.
-      }
-    }
   }
 
   getCurrentPlayer(): DomainPlayer | null {
@@ -629,7 +607,7 @@ export class GameStateService implements IGameStateService {
     );
   }
 
-  async resetRoundState(): Promise<void> {
+  resetRoundState(): void {
     // Keep the current players, scores, and game settings
     const version = this.state.version;
     const players = [...this.state.players];
@@ -650,7 +628,7 @@ export class GameStateService implements IGameStateService {
 
     // Generate new deck and deal cards
     this.state.deck = this.cardService.generateDeck();
-    await this.dealCards();
+    this.dealCards();
   }
 
   get roundNumber(): number {
@@ -673,19 +651,6 @@ export class GameStateService implements IGameStateService {
       this.state.currentPlayerId = playerId;
       this.state.currentSeatId = asSeatId(playerId);
       this.state.currentPlayerIndex = playerIndex;
-      void this.enqueuePersistence(() =>
-        this.stateManager.persistCurrentPlayerId(
-          this.roomId,
-          this.state,
-          playerId,
-        ),
-      )
-        .then((version) => {
-          this.state.version = version;
-        })
-        .catch((error) => {
-          this.logger.error('Failed to persist turn change:', error);
-        });
     }
   }
 
@@ -711,13 +676,13 @@ export class GameStateService implements IGameStateService {
       : 0;
   }
 
-  async startGame(): Promise<void> {
-    await this.transitionPhase('blow');
+  startGame(): void {
+    this.transitionPhase('blow');
     let state = this.getState();
 
     // Initialize game state
     state.deck = this.cardService.generateDeck();
-    await this.dealCards();
+    this.dealCards();
     state = this.getState();
 
     // Initialize play state
@@ -760,8 +725,6 @@ export class GameStateService implements IGameStateService {
       currentBlowIndex: firstBlowIndex,
     };
 
-    // Persist the game start
-    await this.saveState();
   }
 
   setDisconnectTimeout(playerId: string, timeout: NodeJS.Timeout): void {

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -1726,7 +1726,7 @@ describe('Game Use Cases', () => {
         (evt) => evt.event === 'update-turn',
       );
       expect(updateTurnEvent?.payload).toBe('player-2');
-      expect(roomGameState.saveState).toHaveBeenCalled();
+      expect(roomGameState.saveState).toHaveBeenCalledTimes(1);
     });
 
     it('adds one attribution when legacy and canonical arrays share a reference', async () => {
@@ -2716,6 +2716,7 @@ describe('Game Use Cases', () => {
         (evt) => evt.event === 'update-turn',
       );
       expect(updateTurn?.payload).toBe('player-2');
+      expect(roomGameState.saveState).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
+++ b/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
@@ -49,7 +49,7 @@ export async function transitionToPlayPhase({
   }
   winningPlayer.hand.sort((a, b) => cardService.compareCards(a, b));
 
-  await roomGameState.transitionPhase('play');
+  roomGameState.transitionPhase('play');
   const nextState = roomGameState.getState();
 
   nextState.blowState.currentTrump = highestDeclaration.trumpType;

--- a/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
+++ b/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
@@ -238,7 +238,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
         payload: updatedField,
       });
 
-      await gameState.nextTurn();
+      gameState.nextTurn();
       const nextPlayer = updatedState.players[updatedState.currentPlayerIndex];
       if (nextPlayer) {
         events.push({
@@ -334,15 +334,22 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
     // over and simply never transitioned. This is reachable because the
     // all-acted check lives inside declare-blow/pass-blow, and a COM
     // replacement changes the roster without either of them running.
-    if (countPlayersActedInBlow(state.players, state.blowState) >=
-      state.players.length) {
+    if (
+      countPlayersActedInBlow(state.players, state.blowState) >=
+      state.players.length
+    ) {
       this.logger.warn(
         `Blow phase in room ${roomId} had all players acted but never transitioned; completing it`,
       );
 
       const room = await this.roomService.getRoom(roomId);
       if (!room) {
-        return { success: false, events: [], shouldContinue: false, error: 'Room not found' };
+        return {
+          success: false,
+          events: [],
+          shouldContinue: false,
+          error: 'Room not found',
+        };
       }
 
       const transition = await transitionToPlayPhase({
@@ -370,7 +377,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
     const maxAttempts = state.players.length;
 
     for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-      await gameState.nextTurn();
+      gameState.nextTurn();
       const candidate = gameState.getCurrentPlayer();
       if (!candidate) break;
 

--- a/mei-tra-backend/src/use-cases/complete-field.use-case.ts
+++ b/mei-tra-backend/src/use-cases/complete-field.use-case.ts
@@ -235,7 +235,6 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
       );
 
       response.delayedEvents = roundResetEvents;
-      await roomGameState.saveState();
 
       return response;
     } catch (error) {
@@ -382,8 +381,8 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
     state: GameState,
     room: Room | null,
   ): Promise<GatewayEvent[]> {
-    await roomGameState.resetRoundState();
-    await roomGameState.updateState({
+    roomGameState.resetRoundState();
+    roomGameState.updateState({
       roundNumber: state.roundNumber + 1,
     });
 
@@ -423,8 +422,8 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
       currentBlowIndex: nextBlowIndex,
     };
 
-    await roomGameState.transitionPhase('blow');
-    await roomGameState.updateState({
+    roomGameState.transitionPhase('blow');
+    roomGameState.updateState({
       playState: newPlayState,
       blowState: newBlowState,
       currentSeatId: asSeatId(nextBlowPlayer.playerId),
@@ -487,6 +486,8 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
         delayMs: 3000,
       },
     ];
+
+    await roomGameState.saveState();
 
     await this.gameEventLogService?.log({
       roomId,

--- a/mei-tra-backend/src/use-cases/declare-blow.use-case.ts
+++ b/mei-tra-backend/src/use-cases/declare-blow.use-case.ts
@@ -176,7 +176,7 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
       }
 
       // Not all players have acted yet - continue to next player
-      await roomGameState.nextTurn();
+      roomGameState.nextTurn();
 
       // Skip players who have already acted (passed or declared)
       let attempts = 0;
@@ -191,7 +191,7 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
           break; // Found a player who hasn't acted yet
         }
 
-        await roomGameState.nextTurn();
+        roomGameState.nextTurn();
         attempts++;
       }
 

--- a/mei-tra-backend/src/use-cases/pass-blow.use-case.ts
+++ b/mei-tra-backend/src/use-cases/pass-blow.use-case.ts
@@ -175,7 +175,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
       }
 
       // 3. Not all players have acted yet → continue to next player
-      await roomGameState.nextTurn();
+      roomGameState.nextTurn();
 
       // Skip players who have already acted (passed or declared)
       let attempts = 0;
@@ -190,7 +190,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
           break; // Found a player who hasn't acted yet
         }
 
-        await roomGameState.nextTurn();
+        roomGameState.nextTurn();
         attempts++;
       }
 
@@ -231,7 +231,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
     state.blowState.currentBlowIndex =
       (state.blowState.currentBlowIndex + 1) % state.players.length;
 
-    await roomGameState.nextTurn();
+    roomGameState.nextTurn();
     const nextDealerIndex = state.currentPlayerIndex;
     const firstBlowIndex = (nextDealerIndex + 1) % state.players.length;
     const firstBlowPlayer = state.players[firstBlowIndex];
@@ -244,7 +244,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
     state.currentPlayerId = firstBlowPlayer.playerId;
     state.currentSeatId = asSeatId(firstBlowPlayer.playerId);
     state.deck = this.cardService.generateDeck();
-    await roomGameState.dealCards();
+    roomGameState.dealCards();
 
     await this.gameEventLogService?.log({
       roomId,

--- a/mei-tra-backend/src/use-cases/play-card.use-case.ts
+++ b/mei-tra-backend/src/use-cases/play-card.use-case.ts
@@ -157,7 +157,7 @@ export class PlayCardUseCase implements IPlayCardUseCase {
         return { success: true, events };
       }
 
-      await roomGameState.nextTurn();
+      roomGameState.nextTurn();
       const nextPlayer = state.players[state.currentPlayerIndex];
       if (nextPlayer) {
         cardPlayedPayload.nextSeatId = asSeatId(nextPlayer.playerId);

--- a/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
@@ -161,7 +161,7 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
         statePlayer.isPasser = false;
       });
       nextState.deck = this.cardService.generateDeck();
-      await roomGameState.dealCards();
+      roomGameState.dealCards();
 
       const events: GatewayEvent[] = [];
       if (firstBlowPlayer) {

--- a/mei-tra-backend/src/use-cases/select-base-suit.use-case.ts
+++ b/mei-tra-backend/src/use-cases/select-base-suit.use-case.ts
@@ -45,8 +45,6 @@ export class SelectBaseSuitUseCase implements ISelectBaseSuitUseCase {
 
       state.playState.currentField.baseSuit = suit;
 
-      await roomGameState.saveState();
-
       const events: GatewayEvent[] = [
         {
           scope: 'room',
@@ -56,7 +54,7 @@ export class SelectBaseSuitUseCase implements ISelectBaseSuitUseCase {
         },
       ];
 
-      await roomGameState.nextTurn();
+      roomGameState.nextTurn();
       const nextPlayer = state.players[state.currentPlayerIndex];
       if (nextPlayer) {
         events.push({

--- a/mei-tra-backend/src/use-cases/start-game.use-case.ts
+++ b/mei-tra-backend/src/use-cases/start-game.use-case.ts
@@ -103,7 +103,7 @@ export class StartGameUseCase implements IStartGameUseCase {
           errorMessage: 'Failed to mark room as playing',
         };
       }
-      await roomGameState.startGame();
+      roomGameState.startGame();
 
       let updatedState = roomGameState.getState();
       if (
@@ -112,7 +112,7 @@ export class StartGameUseCase implements IStartGameUseCase {
       ) {
         const currentPlayer =
           updatedState.players[updatedState.currentPlayerIndex] ?? null;
-        await roomGameState.updateState({
+        roomGameState.updateState({
           currentSeatId: currentPlayer
             ? asSeatId(currentPlayer.playerId)
             : null,
@@ -146,6 +146,8 @@ export class StartGameUseCase implements IStartGameUseCase {
         updatedState.players[updatedState.currentPlayerIndex];
       const firstBlowPlayer =
         updatedState.players[updatedState.blowState.currentBlowIndex];
+
+      await roomGameState.saveState();
 
       await this.gameEventLogService?.log({
         roomId,


### PR DESCRIPTION
## Summary

`nextTurn()`から隠れたDB書き込みを外し、カード・吹き・COM進行はUseCase終端の`saveState()`で一度だけ永続化します。JOKERのキリ選択も中間保存を削除しました。

## User-facing change

カード操作と手番更新を1回の状態保存で反映します。

## User benefit

対局中のDB往復と競合機会が減り、手番進行が安定します。

## Validation

- `npm test -- --runInBand src/services/__tests__/game-state-phase.spec.ts src/use-cases/__tests__/game.use-cases.spec.ts`
- `npm run build`
- 変更対象ファイルのESLint
- `git diff --check`