### PR TITLE
runtime席ロスター更新を集約

### DIFF
--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -4,7 +4,10 @@ import { IGameStateRepository } from '../../repositories/interfaces/game-state.r
 import { IRoomRepository } from '../../repositories/interfaces/room.repository.interface';
 import { IUserProfileRepository } from '../../repositories/interfaces/user-profile.repository.interface';
 import { GameStateFactory } from '../game-state.factory';
-import { DomainPlayer, GameState } from '../../types/game.types';
+import {
+  DomainPlayer,
+  GameState,
+} from '../../types/game.types';
 import { Room, RoomStatus, RoomPlayer } from '../../types/room.types';
 import { CardService } from '../card.service';
 import { ChomboService } from '../chombo.service';
@@ -1337,7 +1340,13 @@ describe('Reconnection Token Management', () => {
         // Verify player was restored to index 0
         const restoredRoom = roomState.getPersistedRoom();
         expect(restoredRoom?.players[0].playerId).toBe(comPlayer.playerId);
-        expect(restoredRoom?.players[0].hand).toEqual(['H2', 'D3', 'C4']);
+        expect(restoredRoom?.players[0].hand).toEqual([]);
+        const restoredState = await roomService.getRoomGameState(roomId);
+        expect(restoredState.getState().players[0].hand).toEqual([
+          'H2',
+          'D3',
+          'C4',
+        ]);
         expect(restoredRoom?.players[0].team).toBe(0);
       });
 
