### PR TITLE
手番identityをseat UUIDへ統一

### DIFF
--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts
@@ -77,7 +77,7 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
               canonicalGameState.pendingBrokenHandReveal,
             ),
           },
-          current_seat_id: this.resolveCurrentPlayerId(canonicalGameState),
+          current_seat_id: canonicalGameState.currentSeatId,
           game_phase: canonicalGameState.gamePhase,
           round_number: canonicalGameState.roundNumber,
           points_to_win: canonicalGameState.pointsToWin,
@@ -243,14 +243,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
 
     if (gameState.currentSeatId !== undefined) {
       patch.currentSeatId = gameState.currentSeatId;
-    } else if (gameState.currentPlayerId !== undefined) {
-      patch.currentSeatId = gameState.currentPlayerId;
-    } else if (gameState.currentPlayerIndex !== undefined) {
-      const currentPlayerId =
-        gameState.players?.[gameState.currentPlayerIndex]?.playerId;
-      if (currentPlayerId !== undefined) {
-        patch.currentSeatId = currentPlayerId;
-      }
     }
     if (gameState.gamePhase !== undefined) {
       patch.gamePhase = gameState.gamePhase;
@@ -389,7 +381,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
         gameStateUpdates.currentSeatId = updates.current_seat_id
           ? asSeatId(updates.current_seat_id)
           : null;
-        gameStateUpdates.currentPlayerId = updates.current_seat_id;
       }
       if (updates.game_phase !== undefined) {
         gameStateUpdates.gamePhase = updates.game_phase;
@@ -487,12 +478,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
         `Current seat ${canonicalCurrentPlayerId} is outside room ${dbGameState.room_id}`,
       );
     }
-    const currentPlayerIndex =
-      canonicalCurrentPlayerId === null
-        ? 0
-        : players.findIndex(
-            (player) => player.playerId === canonicalCurrentPlayerId,
-          );
     const blowState = (stateData.blowState ?? {
       currentTrump: null,
       currentHighestDeclaration: null,
@@ -511,8 +496,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
       currentSeatId: canonicalCurrentPlayerId
         ? asSeatId(canonicalCurrentPlayerId)
         : null,
-      currentPlayerId: canonicalCurrentPlayerId,
-      currentPlayerIndex: currentPlayerIndex === -1 ? 0 : currentPlayerIndex,
       gamePhase: dbGameState.game_phase,
       deck: stateData.deck || [],
       teamScores: dbGameState.team_scores as Record<
@@ -532,17 +515,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
         players.map((player) => [player.playerId, player.team]),
       ),
     });
-  }
-
-  private resolveCurrentPlayerId(gameState: GameState): string | null {
-    if (gameState.currentSeatId !== undefined) {
-      return gameState.currentSeatId;
-    }
-    if (gameState.currentPlayerId !== undefined) {
-      return gameState.currentPlayerId;
-    }
-
-    return gameState.players[gameState.currentPlayerIndex]?.playerId ?? null;
   }
 
   private toRosterPlayerSnapshot(

--- a/mei-tra-backend/src/services/__tests__/game-state-phase.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/game-state-phase.spec.ts
@@ -3,6 +3,7 @@ import { CardService } from '../card.service';
 import { ChomboService } from '../chombo.service';
 import { PlayService } from '../play.service';
 import { IGameStateRepository } from '../../repositories/interfaces/game-state.repository.interface';
+import { asSeatId } from '../../types/identity.types';
 
 describe('GameStateService phase transitions', () => {
   let service: GameStateService;
@@ -131,13 +132,12 @@ describe('GameStateService phase transitions', () => {
         isPasser: false,
       },
     ];
-    state.currentPlayerId = 'player-1';
-    state.currentPlayerIndex = 0;
+    state.currentSeatId = asSeatId('player-1');
 
     service.nextTurn();
 
-    expect(state.currentPlayerId).toBe('player-2');
-    expect(state.currentPlayerIndex).toBe(1);
+    expect(state.currentSeatId).toBe('player-2');
+    expect(service.getCurrentPlayerIndex()).toBe(1);
     expect(repository.update).not.toHaveBeenCalled();
 
     await service.saveState();
@@ -226,10 +226,8 @@ describe('GameStateService phase transitions', () => {
     service.startGame();
 
     const startedState = service.getState();
-    expect(startedState.currentPlayerIndex).toBe(2);
-    expect(startedState.players[startedState.currentPlayerIndex].playerId).toBe(
-      'player-3',
-    );
+    expect(service.getCurrentPlayerIndex()).toBe(2);
+    expect(startedState.currentSeatId).toBe('player-3');
     expect(startedState.blowState.currentBlowIndex).toBe(2);
     expect(repository.update).not.toHaveBeenCalled();
   });

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -11,6 +11,7 @@ import { ChomboService } from '../chombo.service';
 import { PlayService } from '../play.service';
 import { IComPlayerService } from '../interfaces/com-player-service.interface';
 import { RoomMembershipService } from '../room-membership.service';
+import { asSeatId } from '../../types/identity.types';
 
 const makeGamePlayer = (
   playerId: string,
@@ -212,7 +213,7 @@ describe('Reconnection Token Management', () => {
               hasRequiredBroken: false,
             },
           ],
-          currentPlayerIndex: 0,
+          currentSeatId: asSeatId('player-1'),
           gamePhase: 'play',
           deck: [],
           blowState: {
@@ -249,14 +250,8 @@ describe('Reconnection Token Management', () => {
 
         expect(foundPlayer1?.playerId).toBe('player-1');
         expect(foundPlayer2?.playerId).toBe('player-2');
-        expect(gameStateRepository.update).toHaveBeenCalledWith(
-          roomId,
-          expect.objectContaining({
-            currentPlayerId: 'player-1',
-            currentPlayerIndex: 0,
-          }),
-          undefined,
-        );
+        expect(gameStateService.getState().currentSeatId).toBe('player-1');
+        expect(gameStateRepository.update).not.toHaveBeenCalled();
       });
 
       it('should handle empty players array', async () => {
@@ -2039,8 +2034,7 @@ describe('Reconnection Token Management', () => {
             hasRequiredBroken: false,
           },
         ];
-        gameState.getState().currentPlayerId = replacingComId;
-        gameState.getState().currentPlayerIndex = 0;
+        gameState.getState().currentSeatId = asSeatId(replacingComId);
         gameState.getState().blowState = {
           currentTrump: null,
           currentHighestDeclaration: {
@@ -2081,11 +2075,11 @@ describe('Reconnection Token Management', () => {
         expect(gameState.getState().blowState.declarations[0]?.playerId).toBe(
           replacingComId,
         );
-        expect(gameState.getState().currentPlayerId).toBe(nextPlayerId);
-        expect(gameState.getState().currentPlayerIndex).toBe(1);
+        expect(gameState.getState().currentSeatId).toBe(nextPlayerId);
+        expect(gameState.getCurrentPlayerIndex()).toBe(1);
         expect(gameStateRepository.update).toHaveBeenCalledWith(
           roomId,
-          expect.objectContaining({ currentPlayerId: nextPlayerId }),
+          expect.objectContaining({ currentSeatId: nextPlayerId }),
           expect.any(Number),
         );
       });
@@ -2166,8 +2160,7 @@ describe('Reconnection Token Management', () => {
             hasRequiredBroken: false,
           },
         ];
-        gameState.getState().currentPlayerId = replacingComId;
-        gameState.getState().currentPlayerIndex = 0;
+        gameState.getState().currentSeatId = asSeatId(replacingComId);
         gameState.getState().blowState = {
           currentTrump: null,
           currentHighestDeclaration: {
@@ -2250,11 +2243,11 @@ describe('Reconnection Token Management', () => {
         expect(gameState.getState().blowState.actionHistory[0]?.playerId).toBe(
           replacingComId,
         );
-        expect(gameState.getState().currentPlayerId).toBe(nextPlayerId);
-        expect(gameState.getState().currentPlayerIndex).toBe(1);
+        expect(gameState.getState().currentSeatId).toBe(nextPlayerId);
+        expect(gameState.getCurrentPlayerIndex()).toBe(1);
         expect(gameStateRepository.update).toHaveBeenCalledWith(
           roomId,
-          expect.objectContaining({ currentPlayerId: nextPlayerId }),
+          expect.objectContaining({ currentSeatId: nextPlayerId }),
           expect.any(Number),
         );
         expect(

--- a/mei-tra-backend/src/services/game-event-log.service.ts
+++ b/mei-tra-backend/src/services/game-event-log.service.ts
@@ -216,10 +216,8 @@ export class GameEventLogService implements IGameEventLogService {
     return {
       roundNumber: input.roundNumber,
       gamePhase: input.gamePhase,
-      currentTurnSeatId:
-        input.currentSeatId ??
-        (input.currentPlayerId ? asSeatId(input.currentPlayerId) : null),
-      currentTurnPlayerId: input.currentSeatId ?? input.currentPlayerId ?? null,
+      currentTurnSeatId: input.currentSeatId ?? null,
+      currentTurnPlayerId: input.currentSeatId ?? null,
       teamScores: input.teamScores,
     };
   }

--- a/mei-tra-backend/src/services/game-state-manager.service.ts
+++ b/mei-tra-backend/src/services/game-state-manager.service.ts
@@ -4,7 +4,6 @@ import { GameState, PlayerConnectionMetadata } from '../types/game.types';
 import { RoomPlayer } from '../types/room.types';
 import { RosterMembershipMutation } from '../types/room-membership.types';
 import { GamePhaseService } from './game-phase.service';
-import { asSeatId } from '../types/identity.types';
 import { normalizeGameStateIdentityAliases } from '../types/game-state-identity';
 
 export class GameStateManager {
@@ -25,21 +24,11 @@ export class GameStateManager {
       );
     }
 
-    let nextState: GameState = {
+    const nextState: GameState = {
       ...currentState,
       ...newState,
     };
-    if (
-      Object.prototype.hasOwnProperty.call(newState, 'currentPlayerId') &&
-      !Object.prototype.hasOwnProperty.call(newState, 'currentSeatId')
-    ) {
-      nextState.currentSeatId = newState.currentPlayerId
-        ? asSeatId(newState.currentPlayerId)
-        : null;
-    }
-    nextState = normalizeGameStateIdentityAliases(nextState);
-
-    return nextState;
+    return normalizeGameStateIdentityAliases(nextState);
   }
 
   async updateState(
@@ -51,13 +40,10 @@ export class GameStateManager {
 
     if (roomId) {
       const persistencePatch: Partial<GameState> = { ...newState };
-      if (
-        Object.prototype.hasOwnProperty.call(newState, 'currentSeatId') ||
-        Object.prototype.hasOwnProperty.call(newState, 'currentPlayerId') ||
-        Object.prototype.hasOwnProperty.call(newState, 'currentPlayerIndex')
-      ) {
+      delete persistencePatch.currentPlayerId;
+      delete persistencePatch.currentPlayerIndex;
+      if (Object.prototype.hasOwnProperty.call(newState, 'currentSeatId')) {
         persistencePatch.currentSeatId = nextState.currentSeatId;
-        persistencePatch.currentPlayerId = nextState.currentPlayerId;
       }
       if (newState.players) {
         persistencePatch.players = nextState.players;

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -28,6 +28,12 @@ import {
 import { RoomPlayer } from '../types/room.types';
 import { RosterMembershipMutation } from '../types/room-membership.types';
 import { asSeatId } from '../types/identity.types';
+import {
+  resolveCurrentPlayer,
+  resolveCurrentPlayerIndex,
+  resolveCurrentSeatId,
+  setCurrentSeat,
+} from '../types/current-turn';
 
 @Injectable()
 export class GameStateService implements IGameStateService {
@@ -70,8 +76,6 @@ export class GameStateService implements IGameStateService {
       players: [],
       deck: [],
       currentSeatId: null,
-      currentPlayerId: null,
-      currentPlayerIndex: 0,
       agari: undefined,
       teamScores: {
         0: { play: 0, total: 0 },
@@ -158,25 +162,7 @@ export class GameStateService implements IGameStateService {
       }
     }
 
-    const normalizedIndex = this.resolveCurrentPlayerIndex();
-
-    if (normalizedIndex !== this.state.currentPlayerIndex) {
-      this.state.currentPlayerIndex = normalizedIndex;
-      changed = true;
-    }
-
-    const normalizedPlayerId =
-      this.state.players[normalizedIndex]?.playerId ?? null;
-    if (this.state.currentPlayerId !== normalizedPlayerId) {
-      const hadStaleCurrentPlayerId = this.state.currentPlayerId != null;
-      this.state.currentPlayerId = normalizedPlayerId;
-      if (hadStaleCurrentPlayerId) {
-        changed = true;
-      }
-    }
-    const normalizedSeatId = normalizedPlayerId
-      ? asSeatId(normalizedPlayerId)
-      : null;
+    const normalizedSeatId = resolveCurrentSeatId(this.state);
     if (this.state.currentSeatId !== normalizedSeatId) {
       this.state.currentSeatId = normalizedSeatId;
       changed = true;
@@ -255,8 +241,7 @@ export class GameStateService implements IGameStateService {
       if (sanitized) {
         this.state = await this.stateManager.updateState(roomId, this.state, {
           players: this.state.players,
-          currentPlayerId: this.state.currentPlayerId,
-          currentPlayerIndex: this.state.currentPlayerIndex,
+          currentSeatId: this.state.currentSeatId,
         });
       }
 
@@ -548,18 +533,24 @@ export class GameStateService implements IGameStateService {
 
   nextTurn(): void {
     if (this.state.players.length === 0) return;
-    const currentIndex = this.resolveCurrentPlayerIndex();
+    const currentIndex = resolveCurrentPlayerIndex(this.state);
+    if (currentIndex === -1) {
+      throw new Error('Current seat is not initialized');
+    }
     const nextIndex = (currentIndex + 1) % this.state.players.length;
-    this.state.currentPlayerIndex = nextIndex;
-    this.state.currentPlayerId =
-      this.state.players[nextIndex]?.playerId ?? null;
-    this.state.currentSeatId = this.state.currentPlayerId
-      ? asSeatId(this.state.currentPlayerId)
-      : null;
+    setCurrentSeat(this.state, this.state.players[nextIndex]?.playerId ?? null);
   }
 
   getCurrentPlayer(): DomainPlayer | null {
-    return this.state.players[this.resolveCurrentPlayerIndex()] || null;
+    return resolveCurrentPlayer(this.state);
+  }
+
+  getCurrentPlayerIndex(): number {
+    return resolveCurrentPlayerIndex(this.state);
+  }
+
+  setCurrentSeat(seatId: string | null): DomainPlayer | null {
+    return setCurrentSeat(this.state, seatId);
   }
 
   isPlayerTurn(playerId: string): boolean {
@@ -640,40 +631,7 @@ export class GameStateService implements IGameStateService {
   }
 
   get currentTurn(): string | null {
-    return this.getCurrentPlayer()?.playerId ?? null;
-  }
-
-  set currentTurn(playerId: string) {
-    const playerIndex = this.state.players.findIndex(
-      (p) => p.playerId === playerId,
-    );
-    if (playerIndex !== -1) {
-      this.state.currentPlayerId = playerId;
-      this.state.currentSeatId = asSeatId(playerId);
-      this.state.currentPlayerIndex = playerIndex;
-    }
-  }
-
-  private resolveCurrentPlayerIndex(): number {
-    if (this.state.players.length === 0) {
-      return 0;
-    }
-
-    if (this.state.currentPlayerId) {
-      const index = this.state.players.findIndex(
-        (player) => player.playerId === this.state.currentPlayerId,
-      );
-      if (index !== -1) {
-        return index;
-      }
-    }
-
-    return Number.isInteger(this.state.currentPlayerIndex)
-      ? Math.min(
-          Math.max(this.state.currentPlayerIndex, 0),
-          this.state.players.length - 1,
-        )
-      : 0;
+    return resolveCurrentSeatId(this.state);
   }
 
   startGame(): void {
@@ -708,11 +666,7 @@ export class GameStateService implements IGameStateService {
 
     // Randomize the first blow player
     const firstBlowIndex = Math.floor(Math.random() * state.players.length);
-    state.currentPlayerId = state.players[firstBlowIndex]?.playerId ?? null;
-    state.currentSeatId = state.currentPlayerId
-      ? asSeatId(state.currentPlayerId)
-      : null;
-    state.currentPlayerIndex = firstBlowIndex;
+    this.setCurrentSeat(state.players[firstBlowIndex]?.playerId ?? null);
 
     // Initialize blow state
     state.blowState = {

--- a/mei-tra-backend/src/services/interfaces/game-event-log.service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/game-event-log.service.interface.ts
@@ -18,7 +18,6 @@ export interface LogGameEventInput {
     GameState,
     | 'players'
     | 'currentSeatId'
-    | 'currentPlayerId'
     | 'gamePhase'
     | 'roundNumber'
     | 'teamScores'

--- a/mei-tra-backend/src/services/room-join.service.ts
+++ b/mei-tra-backend/src/services/room-join.service.ts
@@ -8,6 +8,10 @@ import { SessionUser } from '../types/session.types';
 import { randomUUID } from 'crypto';
 import { asSeatId, resolveSeatId } from '../types/identity.types';
 import { RosterMembershipMutation } from '../types/room-membership.types';
+import {
+  resolveCurrentPlayerIndex,
+  setCurrentSeat,
+} from '../types/current-turn';
 
 interface JoinRoomParams {
   roomId: string;
@@ -417,7 +421,7 @@ export class RoomJoinService {
       return false;
     }
 
-    const currentIndex = this.resolveCurrentPlayerIndex(state);
+    const currentIndex = resolveCurrentPlayerIndex(state);
     const currentPlayer = state.players[currentIndex];
     if (
       !currentPlayer ||
@@ -430,30 +434,12 @@ export class RoomJoinService {
       const candidateIndex = (currentIndex + offset) % state.players.length;
       const candidatePlayer = state.players[candidateIndex];
       if (!this.hasActedInBlow(state.blowState, candidatePlayer)) {
-        state.currentPlayerIndex = candidateIndex;
-        state.currentPlayerId = candidatePlayer.playerId;
-        state.currentSeatId = asSeatId(candidatePlayer.playerId);
+        setCurrentSeat(state, candidatePlayer.playerId);
         return true;
       }
     }
 
     return false;
-  }
-
-  private resolveCurrentPlayerIndex(state: GameState): number {
-    if (state.currentPlayerId) {
-      const index = state.players.findIndex(
-        (player) => player.playerId === state.currentPlayerId,
-      );
-      if (index !== -1) {
-        return index;
-      }
-    }
-
-    return Math.min(
-      Math.max(state.currentPlayerIndex ?? 0, 0),
-      state.players.length - 1,
-    );
   }
 
   private hasActedInBlow(blowState: BlowState, player: DomainPlayer): boolean {

--- a/mei-tra-backend/src/services/seat-restoration.service.ts
+++ b/mei-tra-backend/src/services/seat-restoration.service.ts
@@ -4,7 +4,11 @@ import { toDomainPlayer } from '../types/player-adapters';
 import { Room, RoomPlayer } from '../types/room.types';
 import { GameStateService } from './game-state.service';
 import { VacantSeats } from './com-session.service';
-import { asSeatId, resolveSeatId } from '../types/identity.types';
+import { resolveSeatId } from '../types/identity.types';
+import {
+  resolveCurrentPlayerIndex,
+  setCurrentSeat,
+} from '../types/current-turn';
 
 @Injectable()
 export class SeatRestorationService {
@@ -131,7 +135,7 @@ export class SeatRestorationService {
       return false;
     }
 
-    const currentIndex = this.resolveCurrentPlayerIndex(state);
+    const currentIndex = resolveCurrentPlayerIndex(state);
     const currentPlayer = state.players[currentIndex];
     if (
       !currentPlayer ||
@@ -144,30 +148,12 @@ export class SeatRestorationService {
       const candidateIndex = (currentIndex + offset) % state.players.length;
       const candidatePlayer = state.players[candidateIndex];
       if (!this.hasActedInBlow(state.blowState, candidatePlayer)) {
-        state.currentPlayerIndex = candidateIndex;
-        state.currentPlayerId = candidatePlayer.playerId;
-        state.currentSeatId = asSeatId(candidatePlayer.playerId);
+        setCurrentSeat(state, candidatePlayer.playerId);
         return true;
       }
     }
 
     return false;
-  }
-
-  private resolveCurrentPlayerIndex(state: GameState): number {
-    if (state.currentPlayerId) {
-      const index = state.players.findIndex(
-        (player) => player.playerId === state.currentPlayerId,
-      );
-      if (index !== -1) {
-        return index;
-      }
-    }
-
-    return Math.min(
-      Math.max(state.currentPlayerIndex ?? 0, 0),
-      state.players.length - 1,
-    );
   }
 
   private hasActedInBlow(blowState: BlowState, player: DomainPlayer): boolean {

--- a/mei-tra-backend/src/services/turn-monitor.service.ts
+++ b/mei-tra-backend/src/services/turn-monitor.service.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { Server } from 'socket.io';
 import { IRoomService } from './interfaces/room-service.interface';
 import { RoomStatus } from '../types/room.types';
+import { resolveCurrentPlayer } from '../types/current-turn';
 
 const TURN_ACK_PING_INTERVAL_MS = 15 * 1000;
 const TURN_IDLE_WARNING_MS = 45 * 1000;
@@ -196,7 +197,7 @@ export class TurnMonitorService implements OnModuleDestroy {
 
     const roomGameState = await this.roomService.getRoomGameState(roomId);
     const state = roomGameState.getState();
-    const currentPlayer = state.players[state.currentPlayerIndex];
+    const currentPlayer = resolveCurrentPlayer(state);
 
     return (
       (state.gamePhase === 'play' || state.gamePhase === 'blow') &&

--- a/mei-tra-backend/src/types/current-turn.spec.ts
+++ b/mei-tra-backend/src/types/current-turn.spec.ts
@@ -1,0 +1,72 @@
+import {
+  resolveCurrentPlayer,
+  resolveCurrentPlayerIndex,
+  resolveCurrentSeatId,
+  setCurrentSeat,
+} from './current-turn';
+import { asSeatId } from './identity.types';
+import type { DomainPlayer, GameState } from './game.types';
+
+const players: DomainPlayer[] = [
+  {
+    seatId: asSeatId('seat-1'),
+    playerId: 'seat-1',
+    name: 'Player 1',
+    team: 0,
+    hand: [],
+    isPasser: false,
+  },
+  {
+    seatId: asSeatId('seat-2'),
+    playerId: 'seat-2',
+    name: 'Player 2',
+    team: 1,
+    hand: [],
+    isPasser: false,
+  },
+];
+
+const turnState = (
+  overrides: Partial<GameState> = {},
+): Pick<GameState, 'players' | 'currentSeatId'> => ({
+  players: players.map((player) => ({ ...player })),
+  currentSeatId: asSeatId('seat-1'),
+  ...overrides,
+});
+
+describe('current turn identity', () => {
+  it('resolves the canonical seat and its roster position', () => {
+    const state = turnState({ currentSeatId: asSeatId('seat-1') });
+
+    expect(resolveCurrentSeatId(state)).toBe('seat-1');
+    expect(resolveCurrentPlayerIndex(state)).toBe(0);
+    expect(resolveCurrentPlayer(state)?.playerId).toBe('seat-1');
+  });
+
+  it('updates only the canonical seat assignment', () => {
+    const state = turnState();
+
+    const currentPlayer = setCurrentSeat(state, 'seat-2');
+
+    expect(currentPlayer?.playerId).toBe('seat-2');
+    expect(state.currentSeatId).toBe('seat-2');
+  });
+
+  it('does not infer a turn when the canonical seat is missing', () => {
+    const state = {
+      ...turnState({ currentSeatId: null }),
+      currentPlayerId: 'seat-2',
+      currentPlayerIndex: 1,
+    };
+
+    expect(resolveCurrentSeatId(state)).toBeNull();
+    expect(resolveCurrentPlayerIndex(state)).toBe(-1);
+    expect(resolveCurrentPlayer(state)).toBeNull();
+  });
+
+  it('rejects a seat outside the roster', () => {
+    expect(() => setCurrentSeat(turnState(), 'seat-unknown')).toThrow(
+      'Current seat seat-unknown is not in the game roster',
+    );
+  });
+});

--- a/mei-tra-backend/src/types/current-turn.ts
+++ b/mei-tra-backend/src/types/current-turn.ts
@@ -1,0 +1,68 @@
+import { asSeatId, SeatId } from './identity.types';
+import type { DomainPlayer, GameState } from './game.types';
+
+type CurrentTurnState = Pick<GameState, 'players' | 'currentSeatId'>;
+
+function playerSeatId(player: DomainPlayer): SeatId {
+  return player.seatId ?? asSeatId(player.playerId);
+}
+
+export function resolveCurrentSeatId(
+  state: CurrentTurnState,
+): SeatId | null {
+  if (
+    state.currentSeatId &&
+    state.players.some(
+      (player) => playerSeatId(player) === state.currentSeatId,
+    )
+  ) {
+    return state.currentSeatId;
+  }
+
+  return null;
+}
+
+export function resolveCurrentPlayerIndex(state: CurrentTurnState): number {
+  const currentSeatId = resolveCurrentSeatId(state);
+  if (currentSeatId) {
+    const currentIndex = state.players.findIndex(
+      (player) => playerSeatId(player) === currentSeatId,
+    );
+    if (currentIndex !== -1) {
+      return currentIndex;
+    }
+  }
+
+  return -1;
+}
+
+export function resolveCurrentPlayer(
+  state: CurrentTurnState,
+): DomainPlayer | null {
+  const currentPlayerIndex = resolveCurrentPlayerIndex(state);
+  return currentPlayerIndex === -1
+    ? null
+    : (state.players[currentPlayerIndex] ?? null);
+}
+
+export function setCurrentSeat(
+  state: CurrentTurnState,
+  seatId: string | null,
+): DomainPlayer | null {
+  if (seatId === null) {
+    state.currentSeatId = null;
+    return null;
+  }
+
+  const canonicalSeatId = asSeatId(seatId);
+  const currentPlayerIndex = state.players.findIndex(
+    (player) => playerSeatId(player) === canonicalSeatId,
+  );
+  if (currentPlayerIndex === -1) {
+    throw new Error(`Current seat ${seatId} is not in the game roster`);
+  }
+
+  const currentPlayer = state.players[currentPlayerIndex];
+  state.currentSeatId = canonicalSeatId;
+  return currentPlayer;
+}

--- a/mei-tra-backend/src/types/game-state-identity.spec.ts
+++ b/mei-tra-backend/src/types/game-state-identity.spec.ts
@@ -68,7 +68,8 @@ describe('normalizeGameStateIdentityAliases', () => {
       expect.objectContaining({ seatId: 'seat-1', playerId: 'seat-1' }),
     );
     expect(normalized.currentSeatId).toBe('seat-1');
-    expect(normalized.currentPlayerId).toBe('seat-1');
+    expect(normalized.currentPlayerId).toBeUndefined();
+    expect(normalized.currentPlayerIndex).toBeUndefined();
     expect(normalized.blowState.lastPasserSeatId).toBe('seat-1');
     expect(normalized.blowState.lastPasser).toBe('seat-1');
     expect(normalized.playState?.currentField?.playedBy).toEqual(['seat-1']);

--- a/mei-tra-backend/src/types/game-state-identity.ts
+++ b/mei-tra-backend/src/types/game-state-identity.ts
@@ -19,12 +19,9 @@ function normalizePlayedBySeatIds(field: Field) {
 }
 
 export function normalizeGameStateIdentityAliases(state: GameState): GameState {
-  const currentSeatValue =
-    state.currentSeatId ??
-    state.currentPlayerId ??
-    state.players[state.currentPlayerIndex]?.playerId ??
-    null;
-  const currentSeatId = currentSeatValue ? asSeatId(currentSeatValue) : null;
+  const currentSeatId = state.currentSeatId
+    ? asSeatId(state.currentSeatId)
+    : null;
   const players = state.players.map((player) => {
     const seatId = player.seatId ?? asSeatId(player.playerId);
     return { ...player, seatId, playerId: seatId };
@@ -129,12 +126,11 @@ export function normalizeGameStateIdentityAliases(state: GameState): GameState {
       })()
     : state.pendingBrokenHandReveal;
 
-  return {
+  const normalizedState: GameState = {
     ...state,
     identitySchemaVersion: 2,
     players,
     currentSeatId,
-    currentPlayerId: currentSeatId,
     blowState,
     playState,
     pendingBrokenHandReveal,
@@ -142,4 +138,8 @@ export function normalizeGameStateIdentityAliases(state: GameState): GameState {
       players.map((player) => [player.playerId, player.team]),
     ),
   };
+
+  delete normalizedState.currentPlayerId;
+  delete normalizedState.currentPlayerIndex;
+  return normalizedState;
 }

--- a/mei-tra-backend/src/types/game.types.ts
+++ b/mei-tra-backend/src/types/game.types.ts
@@ -160,7 +160,8 @@ export interface GameState {
   currentSeatId?: SeatId | null;
   /** @deprecated Use currentSeatId. */
   currentPlayerId?: string | null;
-  currentPlayerIndex: number;
+  /** @deprecated Derive the index from currentSeatId and players. */
+  currentPlayerIndex?: number;
   gamePhase: GamePhase;
   deck: string[];
   teamScores: Record<Team, { play: number; total: number }>;

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -733,7 +733,7 @@ describe('Game Use Cases', () => {
 
       const state: {
         players: DomainPlayer[];
-        currentPlayerIndex: number;
+        currentSeatId: ReturnType<typeof asSeatId>;
         blowState: {
           currentBlowIndex: number;
           currentTrump: string | null;
@@ -762,7 +762,7 @@ describe('Game Use Cases', () => {
             isPasser: false,
           },
         ],
-        currentPlayerIndex: 0,
+        currentSeatId: asSeatId('player-1'),
         blowState: {
           currentBlowIndex: 0,
           currentTrump: null,
@@ -781,8 +781,11 @@ describe('Game Use Cases', () => {
 
       const roomGameState = {
         getState: jest.fn(() => state),
-        startGame: jest.fn().mockResolvedValue(undefined),
+        startGame: jest.fn(() => {
+          state.currentSeatId = asSeatId('player-1');
+        }),
         persistRoster: jest.fn().mockResolvedValue(undefined),
+        saveState: jest.fn().mockResolvedValue(undefined),
       } as unknown as GameStateService;
 
       roomService.getRoom.mockResolvedValue(room);
@@ -834,7 +837,7 @@ describe('Game Use Cases', () => {
             isPasser: false,
           },
         ] as DomainPlayer[],
-        currentPlayerIndex: 1,
+        currentSeatId: asSeatId('player-2'),
         blowState: {
           currentBlowIndex: 0,
           currentTrump: null,
@@ -852,10 +855,13 @@ describe('Game Use Cases', () => {
       };
       const roomGameState = {
         getState: jest.fn(() => state),
-        startGame: jest.fn().mockResolvedValue(undefined),
+        startGame: jest.fn(() => {
+          state.currentSeatId = asSeatId('player-2');
+        }),
         persistRoster: jest.fn().mockResolvedValue(undefined),
+        saveState: jest.fn().mockResolvedValue(undefined),
         updateState: jest.fn(async (updates) => {
-          state.currentPlayerIndex = updates.currentPlayerIndex;
+          state.currentSeatId = updates.currentSeatId ?? state.currentSeatId;
           state.blowState = updates.blowState;
         }),
       } as unknown as GameStateService;
@@ -875,8 +881,6 @@ describe('Game Use Cases', () => {
       expect(state.blowState.currentBlowIndex).toBe(1);
       expect(roomGameState.updateState).toHaveBeenCalledWith({
         currentSeatId: 'player-2',
-        currentPlayerId: 'player-2',
-        currentPlayerIndex: 1,
         blowState: expect.objectContaining({ currentBlowIndex: 1 }),
       });
     });
@@ -964,7 +968,7 @@ describe('Game Use Cases', () => {
             isPasser: false,
           },
         ] as DomainPlayer[],
-        currentPlayerIndex: 0,
+        currentSeatId: asSeatId('player-1'),
         blowState: {
           currentBlowIndex: 0,
           currentTrump: null,
@@ -991,12 +995,14 @@ describe('Game Use Cases', () => {
           state.players[2],
           state.players[3],
         ];
+        state.currentSeatId = asSeatId('player-1');
       });
       const roomGameState = {
         getState: jest.fn(() => state),
         registerPlayerToken: registerPlayerTokenMock,
         startGame: startGameMock,
         persistRoster: persistRosterMock,
+        saveState: jest.fn().mockResolvedValue(undefined),
       } as unknown as GameStateService;
 
       roomService.getRoom.mockResolvedValue(room);
@@ -1652,7 +1658,7 @@ describe('Game Use Cases', () => {
       const state: {
         players: DomainPlayer[];
         playState: { currentField: Field };
-        currentPlayerIndex: number;
+        currentSeatId: ReturnType<typeof asSeatId>;
       } = {
         players: [
           {
@@ -1673,15 +1679,14 @@ describe('Game Use Cases', () => {
         playState: {
           currentField,
         },
-        currentPlayerIndex: 0,
+        currentSeatId: asSeatId('player-1'),
       };
 
       const roomGameState = {
         getState: jest.fn(() => state),
         saveState: jest.fn(),
         nextTurn: jest.fn(() => {
-          state.currentPlayerIndex =
-            (state.currentPlayerIndex + 1) % state.players.length;
+          state.currentSeatId = asSeatId('player-2');
         }),
         findPlayerByActorId: jest.fn((actorId: string) =>
           actorId === 'user-1'
@@ -1696,7 +1701,7 @@ describe('Game Use Cases', () => {
         ),
         isPlayerTurn: jest.fn(
           (playerId: string) =>
-            state.players[state.currentPlayerIndex]?.playerId === playerId,
+            state.currentSeatId === asSeatId(playerId),
         ),
       } as unknown as GameStateService;
 
@@ -1798,7 +1803,7 @@ describe('Game Use Cases', () => {
       const state: {
         players: DomainPlayer[];
         playState: { currentField: Field };
-        currentPlayerIndex: number;
+        currentSeatId: ReturnType<typeof asSeatId>;
       } = {
         players: [
           {
@@ -1812,7 +1817,7 @@ describe('Game Use Cases', () => {
         playState: {
           currentField: fieldBefore,
         },
-        currentPlayerIndex: 0,
+        currentSeatId: asSeatId('player-1'),
       };
 
       const roomGameState = {
@@ -1828,7 +1833,7 @@ describe('Game Use Cases', () => {
         ),
         isPlayerTurn: jest.fn(
           (playerId: string) =>
-            state.players[state.currentPlayerIndex]?.playerId === playerId,
+            state.currentSeatId === asSeatId(playerId),
         ),
       } as unknown as GameStateService;
 
@@ -1880,13 +1885,13 @@ describe('Game Use Cases', () => {
             isComplete: false,
           } as Field,
         },
-        currentPlayerIndex: 0,
+        currentSeatId: asSeatId('player-1'),
       };
       const roomGameState = {
         getState: jest.fn(() => state),
         saveState: jest.fn(),
         nextTurn: jest.fn(() => {
-          state.currentPlayerIndex = 1;
+          state.currentSeatId = asSeatId('player-2');
         }),
         findPlayerByActorId: jest.fn(() => state.players[0]),
         isPlayerTurn: jest.fn(() => true),
@@ -2648,7 +2653,7 @@ describe('Game Use Cases', () => {
       const state: {
         players: DomainPlayer[];
         playState: { currentField: Field };
-        currentPlayerIndex: number;
+        currentSeatId: ReturnType<typeof asSeatId>;
       } = {
         players: [
           {
@@ -2677,14 +2682,14 @@ describe('Game Use Cases', () => {
             isComplete: false,
           },
         },
-        currentPlayerIndex: 0,
+        currentSeatId: asSeatId('player-1'),
       };
 
       const roomGameState = {
         getState: jest.fn(() => state),
         saveState: jest.fn(),
         nextTurn: jest.fn(() => {
-          state.currentPlayerIndex = 1;
+          state.currentSeatId = asSeatId('player-2');
         }),
         findPlayerByActorId: jest.fn((actorId: string) =>
           actorId === 'user-1'
@@ -2736,10 +2741,11 @@ describe('Game Use Cases', () => {
       const state: {
         players: DomainPlayer[];
         blowState: BlowState;
-        currentPlayerIndex: number;
+        currentSeatId: ReturnType<typeof asSeatId>;
         gamePhase: 'play' | 'blow';
         deck: string[];
         pendingBrokenHandReveal?: {
+          seatId?: ReturnType<typeof asSeatId>;
           playerId: string;
           handSnapshot: string[];
           startedAt: number;
@@ -2772,7 +2778,7 @@ describe('Game Use Cases', () => {
           isRoundCancelled: false,
           currentBlowIndex: 0,
         },
-        currentPlayerIndex: 0,
+        currentSeatId: asSeatId('player-1'),
         gamePhase: 'blow' as const,
         deck: [],
       };
@@ -2988,10 +2994,11 @@ describe('Game Use Cases', () => {
       const state: {
         players: DomainPlayer[];
         blowState: BlowState;
-        currentPlayerIndex: number;
+        currentSeatId: ReturnType<typeof asSeatId>;
         gamePhase: 'play' | 'blow';
         deck: string[];
         pendingBrokenHandReveal?: {
+          seatId?: ReturnType<typeof asSeatId>;
           playerId: string;
           handSnapshot: string[];
           startedAt: number;
@@ -3064,7 +3071,7 @@ describe('Game Use Cases', () => {
           isRoundCancelled: false,
           currentBlowIndex: 2,
         },
-        currentPlayerIndex: 1,
+        currentSeatId: asSeatId('player-2'),
         gamePhase: 'blow',
         deck: [],
         pendingBrokenHandReveal: {
@@ -3100,7 +3107,7 @@ describe('Game Use Cases', () => {
       expect(completion.success).toBe(true);
       expect(state.pendingBrokenHandReveal).toBeNull();
       expect(state.blowState.currentBlowIndex).toBe(2);
-      expect(state.currentPlayerIndex).toBe(2);
+      expect(state.currentSeatId).toBe(asSeatId('player-3'));
       expect(state.blowState.declarations).toEqual([]);
       expect(state.blowState.actionHistory).toEqual([]);
       expect(state.blowState.currentHighestDeclaration).toBeNull();

--- a/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
+++ b/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
@@ -8,6 +8,7 @@ import { IGameEventLogService } from '../services/interfaces/game-event-log.serv
 import { buildPlayerSyncEvents } from './helpers/player-resolution.helper';
 import { GatewayEvent } from './interfaces/gateway-event.interface';
 import { asSeatId } from '../types/identity.types';
+import { setCurrentSeat } from '../types/current-turn';
 
 export interface TransitionResult {
   events: GatewayEvent[];
@@ -53,14 +54,7 @@ export async function transitionToPlayPhase({
   const nextState = roomGameState.getState();
 
   nextState.blowState.currentTrump = highestDeclaration.trumpType;
-  const winnerIndex = nextState.players.findIndex(
-    (p) => p.playerId === winningPlayer.playerId,
-  );
-  if (winnerIndex !== -1) {
-    nextState.currentPlayerId = winningPlayer.playerId;
-    nextState.currentSeatId = asSeatId(winningPlayer.playerId);
-    nextState.currentPlayerIndex = winnerIndex;
-  }
+  setCurrentSeat(nextState, winningPlayer.playerId);
 
   const events: GatewayEvent[] = buildPlayerSyncEvents(
     roomGameState,

--- a/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
+++ b/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
@@ -26,6 +26,7 @@ import {
 import { IRevealBrokenHandUseCase } from './interfaces/reveal-broken-hand.use-case.interface';
 import { transitionToPlayPhase } from './blow-phase-transition.helper';
 import { countPlayersActedInBlow } from './helpers/blow-action.helper';
+import { resolveCurrentSeatId } from '../types/current-turn';
 import { IBlowService } from '../services/interfaces/blow-service.interface';
 import { ICardService } from '../services/interfaces/card-service.interface';
 import { IGameEventLogService } from '../services/interfaces/game-event-log.service.interface';
@@ -90,7 +91,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
     if (!currentPlayer) {
       this.logger.warn(
         `Turn unplayable in room ${roomId}: no current player resolved ` +
-          `(currentPlayerId=${state.currentPlayerId ?? 'null'}, ` +
+          `(currentSeatId=${resolveCurrentSeatId(state) ?? 'null'}, ` +
           `roster=[${state.players.map((player) => player.playerId).join(', ')}])`,
       );
       return;
@@ -106,7 +107,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
     this.logger.warn(
       `Turn unplayable in room ${roomId}: auto-play skipped non-COM player ` +
         `${currentPlayer.playerId} which has no live socket ` +
-        `(phase=${state.gamePhase}, currentPlayerId=${state.currentPlayerId ?? 'null'}, ` +
+        `(phase=${state.gamePhase}, currentSeatId=${resolveCurrentSeatId(state) ?? 'null'}, ` +
         `isCOM=${String(currentPlayer.isCOM)})`,
     );
   }
@@ -239,7 +240,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       });
 
       gameState.nextTurn();
-      const nextPlayer = updatedState.players[updatedState.currentPlayerIndex];
+      const nextPlayer = gameState.getCurrentPlayer();
       if (nextPlayer) {
         events.push({
           scope: 'room',
@@ -252,7 +253,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       await gameState.saveState();
     }
 
-    const nextPlayer = updatedState.players[updatedState.currentPlayerIndex];
+    const nextPlayer = gameState.getCurrentPlayer();
     // Continue from the persisted turn owner instead of trusting only emitted
     // events; this keeps autoplay alive even when a use-case emits no turn event.
     const shouldContinue =

--- a/mei-tra-backend/src/use-cases/complete-field.use-case.ts
+++ b/mei-tra-backend/src/use-cases/complete-field.use-case.ts
@@ -25,6 +25,7 @@ import {
   resolveTransportPlayers,
 } from './helpers/player-resolution.helper';
 import { asSeatId } from '../types/identity.types';
+import { setCurrentSeat } from '../types/current-turn';
 
 @Injectable()
 export class CompleteFieldUseCase implements ICompleteFieldUseCase {
@@ -90,7 +91,7 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
         (player) => player.hand.length === 0,
       );
 
-      this.setNextDealer(state, winner.playerId);
+      setCurrentSeat(state, winner.playerId);
 
       if (state.playState) {
         state.playState.currentField = {
@@ -297,17 +298,6 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
     );
   }
 
-  private setNextDealer(state: GameState, playerId: string) {
-    const winnerIndex = state.players.findIndex(
-      (player) => player.playerId === playerId,
-    );
-    if (winnerIndex !== -1) {
-      state.currentPlayerId = playerId;
-      state.currentSeatId = asSeatId(playerId);
-      state.currentPlayerIndex = winnerIndex;
-    }
-  }
-
   private findDeclaringTeam(state: GameState): Team | null {
     const highestDeclaration = state.blowState.currentHighestDeclaration;
     if (!highestDeclaration) {
@@ -427,8 +417,6 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
       playState: newPlayState,
       blowState: newBlowState,
       currentSeatId: asSeatId(nextBlowPlayer.playerId),
-      currentPlayerId: nextBlowPlayer.playerId,
-      currentPlayerIndex: nextBlowIndex,
     });
 
     const newRoundPayload: NewRoundStartedPayload = {

--- a/mei-tra-backend/src/use-cases/declare-blow.use-case.ts
+++ b/mei-tra-backend/src/use-cases/declare-blow.use-case.ts
@@ -27,6 +27,7 @@ import {
   hasPlayerPassedInBlow,
 } from './helpers/blow-action.helper';
 import { asSeatId } from '../types/identity.types';
+import { resolveCurrentPlayer } from '../types/current-turn';
 
 @Injectable()
 export class DeclareBlowUseCase implements IDeclareBlowUseCase {
@@ -182,7 +183,10 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
       let attempts = 0;
       const maxAttempts = state.players.length;
       while (attempts < maxAttempts) {
-        const currentPlayer = state.players[state.currentPlayerIndex];
+        const currentPlayer = resolveCurrentPlayer(state);
+        if (!currentPlayer) {
+          break;
+        }
         const hasActed =
           hasPlayerDeclaredInBlow(state.blowState, currentPlayer.playerId) ||
           hasPlayerPassedInBlow(state.blowState, currentPlayer);
@@ -198,7 +202,7 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
       // Save the final turn state after skipping
       await roomGameState.saveState();
 
-      const nextPlayer = state.players[state.currentPlayerIndex];
+      const nextPlayer = resolveCurrentPlayer(state);
       if (nextPlayer) {
         events.push({
           scope: 'room',

--- a/mei-tra-backend/src/use-cases/join-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/join-room.use-case.ts
@@ -11,6 +11,7 @@ import {
 import { RoomStatus } from '../types/room.types';
 import { SessionUser } from '../types/session.types';
 import { ActiveRoomMembershipConflictError } from '../types/room-membership.types';
+import { resolveCurrentSeatId } from '../types/current-turn';
 
 @Injectable()
 export class JoinRoomUseCase implements IJoinRoomUseCase {
@@ -191,14 +192,7 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
     // COMが残っていても、ゲーム中フェーズ（blow/play）でも game-state を送る
     // （プレイ中ルームへの途中参加・COM引き継ぎに対応）
 
-    const currentTurn =
-      state.currentPlayerId &&
-      state.players.some((player) => player.playerId === state.currentPlayerId)
-        ? state.currentPlayerId
-        : state.currentPlayerIndex !== -1 &&
-            state.players[state.currentPlayerIndex]
-          ? state.players[state.currentPlayerIndex].playerId
-          : null;
+    const currentTurn = resolveCurrentSeatId(state);
 
     return {
       message: 'Joined active game.',

--- a/mei-tra-backend/src/use-cases/pass-blow.use-case.ts
+++ b/mei-tra-backend/src/use-cases/pass-blow.use-case.ts
@@ -31,6 +31,11 @@ import {
   hasPlayerPassedInBlow,
 } from './helpers/blow-action.helper';
 import { asSeatId } from '../types/identity.types';
+import {
+  resolveCurrentPlayer,
+  resolveCurrentPlayerIndex,
+  setCurrentSeat,
+} from '../types/current-turn';
 
 @Injectable()
 export class PassBlowUseCase implements IPassBlowUseCase {
@@ -181,7 +186,10 @@ export class PassBlowUseCase implements IPassBlowUseCase {
       let attempts = 0;
       const maxAttempts = state.players.length;
       while (attempts < maxAttempts) {
-        const currentPlayer = state.players[state.currentPlayerIndex];
+        const currentPlayer = resolveCurrentPlayer(state);
+        if (!currentPlayer) {
+          break;
+        }
         const hasActed =
           hasPlayerDeclaredInBlow(state.blowState, currentPlayer.playerId) ||
           hasPlayerPassedInBlow(state.blowState, currentPlayer);
@@ -197,7 +205,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
       // Save the final turn state after skipping
       await roomGameState.saveState();
 
-      const nextPlayer = state.players[state.currentPlayerIndex];
+      const nextPlayer = resolveCurrentPlayer(state);
       if (nextPlayer) {
         events.push({
           scope: 'room',
@@ -232,7 +240,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
       (state.blowState.currentBlowIndex + 1) % state.players.length;
 
     roomGameState.nextTurn();
-    const nextDealerIndex = state.currentPlayerIndex;
+    const nextDealerIndex = resolveCurrentPlayerIndex(state);
     const firstBlowIndex = (nextDealerIndex + 1) % state.players.length;
     const firstBlowPlayer = state.players[firstBlowIndex];
 
@@ -240,9 +248,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
       return { events: [] };
     }
 
-    state.currentPlayerIndex = firstBlowIndex;
-    state.currentPlayerId = firstBlowPlayer.playerId;
-    state.currentSeatId = asSeatId(firstBlowPlayer.playerId);
+    setCurrentSeat(state, firstBlowPlayer.playerId);
     state.deck = this.cardService.generateDeck();
     roomGameState.dealCards();
 

--- a/mei-tra-backend/src/use-cases/play-card.use-case.ts
+++ b/mei-tra-backend/src/use-cases/play-card.use-case.ts
@@ -15,6 +15,7 @@ import {
 } from './helpers/player-resolution.helper';
 import { IPlayService } from '../services/interfaces/play-service.interface';
 import { asSeatId } from '../types/identity.types';
+import { resolveCurrentPlayer } from '../types/current-turn';
 
 @Injectable()
 export class PlayCardUseCase implements IPlayCardUseCase {
@@ -158,7 +159,7 @@ export class PlayCardUseCase implements IPlayCardUseCase {
       }
 
       roomGameState.nextTurn();
-      const nextPlayer = state.players[state.currentPlayerIndex];
+      const nextPlayer = resolveCurrentPlayer(state);
       if (nextPlayer) {
         cardPlayedPayload.nextSeatId = asSeatId(nextPlayer.playerId);
         cardPlayedPayload.nextPlayerId = nextPlayer.playerId;

--- a/mei-tra-backend/src/use-cases/reconnection.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reconnection.use-case.ts
@@ -15,6 +15,7 @@ import {
 import { DomainPlayer, Team } from '../types/game.types';
 import { RoomMembershipService } from '../services/room-membership.service';
 import { asSeatId, type SeatId } from '../types/identity.types';
+import { resolveCurrentSeatId } from '../types/current-turn';
 
 export type ReconnectionResult =
   | {
@@ -385,14 +386,7 @@ export class ReconnectionUseCase {
     player: DomainPlayer,
   ): ActiveGameSnapshot {
     const state = roomGameState.getState();
-    const currentTurnPlayerId =
-      state.currentPlayerId &&
-      state.players.some((player) => player.playerId === state.currentPlayerId)
-        ? state.currentPlayerId
-        : state.currentPlayerIndex !== -1 &&
-            state.players[state.currentPlayerIndex]
-          ? state.players[state.currentPlayerIndex].playerId
-          : null;
+    const currentTurnPlayerId = resolveCurrentSeatId(state);
 
     return {
       selfSeatId: asSeatId(player.playerId),

--- a/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
@@ -16,6 +16,7 @@ import {
 } from './helpers/player-resolution.helper';
 import { getBrokenHandRevealPendingError } from './helpers/broken-hand.helper';
 import { asSeatId } from '../types/identity.types';
+import { setCurrentSeat } from '../types/current-turn';
 
 @Injectable()
 export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
@@ -152,11 +153,7 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
       const firstBlowIndex = nextState.blowState.currentBlowIndex;
       const firstBlowPlayer = nextState.players[firstBlowIndex];
 
-      nextState.currentPlayerId = firstBlowPlayer?.playerId ?? null;
-      nextState.currentSeatId = firstBlowPlayer
-        ? asSeatId(firstBlowPlayer.playerId)
-        : null;
-      nextState.currentPlayerIndex = firstBlowIndex;
+      setCurrentSeat(nextState, firstBlowPlayer?.playerId ?? null);
       nextState.players.forEach((statePlayer) => {
         statePlayer.isPasser = false;
       });

--- a/mei-tra-backend/src/use-cases/select-base-suit.use-case.ts
+++ b/mei-tra-backend/src/use-cases/select-base-suit.use-case.ts
@@ -7,6 +7,7 @@ import {
 import { IRoomService } from '../services/interfaces/room-service.interface';
 import { GatewayEvent } from './interfaces/gateway-event.interface';
 import { resolvePlayerByActorId } from './helpers/player-resolution.helper';
+import { resolveCurrentPlayer } from '../types/current-turn';
 
 @Injectable()
 export class SelectBaseSuitUseCase implements ISelectBaseSuitUseCase {
@@ -55,7 +56,7 @@ export class SelectBaseSuitUseCase implements ISelectBaseSuitUseCase {
       ];
 
       roomGameState.nextTurn();
-      const nextPlayer = state.players[state.currentPlayerIndex];
+      const nextPlayer = resolveCurrentPlayer(state);
       if (nextPlayer) {
         events.push({
           scope: 'room',

--- a/mei-tra-backend/src/use-cases/select-negri.use-case.ts
+++ b/mei-tra-backend/src/use-cases/select-negri.use-case.ts
@@ -12,6 +12,7 @@ import {
   resolvePlayerByActorId,
 } from './helpers/player-resolution.helper';
 import { asSeatId } from '../types/identity.types';
+import { setCurrentSeat } from '../types/current-turn';
 
 @Injectable()
 export class SelectNegriUseCase implements ISelectNegriUseCase {
@@ -87,9 +88,7 @@ export class SelectNegriUseCase implements ISelectNegriUseCase {
         };
       }
 
-      state.currentPlayerIndex = winnerIndex;
-      state.currentPlayerId = winner.playerId;
-      state.currentSeatId = asSeatId(winner.playerId);
+      setCurrentSeat(state, winner.playerId);
       const room = await this.roomService.getRoom(roomId);
 
       const events: GatewayEvent[] = [

--- a/mei-tra-backend/src/use-cases/start-game.use-case.ts
+++ b/mei-tra-backend/src/use-cases/start-game.use-case.ts
@@ -11,6 +11,10 @@ import { toDomainPlayer } from '../types/player-adapters';
 import { GameStateService } from '../services/game-state.service';
 import { GameState } from '../types/game.types';
 import { asSeatId } from '../types/identity.types';
+import {
+  resolveCurrentPlayer,
+  resolveCurrentPlayerIndex,
+} from '../types/current-turn';
 
 @Injectable()
 export class StartGameUseCase implements IStartGameUseCase {
@@ -106,21 +110,22 @@ export class StartGameUseCase implements IStartGameUseCase {
       roomGameState.startGame();
 
       let updatedState = roomGameState.getState();
-      if (
-        updatedState.blowState.currentBlowIndex !==
-        updatedState.currentPlayerIndex
-      ) {
-        const currentPlayer =
-          updatedState.players[updatedState.currentPlayerIndex] ?? null;
+      const currentPlayerIndex = resolveCurrentPlayerIndex(updatedState);
+      if (currentPlayerIndex === -1) {
+        return {
+          success: false,
+          errorMessage: 'Current turn seat was not initialized',
+        };
+      }
+      if (updatedState.blowState.currentBlowIndex !== currentPlayerIndex) {
+        const currentPlayer = resolveCurrentPlayer(updatedState);
         roomGameState.updateState({
           currentSeatId: currentPlayer
             ? asSeatId(currentPlayer.playerId)
             : null,
-          currentPlayerId: currentPlayer?.playerId ?? null,
-          currentPlayerIndex: updatedState.currentPlayerIndex,
           blowState: {
             ...updatedState.blowState,
-            currentBlowIndex: updatedState.currentPlayerIndex,
+            currentBlowIndex: currentPlayerIndex,
           },
         });
         updatedState = roomGameState.getState();
@@ -142,8 +147,13 @@ export class StartGameUseCase implements IStartGameUseCase {
         p.isPasser = false;
       });
 
-      const currentTurnPlayer =
-        updatedState.players[updatedState.currentPlayerIndex];
+      const currentTurnPlayer = resolveCurrentPlayer(updatedState);
+      if (!currentTurnPlayer) {
+        return {
+          success: false,
+          errorMessage: 'Current turn seat was not initialized',
+        };
+      }
       const firstBlowPlayer =
         updatedState.players[updatedState.blowState.currentBlowIndex];
 

--- a/mei-tra-backend/src/use-cases/watch-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/watch-room.use-case.ts
@@ -10,6 +10,7 @@ import {
 } from './interfaces/watch-room.use-case.interface';
 import { resolveTransportPlayers } from './helpers/player-resolution.helper';
 import { asSeatId } from '../types/identity.types';
+import { resolveCurrentSeatId } from '../types/current-turn';
 
 @Injectable()
 export class WatchRoomUseCase implements IWatchRoomUseCase {
@@ -72,10 +73,7 @@ export class WatchRoomUseCase implements IWatchRoomUseCase {
       state.players.length > 0
         ? state.players
         : room.players.map((player) => toDomainPlayer(player));
-    const currentTurn =
-      state.currentPlayerIndex !== -1 && state.players[state.currentPlayerIndex]
-        ? state.players[state.currentPlayerIndex].playerId
-        : null;
+    const currentTurn = resolveCurrentSeatId(state);
     const spectatorPlayers = resolveTransportPlayers(
       roomGameState,
       statePlayers,


### PR DESCRIPTION
## Summary
- 手番の正本を `currentSeatId` に統一
- `currentPlayerId` / `currentPlayerIndex` は互換境界でのみ解決
- 手番の設定・解決を共通ヘルパーへ集約

## Dependency
- #204 の上に積んだPRです。#204から順にマージしてください。

## Validation
- `npm test -- --runInBand` (62 suites / 391 tests)
- `npm run build`
- changed TypeScript files: ESLint
- `git diff --check`

## User-facing change
手番の見た目や操作仕様は変えず、内部の席参照をUUIDへ統一します。

## User benefit
再接続・COM交代・シャッフル後の手番ずれを起きにくくします。