@@ -1599,13 +1608,18 @@ describe('Reconnection Token Management', () => {
         const updatedRoom = roomState.getPersistedRoom();
         expect(updatedRoom?.players[0].playerId).toBe(otherCom.playerId);
         expect(updatedRoom?.players[1].playerId).toBe(targetCom.playerId);
-        expect(updatedRoom?.players[1].hand).toEqual(['H2', 'D3', 'C4']);
+        expect(updatedRoom?.players[1].hand).toEqual([]);
         expect(gameState.getState().players[0].playerId).toBe(
           otherCom.playerId,
         );
         expect(gameState.getState().players[1].playerId).toBe(
           targetCom.playerId,
         );
+        expect(gameState.getState().players[1].hand).toEqual([
+          'H2',
+          'D3',
+          'C4',
+        ]);
       });
 
       it('should restore the latest com hand after cards were played while disconnected', async () => {
@@ -1690,7 +1704,7 @@ describe('Reconnection Token Management', () => {
         expect(result).toBe(true);
         const updatedRoom = roomState.getPersistedRoom();
         expect(updatedRoom?.players[0].playerId).toBe(targetCom.playerId);
-        expect(updatedRoom?.players[0].hand).toEqual(['H2', 'D3']);
+        expect(updatedRoom?.players[0].hand).toEqual([]);
         expect(gameState.getState().players[0].playerId).toBe(
           targetCom.playerId,
         );
@@ -2329,7 +2343,8 @@ describe('Reconnection Token Management', () => {
         const updatedRoom = roomState.getPersistedRoom();
         expect(updatedRoom?.players[0].playerId).toBe(comPlayer.playerId);
         expect(updatedRoom?.players[0].participantKey).toBe('player-2');
-        expect(updatedRoom?.players[0].hand).toEqual(['H2', 'D3']);
+        expect(updatedRoom?.players[0].hand).toEqual([]);
+        expect(gameState.getState().players[0].hand).toEqual(['H2', 'D3']);
 
         // Original player's token should be removed
         // Token is gone, so findPlayerByReconnectToken uses fallback (playerId direct search)
@@ -2496,10 +2511,11 @@ describe('Reconnection Token Management', () => {
         expect(restored).toBe(true);
         const updatedRoom = roomState.getPersistedRoom();
         expect(updatedRoom?.players[0].playerId).toBe(comPlayer.playerId);
-        expect(updatedRoom?.players[0].hand).toEqual(['H2', 'D3']);
+        expect(updatedRoom?.players[0].hand).toEqual([]);
         expect(gameState.getState().players[0].playerId).toBe(
           comPlayer.playerId,
         );
+        expect(gameState.getState().players[0].hand).toEqual(['H2', 'D3']);
         expect(gameState.getState().players[0].isPasser).toBe(true);
         expect((roomService as any)['vacantSeats'][roomId]).toBeUndefined();
       });

--- a/mei-tra-backend/src/services/__tests__/runtime-seat-roster.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/runtime-seat-roster.spec.ts
@@ -1,0 +1,122 @@
+import { asSeatId } from '../../types/identity.types';
+import {
+  reconcileRuntimeRoster,
+  upsertRuntimeSeat,
+} from '../runtime-seat-roster';
+import type { GameState } from '../../types/game.types';
+import type { Room, RoomPlayer } from '../../types/room.types';
+
+const roomPlayer = (overrides: Partial<RoomPlayer> = {}): RoomPlayer => ({
+  seatId: asSeatId('seat-1'),
+  playerId: 'seat-1',
+  socketId: 'socket-1',
+  name: 'Player 1',
+  hand: [],
+  team: 0,
+  isPasser: false,
+  hasBroken: false,
+  hasRequiredBroken: false,
+  isReady: true,
+  isHost: true,
+  joinedAt: new Date(),
+  ...overrides,
+});
+
+const room = (players: RoomPlayer[]): Pick<Room, 'players'> => ({ players });
+
+const state = (): Pick<GameState, 'players' | 'teamAssignments'> => ({
+  players: [
+    {
+      seatId: asSeatId('seat-1'),
+      playerId: 'seat-1',
+      name: 'Player 1',
+      hand: ['A♠'],
+      team: 0,
+      isPasser: true,
+      hasBroken: true,
+      hasRequiredBroken: false,
+    },
+  ],
+  teamAssignments: { 'seat-1': 0 },
+});
+
+describe('runtime seat roster', () => {
+  it('changes the occupant without changing the seat or gameplay state', () => {
+    const runtimeRoom = room([roomPlayer()]);
+    const runtimeState = state();
+
+    const projection = upsertRuntimeSeat(
+      runtimeRoom,
+      runtimeState,
+      roomPlayer({
+        socketId: 'com-seat-1',
+        name: 'COM',
+        isCOM: true,
+      }),
+      { replaceSeatId: 'seat-1' },
+    );
+
+    expect(projection.roomPlayer).toMatchObject({
+      playerId: 'seat-1',
+      name: 'COM',
+      isCOM: true,
+    });
+    expect(projection.roomPlayer.hand).toEqual([]);
+    expect(projection.roomPlayer.isPasser).toBe(false);
+    expect(runtimeState.players[0]).toMatchObject({
+      playerId: 'seat-1',
+      name: 'COM',
+      isCOM: true,
+      hand: ['A♠'],
+      hasBroken: true,
+    });
+    expect(runtimeState.teamAssignments).toEqual({ 'seat-1': 0 });
+  });
+
+  it('rebuilds the game projection and team lookup from the room roster', () => {
+    const runtimeState = state();
+    const players = [
+      roomPlayer({ name: 'Reconnected' }),
+      roomPlayer({
+        seatId: asSeatId('seat-2'),
+        playerId: 'seat-2',
+        name: 'COM',
+        team: 1,
+        isCOM: true,
+      }),
+    ];
+
+    reconcileRuntimeRoster(runtimeState, players);
+
+    expect(runtimeState.players).toEqual([
+      expect.objectContaining({
+        playerId: 'seat-1',
+        name: 'Reconnected',
+        hand: ['A♠'],
+      }),
+      expect.objectContaining({
+        playerId: 'seat-2',
+        name: 'COM',
+        team: 1,
+      }),
+    ]);
+    expect(runtimeState.teamAssignments).toEqual({
+      'seat-1': 0,
+      'seat-2': 1,
+    });
+  });
+
+  it('rejects replacing a seat with a different identity', () => {
+    expect(() =>
+      upsertRuntimeSeat(
+        room([roomPlayer()]),
+        state(),
+        roomPlayer({
+          seatId: asSeatId('seat-2'),
+          playerId: 'seat-2',
+        }),
+        { replaceSeatId: 'seat-1' },
+      ),
+    ).toThrow('Cannot replace seat seat-1 with a different seat seat-2');
+  });
+});

--- a/mei-tra-backend/src/services/com-session.service.ts
+++ b/mei-tra-backend/src/services/com-session.service.ts
@@ -7,6 +7,7 @@ import { GameStateService } from './game-state.service';
 import { randomUUID } from 'crypto';
 import { asSeatId, resolveSeatId } from '../types/identity.types';
 import { RosterMembershipMutation } from '../types/room-membership.types';
+import { upsertRuntimeSeat } from './runtime-seat-roster';
 
 export type VacantSeats = Record<
   string,
@@ -62,33 +63,22 @@ export class ComSessionService {
   private createActiveCOMReplacement(
     index: number | string,
     sourcePlayer: Pick<
-      DomainPlayer,
-      | 'seatId'
-      | 'playerId'
-      | 'team'
-      | 'isPasser'
-      | 'hasBroken'
-      | 'hasRequiredBroken'
+      RoomPlayer,
+      'seatId' | 'playerId' | 'team'
     >,
-    hand: string[] = [],
   ): RoomPlayer {
-    const comPlayer = this.createCOMPlaceholder(
+    return this.createCOMPlaceholder(
       index,
       sourcePlayer.team,
-      hand,
+      [],
       resolveSeatId(sourcePlayer),
     );
-    comPlayer.isPasser = sourcePlayer.isPasser;
-    comPlayer.hasBroken = sourcePlayer.hasBroken ?? false;
-    comPlayer.hasRequiredBroken = sourcePlayer.hasRequiredBroken ?? false;
-    return comPlayer;
   }
 
   private cloneRoomPlayer(player: RoomPlayer): RoomPlayer {
     return {
       ...player,
       socketId: '',
-      hand: [...player.hand],
       joinedAt: new Date(player.joinedAt),
     };
   }
@@ -122,9 +112,7 @@ export class ComSessionService {
       ).length;
       const team = (team0Count <= team1Count ? 0 : 1) as Team;
       const placeholder = this.createCOMPlaceholder(idx, team);
-      room.players.push(placeholder);
-      state.players.push(toDomainPlayer(placeholder));
-      state.teamAssignments[placeholder.playerId] = placeholder.team;
+      upsertRuntimeSeat(room, state, placeholder);
       gameState.registerPlayerToken(placeholder.playerId, placeholder.playerId);
       rosterChanged = true;
     }
@@ -149,13 +137,9 @@ export class ComSessionService {
       const statePlayer = state.players.find(
         (player) => player.playerId === roomPlayer.playerId,
       );
-      if (statePlayer) {
-        statePlayer.isCOM = true;
-        statePlayer.isPasser = roomPlayer.isPasser;
-      } else {
-        state.players.push(toDomainPlayer(roomPlayer));
-      }
-      state.teamAssignments[roomPlayer.playerId] = roomPlayer.team;
+      upsertRuntimeSeat(room, state, roomPlayer, {
+        gameplaySource: statePlayer ? { ...statePlayer, isCOM: true } : null,
+      });
     });
 
     const maxPlayers = room.settings?.maxPlayers ?? 4;
@@ -196,9 +180,7 @@ export class ComSessionService {
         joinedAt: new Date(),
       });
 
-      room.players.push(roomComPlayer);
-      state.players.push(toDomainPlayer(roomComPlayer));
-      state.teamAssignments[roomComPlayer.playerId] = roomComPlayer.team;
+      upsertRuntimeSeat(room, state, roomComPlayer);
       gameState.registerPlayerToken(
         roomComPlayer.playerId,
         roomComPlayer.playerId,
@@ -232,12 +214,10 @@ export class ComSessionService {
       (player) => player.playerId === playerId,
     );
 
-    const originalHand = room.players[playerIndex].hand ?? [];
     const uniqueIdx = `timeout-${playerIndex}-${Date.now()}`;
     const comPlayer = this.createActiveCOMReplacement(
       uniqueIdx,
       room.players[playerIndex],
-      [...originalHand],
     );
     if (membershipMutation?.type === 'complete-disconnect-timeout') {
       comPlayer.userId = room.players[playerIndex].userId;
@@ -254,18 +234,10 @@ export class ComSessionService {
       replacementPlayerId: comPlayer.playerId,
     };
 
-    room.players[playerIndex] = comPlayer;
-
-    if (gsIndex !== -1) {
-      const originalGameHand = state.players[gsIndex].hand ?? [];
-      const comGamePlayer = this.createActiveCOMReplacement(
-        uniqueIdx,
-        state.players[gsIndex],
-        [...originalGameHand],
-      );
-      state.players[gsIndex] = toDomainPlayer(comGamePlayer);
-      state.teamAssignments[comGamePlayer.playerId] = comGamePlayer.team;
-    }
+    upsertRuntimeSeat(room, state, comPlayer, {
+      replaceSeatId: playerId,
+      gameplaySource: gsIndex === -1 ? null : state.players[gsIndex],
+    });
 
     await gameState.persistRoster(
       room.players,

--- a/mei-tra-backend/src/services/disconnect-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/disconnect-gateway-effects.service.ts
@@ -88,7 +88,6 @@ export class DisconnectGatewayEffectsService {
       return null;
     }
 
-    state.teamAssignments[player.playerId] = player.team;
     await roomGameState.applyPlayerConnectionState(player.playerId, {
       socketId: '',
     });

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -20,7 +20,6 @@ import { PlayerConnectionManager } from './player-connection-manager.service';
 import { GamePhaseService } from './game-phase.service';
 import { PlayerConnectionState, SessionUser } from '../types/session.types';
 import {
-  toDomainPlayer,
   toRuntimePlayer,
   toTransportPlayers,
   TransportPlayer,
@@ -34,6 +33,7 @@ import {
   resolveCurrentSeatId,
   setCurrentSeat,
 } from '../types/current-turn';
+import { reconcileRuntimeRoster } from './runtime-seat-roster';
 
 @Injectable()
 export class GameStateService implements IGameStateService {
@@ -291,27 +291,7 @@ export class GameStateService implements IGameStateService {
   async reconcileWaitingRoomPlayers(roomPlayers: RoomPlayer[]): Promise<void> {
     const previousPlayers = this.state.players;
     const previousTeamAssignments = this.state.teamAssignments;
-    const currentPlayers = new Map(
-      this.state.players.map((player) => [player.playerId, player]),
-    );
-
-    this.state.players = roomPlayers.map((roomPlayer) => {
-      const currentPlayer = currentPlayers.get(roomPlayer.playerId);
-      if (!currentPlayer) {
-        return toDomainPlayer(roomPlayer);
-      }
-
-      return toDomainPlayer({
-        ...roomPlayer,
-        hand: currentPlayer.hand,
-        isPasser: currentPlayer.isPasser,
-        hasBroken: currentPlayer.hasBroken,
-        hasRequiredBroken: currentPlayer.hasRequiredBroken,
-      });
-    });
-    this.state.teamAssignments = Object.fromEntries(
-      roomPlayers.map((player) => [player.playerId, player.team]),
-    );
+    reconcileRuntimeRoster(this.state, roomPlayers);
 
     roomPlayers.forEach((player) => {
       this.connectionManager.registerPlayerToken(

--- a/mei-tra-backend/src/services/room-join.service.ts
+++ b/mei-tra-backend/src/services/room-join.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { BlowState, DomainPlayer, GameState, Team } from '../types/game.types';
-import { toDomainPlayer } from '../types/player-adapters';
 import { Room, RoomPlayer } from '../types/room.types';
 import { GameStateService } from './game-state.service';
 import { VacantSeats } from './com-session.service';
@@ -12,6 +11,7 @@ import {
   resolveCurrentPlayerIndex,
   setCurrentSeat,
 } from '../types/current-turn';
+import { upsertRuntimeSeat } from './runtime-seat-roster';
 
 interface JoinRoomParams {
   roomId: string;
@@ -77,15 +77,9 @@ export class RoomJoinService {
         isHost: room.hostId === existingPlayer.playerId,
         isCOM: reclaimingCOMSeat ? false : existingPlayer.isCOM,
       };
-      Object.assign(existingPlayer, updatedPlayer);
-      if (statePlayer) {
-        statePlayer.name = updatedPlayer.name;
-        statePlayer.team = updatedPlayer.team;
-        statePlayer.isCOM = updatedPlayer.isCOM;
-      } else {
-        state.players.push(toDomainPlayer(updatedPlayer));
-      }
-      state.teamAssignments[updatedPlayer.playerId] = updatedPlayer.team;
+      upsertRuntimeSeat(room, state, updatedPlayer, {
+        gameplaySource: statePlayer,
+      });
 
       gameState.registerPlayerToken(
         updatedPlayer.playerId,
@@ -128,7 +122,6 @@ export class RoomJoinService {
     const vacantIndexes = Object.keys(roomVacant).map(Number);
     let assignedIndex = -1;
     let gsAssignedIndex = -1;
-    let hand: string[] = [];
     let team: Team = 0;
     let replacingComId: string | null = null;
     let restoredSeatData: RestoredSeatData | null = null;
@@ -141,13 +134,7 @@ export class RoomJoinService {
       assignedIndex = matchingVacantIndex;
       const seatData = roomVacant[assignedIndex];
       const seatRoomPlayer = seatData?.roomPlayer;
-      const seatGamePlayer = seatData?.gamePlayer;
 
-      hand = seatGamePlayer
-        ? [...seatGamePlayer.hand]
-        : seatRoomPlayer
-          ? [...seatRoomPlayer.hand]
-          : [];
       team = seatRoomPlayer ? seatRoomPlayer.team : team;
       restoredSeatData = seatData ?? null;
       gameState.clearDisconnectTimeout(user.playerId);
@@ -170,7 +157,6 @@ export class RoomJoinService {
         assignedIndex = availableVacantIndex;
         const seatData = roomVacant[assignedIndex];
         const seatRoomPlayer = seatData?.roomPlayer;
-        hand = seatRoomPlayer ? [...seatRoomPlayer.hand] : [];
         team = seatRoomPlayer ? seatRoomPlayer.team : team;
 
         const originalPlayerId = seatRoomPlayer?.playerId;
@@ -200,15 +186,10 @@ export class RoomJoinService {
           gsAssignedIndex = state.players.findIndex(
             (player) => player.playerId === comPlayerId,
           );
-          const currentGamePlayer =
-            gsAssignedIndex !== -1 ? state.players[gsAssignedIndex] : null;
-          hand = currentGamePlayer
-            ? [...(currentGamePlayer.hand ?? [])]
-            : [...(room.players[comIndex].hand ?? [])];
         }
       }
 
-      if (hand.length === 0) {
+      if (assignedIndex === -1 && replacingComId === null) {
         const team0Count = room.players.filter(
           (player) => !player.isCOM && player.team === 0,
         ).length;
@@ -258,11 +239,6 @@ export class RoomJoinService {
         : assignedIndex !== -1
           ? room.players[assignedIndex]
           : undefined;
-    const currentSeatRoomHand =
-      currentSeatRoomPlayer && currentSeatRoomPlayer.hand.length > 0
-        ? currentSeatRoomPlayer.hand
-        : undefined;
-
     const assignedSeatId = currentSeatRoomPlayer
       ? resolveSeatId(currentSeatRoomPlayer)
       : seatRoomSnapshot
@@ -276,22 +252,10 @@ export class RoomJoinService {
       playerId: assignedSeatId,
       participantKey: user.userId ?? user.playerId,
       team: currentSeatRoomPlayer?.team ?? team,
-      hand: [...(currentSeatRoomHand ?? hand)],
-      isPasser:
-        seatGameSnapshot?.isPasser ??
-        currentSeatRoomPlayer?.isPasser ??
-        seatRoomSnapshot?.isPasser ??
-        false,
-      hasBroken:
-        seatGameSnapshot?.hasBroken ??
-        currentSeatRoomPlayer?.hasBroken ??
-        seatRoomSnapshot?.hasBroken ??
-        false,
-      hasRequiredBroken:
-        seatGameSnapshot?.hasRequiredBroken ??
-        currentSeatRoomPlayer?.hasRequiredBroken ??
-        seatRoomSnapshot?.hasRequiredBroken ??
-        false,
+      hand: [],
+      isPasser: false,
+      hasBroken: false,
+      hasRequiredBroken: false,
       isReady:
         currentSeatRoomPlayer?.isReady ?? seatRoomSnapshot?.isReady ?? false,
       isHost: room.hostId === assignedSeatId,
@@ -300,20 +264,6 @@ export class RoomJoinService {
         ? new Date(seatRoomSnapshot.joinedAt)
         : new Date(),
     };
-
-    if (assignedIndex !== -1) {
-      room.players[assignedIndex] = player;
-    } else {
-      const comIndex = room.players.findIndex(
-        (roomPlayer) =>
-          this.isReplaceableCOMSeat(roomPlayer) && !roomPlayer.isReady,
-      );
-      if (comIndex !== -1) {
-        room.players[comIndex] = player;
-      } else {
-        room.players.push(player);
-      }
-    }
 
     if (replacementPlayerId) {
       gsAssignedIndex = state.players.findIndex(
@@ -333,29 +283,13 @@ export class RoomJoinService {
           )
         : undefined;
 
-    player.hand = [
-      ...(currentSeatGamePlayer?.hand.length
-        ? currentSeatGamePlayer.hand
-        : player.hand),
-    ];
-    player.isPasser =
-      currentSeatGamePlayer?.isPasser ?? player.isPasser ?? false;
-    player.hasBroken =
-      currentSeatGamePlayer?.hasBroken ?? player.hasBroken ?? false;
-    player.hasRequiredBroken =
-      currentSeatGamePlayer?.hasRequiredBroken ??
-      player.hasRequiredBroken ??
-      false;
-
-    const gamePlayer = toDomainPlayer(player);
-
-    if (gsAssignedIndex !== -1) {
-      state.players[gsAssignedIndex] = gamePlayer;
-    } else {
-      state.players.push(gamePlayer);
-    }
-
-    state.teamAssignments[player.playerId] = player.team;
+    upsertRuntimeSeat(room, state, player, {
+      replaceSeatId: replacingComId ?? player.playerId,
+      gameplaySource:
+        currentSeatGamePlayer ??
+        seatGameSnapshot ??
+        (gsAssignedIndex === -1 ? null : state.players[gsAssignedIndex]),
+    });
 
     gameState.registerPlayerToken(player.playerId, player.playerId);
     if (player.userId) {

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -27,6 +27,7 @@ import {
 } from '../types/room-membership.types';
 import { randomUUID } from 'crypto';
 import { asSeatId } from '../types/identity.types';
+import { upsertRuntimeSeat } from './runtime-seat-roster';
 
 @Injectable()
 export class RoomService implements IRoomService, OnModuleDestroy {
@@ -296,27 +297,14 @@ export class RoomService implements IRoomService, OnModuleDestroy {
 
   private createActiveCOMReplacement(
     index: number | string,
-    sourcePlayer: Pick<
-      DomainPlayer | RoomPlayer,
-      | 'seatId'
-      | 'playerId'
-      | 'team'
-      | 'isPasser'
-      | 'hasBroken'
-      | 'hasRequiredBroken'
-    >,
-    hand: string[] = [],
+    sourcePlayer: Pick<RoomPlayer, 'seatId' | 'playerId' | 'team'>,
   ): RoomPlayer {
-    const comPlayer = this.createCOMPlaceholder(
+    return this.createCOMPlaceholder(
       index,
       sourcePlayer.team,
-      hand,
+      [],
       asSeatId(sourcePlayer.seatId ?? sourcePlayer.playerId),
     );
-    comPlayer.isPasser = sourcePlayer.isPasser;
-    comPlayer.hasBroken = sourcePlayer.hasBroken ?? false;
-    comPlayer.hasRequiredBroken = sourcePlayer.hasRequiredBroken ?? false;
-    return comPlayer;
   }
 
   private createWaitingCOMReplacement(
@@ -349,7 +337,6 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     return {
       ...player,
       socketId: '',
-      hand: [...player.hand],
       joinedAt: new Date(player.joinedAt),
     };
   }
@@ -439,16 +426,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       gameState.getState().gamePhase !== null;
 
     if (isGameStarted) {
-      // hand情報をgameStateから同期
       const state = gameState.getState();
-      room.players.forEach((roomPlayer) => {
-        const statePlayer = state.players.find(
-          (p) => p.playerId === roomPlayer.playerId,
-        );
-        if (statePlayer) {
-          roomPlayer.hand = [...statePlayer.hand];
-        }
-      });
 
       // 退出したプレイヤーのindexを記録
       const playerIndex = room.players.findIndex(
@@ -462,11 +440,9 @@ export class RoomService implements IRoomService, OnModuleDestroy {
         // プレイヤーをCOMに置き換え（手札を引き継いでCOMが続行できるようにする）
         // タイムスタンプ付きIDで既存COMとのID衝突を防ぐ
         const uniqueIdx = `left-${Date.now()}`;
-        const originalHand = room.players[playerIndex].hand ?? [];
         const comPlayer = this.createActiveCOMReplacement(
           uniqueIdx,
           room.players[playerIndex],
-          [...originalHand],
         );
 
         this.vacantSeats[roomId][playerIndex] = {
@@ -478,19 +454,10 @@ export class RoomService implements IRoomService, OnModuleDestroy {
           replacementPlayerId: comPlayer.playerId,
         };
 
-        room.players[playerIndex] = comPlayer;
-
-        // ゲーム状態も同時に更新（手札を引き継ぐ）
-        if (gsIndex !== -1) {
-          const originalGameHand = state.players[gsIndex].hand ?? [];
-          const comGamePlayer = this.createActiveCOMReplacement(
-            uniqueIdx,
-            state.players[gsIndex],
-            [...originalGameHand],
-          );
-          state.players[gsIndex] = toDomainPlayer(comGamePlayer);
-          state.teamAssignments[comGamePlayer.playerId] = comGamePlayer.team;
-        }
+        upsertRuntimeSeat(room, state, comPlayer, {
+          replaceSeatId: playerId,
+          gameplaySource: gsIndex === -1 ? null : state.players[gsIndex],
+        });
 
         // 再接続トークンは保持（同じplayerIdで再join可能にする）
         // 他のプレイヤーがこの席を取ったら、その時点でトークンを削除
@@ -515,12 +482,10 @@ export class RoomService implements IRoomService, OnModuleDestroy {
           playerIndex,
           gsIndex,
         );
-        room.players[playerIndex] = comPlaceholder;
-
-        if (gsIndex !== -1) {
-          state.players[gsIndex] = toDomainPlayer(comPlaceholder);
-          state.teamAssignments[comPlaceholder.playerId] = comPlaceholder.team;
-        }
+        upsertRuntimeSeat(room, state, comPlaceholder, {
+          replaceSeatId: playerId,
+          gameplaySource: gsIndex === -1 ? null : state.players[gsIndex],
+        });
       }
       // 再接続トークンを削除
       gameState.removePlayerToken(playerId);
@@ -602,7 +567,6 @@ export class RoomService implements IRoomService, OnModuleDestroy {
         {
           roomPlayer: {
             ...seatData.roomPlayer,
-            hand: [...seatData.roomPlayer.hand],
             joinedAt: new Date(seatData.roomPlayer.joinedAt),
           },
           ...(seatData.gamePlayer && {
@@ -780,28 +744,11 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       const statePlayerIndex = state.players.findIndex(
         (player) => player.playerId === playerId,
       );
-      if (statePlayerIndex === -1) {
-        state.players.push(toDomainPlayer(roomPlayer));
-      } else {
-        const statePlayer = state.players[statePlayerIndex];
-        state.players[statePlayerIndex] = toDomainPlayer({
-          ...statePlayer,
-          ...(updates.name !== undefined && { name: updates.name }),
-          ...(updates.team !== undefined && { team: updates.team }),
-          ...(updates.isCOM !== undefined && { isCOM: updates.isCOM }),
-          ...(updates.hand !== undefined && { hand: [...updates.hand] }),
-          ...(updates.isPasser !== undefined && {
-            isPasser: updates.isPasser,
-          }),
-          ...(updates.hasBroken !== undefined && {
-            hasBroken: updates.hasBroken,
-          }),
-          ...(updates.hasRequiredBroken !== undefined && {
-            hasRequiredBroken: updates.hasRequiredBroken,
-          }),
-        });
-      }
-      state.teamAssignments[playerId] = roomPlayer.team;
+      const statePlayer =
+        statePlayerIndex === -1 ? null : state.players[statePlayerIndex];
+      upsertRuntimeSeat(room, state, roomPlayer, {
+        gameplaySource: statePlayer,
+      });
     }
 
     room.players.forEach((player) => {

--- a/mei-tra-backend/src/services/runtime-seat-roster.ts
+++ b/mei-tra-backend/src/services/runtime-seat-roster.ts
@@ -1,0 +1,104 @@
+import type { DomainPlayer, GameState } from '../types/game.types';
+import { resolveSeatId } from '../types/identity.types';
+import { toDomainPlayer } from '../types/player-adapters';
+import type { Room, RoomPlayer } from '../types/room.types';
+
+type RuntimeRoomRoster = Pick<Room, 'players'>;
+type RuntimeGameRoster = Pick<GameState, 'players' | 'teamAssignments'>;
+
+interface UpsertRuntimeSeatOptions {
+  replaceSeatId?: string;
+  gameplaySource?: DomainPlayer | null;
+}
+
+export interface RuntimeSeatProjection {
+  roomPlayer: RoomPlayer;
+  gamePlayer: DomainPlayer;
+}
+
+function replaceOrAppend<T>(items: T[], index: number, value: T): void {
+  if (index === -1) {
+    items.push(value);
+    return;
+  }
+
+  items[index] = value;
+}
+
+export function rebuildTeamAssignments(state: RuntimeGameRoster): void {
+  state.teamAssignments = Object.fromEntries(
+    state.players.map((player) => [player.playerId, player.team]),
+  );
+}
+
+function projectGamePlayer(
+  roomPlayer: RoomPlayer,
+  gameplaySource?: DomainPlayer | null,
+): DomainPlayer {
+  return toDomainPlayer({
+    ...roomPlayer,
+    hand: [...(gameplaySource?.hand ?? [])],
+    isPasser: gameplaySource?.isPasser ?? false,
+    hasBroken: gameplaySource?.hasBroken ?? false,
+    hasRequiredBroken: gameplaySource?.hasRequiredBroken ?? false,
+  });
+}
+
+export function upsertRuntimeSeat(
+  room: RuntimeRoomRoster,
+  state: RuntimeGameRoster,
+  roomPlayer: RoomPlayer,
+  options: UpsertRuntimeSeatOptions = {},
+): RuntimeSeatProjection {
+  const seatId = resolveSeatId(roomPlayer);
+  const replaceSeatId = options.replaceSeatId ?? seatId;
+
+  if (replaceSeatId !== seatId) {
+    throw new Error(
+      `Cannot replace seat ${replaceSeatId} with a different seat ${seatId}`,
+    );
+  }
+
+  const roomIndex = room.players.findIndex(
+    (player) => resolveSeatId(player) === seatId,
+  );
+  const gameIndex = state.players.findIndex(
+    (player) => resolveSeatId(player) === seatId,
+  );
+  const gameplaySource =
+    options.gameplaySource ??
+    (gameIndex === -1 ? null : state.players[gameIndex]);
+  const normalizedRoomPlayer: RoomPlayer = {
+    ...roomPlayer,
+    seatId,
+    playerId: seatId,
+    hand: [],
+    isPasser: false,
+    hasBroken: false,
+    hasRequiredBroken: false,
+  };
+  const gamePlayer = projectGamePlayer(normalizedRoomPlayer, gameplaySource);
+
+  replaceOrAppend(room.players, roomIndex, normalizedRoomPlayer);
+  replaceOrAppend(state.players, gameIndex, gamePlayer);
+  rebuildTeamAssignments(state);
+
+  return { roomPlayer: normalizedRoomPlayer, gamePlayer };
+}
+
+export function reconcileRuntimeRoster(
+  state: RuntimeGameRoster,
+  roomPlayers: RoomPlayer[],
+): void {
+  const currentPlayers = new Map(
+    state.players.map((player) => [resolveSeatId(player), player]),
+  );
+
+  state.players = roomPlayers.map((roomPlayer) =>
+    projectGamePlayer(
+      roomPlayer,
+      currentPlayers.get(resolveSeatId(roomPlayer)) ?? null,
+    ),
+  );
+  rebuildTeamAssignments(state);
+}

--- a/mei-tra-backend/src/services/seat-restoration.service.ts
+++ b/mei-tra-backend/src/services/seat-restoration.service.ts
@@ -9,6 +9,7 @@ import {
   resolveCurrentPlayerIndex,
   setCurrentSeat,
 } from '../types/current-turn';
+import { upsertRuntimeSeat } from './runtime-seat-roster';
 
 @Injectable()
 export class SeatRestorationService {
@@ -57,15 +58,8 @@ export class SeatRestorationService {
       socketId: '',
       seatId,
       playerId: seatId,
-      hand: [
-        ...(currentSeatPlayer.hand.length
-          ? currentSeatPlayer.hand
-          : seatData.roomPlayer.hand),
-      ],
       joinedAt: new Date(seatData.roomPlayer.joinedAt),
     };
-
-    room.players[currentSeatIndex] = restoredRoomPlayer;
 
     const state = gameState.getState();
     const gsIndex = state.players.findIndex(
@@ -84,37 +78,18 @@ export class SeatRestorationService {
               : seatData.gamePlayer.hand),
           ],
         }
-      : toDomainPlayer(restoredRoomPlayer);
+      : toDomainPlayer({
+          ...restoredRoomPlayer,
+          hand: state.players[gsIndex]?.hand ?? [],
+        });
 
-    if (gsIndex !== -1) {
-      state.players[gsIndex] = toDomainPlayer({
-        ...restoredGamePlayerBase,
-        seatId,
-        playerId: seatId,
-        name: restoredRoomPlayer.name,
-        team: restoredRoomPlayer.team,
-        hand: [...restoredRoomPlayer.hand],
-        isPasser:
-          restoredGamePlayerBase.isPasser ??
-          restoredRoomPlayer.isPasser ??
-          false,
-        hasBroken:
-          restoredGamePlayerBase.hasBroken ??
-          restoredRoomPlayer.hasBroken ??
-          false,
-        hasRequiredBroken:
-          restoredGamePlayerBase.hasRequiredBroken ??
-          restoredRoomPlayer.hasRequiredBroken ??
-          false,
-      });
-    } else {
-      state.players.push(restoredGamePlayerBase);
-    }
+    upsertRuntimeSeat(room, state, restoredRoomPlayer, {
+      replaceSeatId: comPlayerId,
+      gameplaySource: restoredGamePlayerBase,
+    });
 
     gameState.registerPlayerToken(seatId, seatId);
     gameState.clearDisconnectTimeout(seatId);
-    state.teamAssignments[seatId] = restoredRoomPlayer.team;
-
     delete vacantSeatsForRoom[seatIndex];
     if (Object.keys(vacantSeatsForRoom).length === 0) {
       delete vacantSeats[roomId];

--- a/mei-tra-backend/src/types/player-adapters.ts
+++ b/mei-tra-backend/src/types/player-adapters.ts
@@ -34,22 +34,19 @@ export function toDomainPlayer(
     | 'seatId'
     | 'playerId'
     | 'name'
-    | 'hand'
     | 'team'
-    | 'isPasser'
     | 'isCOM'
-    | 'hasBroken'
-    | 'hasRequiredBroken'
-  >,
+  > &
+    Partial<PlayerGameplayState>,
 ): DomainPlayer {
   const seatId = resolveSeatId(player);
   return {
     seatId,
     playerId: seatId,
     name: player.name,
-    hand: [...player.hand],
+    hand: [...(player.hand ?? [])],
     team: player.team,
-    isPasser: player.isPasser,
+    isPasser: player.isPasser ?? false,
     isCOM: player.isCOM,
     hasBroken: player.hasBroken ?? false,
     hasRequiredBroken: player.hasRequiredBroken ?? false,
@@ -189,12 +186,12 @@ export function toRoomPlayer(params: {
     name: params.gameplay.name,
     userId: params.session.userId,
     isAuthenticated: params.session.isAuthenticated,
-    hand: [...params.gameplay.hand],
+    hand: [],
     team: params.gameplay.team,
-    isPasser: params.gameplay.isPasser,
+    isPasser: false,
     isCOM: params.gameplay.isCOM,
-    hasBroken: params.gameplay.hasBroken ?? false,
-    hasRequiredBroken: params.gameplay.hasRequiredBroken ?? false,
+    hasBroken: false,
+    hasRequiredBroken: false,
     isReady: params.isReady,
     isHost: params.isHost,
     joinedAt: params.joinedAt,

--- a/mei-tra-backend/src/types/room-adapters.ts
+++ b/mei-tra-backend/src/types/room-adapters.ts
@@ -24,15 +24,12 @@ export function toRoomPlayerContract(
     isAuthenticated:
       transportPlayer?.isAuthenticated ?? roomPlayer.isAuthenticated,
     team: transportPlayer?.team ?? roomPlayer.team,
-    hand: transportPlayer?.hand ?? [...roomPlayer.hand],
+    hand: transportPlayer?.hand ?? [],
     isHost: roomPlayer.isHost,
-    isPasser: transportPlayer?.isPasser ?? roomPlayer.isPasser,
+    isPasser: transportPlayer?.isPasser ?? false,
     isCOM: transportPlayer?.isCOM ?? roomPlayer.isCOM,
-    hasBroken: transportPlayer?.hasBroken ?? roomPlayer.hasBroken ?? false,
-    hasRequiredBroken:
-      transportPlayer?.hasRequiredBroken ??
-      roomPlayer.hasRequiredBroken ??
-      false,
+    hasBroken: transportPlayer?.hasBroken ?? false,
+    hasRequiredBroken: transportPlayer?.hasRequiredBroken ?? false,
     isReady: roomPlayer.isReady,
     joinedAt: toIsoString(roomPlayer.joinedAt),
   };

--- a/mei-tra-backend/src/use-cases/start-game.use-case.ts
+++ b/mei-tra-backend/src/use-cases/start-game.use-case.ts
@@ -132,16 +132,6 @@ export class StartGameUseCase implements IStartGameUseCase {
       }
       updatedState.pointsToWin = room.settings.pointsToWin;
 
-      // Synchronize hands with room representation
-      roomWithFilledSeats.players.forEach((roomPlayer) => {
-        const statePlayer = updatedState.players.find(
-          (p) => p.playerId === roomPlayer.playerId,
-        );
-        if (statePlayer) {
-          roomPlayer.hand = [...statePlayer.hand];
-        }
-      });
-
       // Reset all players' isPasser flag at blow phase start
       updatedState.players.forEach((p) => {
         p.isPasser = false;
@@ -237,10 +227,6 @@ export class StartGameUseCase implements IStartGameUseCase {
         }
         return {
           ...toDomainPlayer(roomPlayer),
-          hand: [...roomPlayer.hand],
-          isPasser: roomPlayer.isPasser ?? false,
-          hasBroken: roomPlayer.hasBroken ?? false,
-          hasRequiredBroken: roomPlayer.hasRequiredBroken ?? false,
         };
       }
 


### PR DESCRIPTION
## Summary
- `room.players`を席・占有者の正本、`gameState.players`をゲーム進行投影として集約
- 人間/COM/再接続の更新を`upsertRuntimeSeat`へ統一
- `teamAssignments`をロスターから毎回再生成し、個別更新を廃止

## Dependency
- #205 の上に積んだPRです。#204 → #205 → 本PRの順にマージしてください。

## Validation
- `npm test -- --runInBand` (63 suites / 394 tests)
- `npm run build`
- changed TypeScript files: ESLint
- `git diff --check`

## User-facing change
画面仕様は変えず、人間・COM・再接続時の席状態更新を一つにまとめます。

## User benefit
退出や復帰の途中で名前・手札・チーム表示だけ古くなる不整合を防ぎます。