### PR TITLE
互換seat aliasをtransport境界へ隔離

### DIFF
--- a/contracts/game.ts
+++ b/contracts/game.ts
@@ -10,9 +10,7 @@ export type TrumpType = 'tra' | 'herz' | 'daiya' | 'club' | 'zuppe';
 
 export interface ConnectionUserContract {
   socketId: string;
-  seatId?: SeatId;
-  /** @deprecated Use seatId. This alias has the same value during migration. */
-  playerId: string;
+  seatId: SeatId;
   name: string;
   userId?: string;
   isAuthenticated?: boolean;
@@ -29,9 +27,7 @@ export interface PlayerContract extends ConnectionUserContract {
 }
 
 export interface BlowDeclarationContract {
-  seatId?: SeatId;
-  /** @deprecated Use seatId. */
-  playerId: string;
+  seatId: SeatId;
   team?: Team;
   trumpType: TrumpType;
   numberOfPairs: number;
@@ -40,9 +36,7 @@ export interface BlowDeclarationContract {
 
 export interface BlowActionContract {
   type: 'declare' | 'pass';
-  seatId?: SeatId;
-  /** @deprecated Use seatId. */
-  playerId: string;
+  seatId: SeatId;
   trumpType?: TrumpType;
   numberOfPairs?: number;
   timestamp: number;
@@ -53,35 +47,26 @@ export interface BlowStateContract {
   currentHighestDeclaration: BlowDeclarationContract | null;
   declarations: BlowDeclarationContract[];
   actionHistory: BlowActionContract[];
-  lastPasserSeatId?: SeatId | null;
-  /** @deprecated Use lastPasserSeatId. */
-  lastPasser: string | null;
+  lastPasserSeatId: SeatId | null;
   isRoundCancelled: boolean;
   currentBlowIndex: number;
 }
 
 export interface FieldContract {
   cards: string[];
-  playedBy: string[];
-  playedBySeatIds?: SeatId[];
+  playedBySeatIds: SeatId[];
   baseCard: string;
   baseSuit?: string;
-  dealerSeatId?: SeatId;
-  /** @deprecated Use dealerSeatId. */
-  dealerId: string;
+  dealerSeatId: SeatId;
   declaredSuit?: string;
   isComplete: boolean;
 }
 
 export interface CompletedFieldContract {
   cards: string[];
-  winnerSeatId?: SeatId;
-  /** @deprecated Use winnerSeatId. */
-  winnerId: string;
+  winnerSeatId: SeatId;
   winnerTeam: Team;
-  dealerSeatId?: SeatId;
-  /** @deprecated Use dealerSeatId. */
-  dealerId: string;
+  dealerSeatId: SeatId;
 }
 
 export interface TransportTeamScore {
@@ -97,25 +82,17 @@ export interface GameStatePayload {
   players: PlayerContract[];
   gamePhase: TransportGamePhase;
   currentField: FieldContract | null;
-  currentTurnSeatId?: SeatId | null;
-  /** @deprecated Use currentTurnSeatId. */
-  currentTurn: string | null;
+  currentTurnSeatId: SeatId | null;
   blowState: BlowStateContract;
   teamScores: TransportTeamScores;
-  youSeatId?: SeatId | null;
-  /** @deprecated Use youSeatId. */
-  you: string | null;
+  youSeatId: SeatId | null;
   isSpectator?: boolean;
   negriCard: string | null;
-  negriSeatId?: SeatId | null;
-  /** @deprecated Use negriSeatId. */
-  negriPlayerId?: string | null;
+  negriSeatId: SeatId | null;
   revealedAgari?: string | null;
   fields: CompletedFieldContract[];
   roomId: string;
-  hostSeatId?: SeatId;
-  /** @deprecated Use hostSeatId. */
-  hostId?: string;
+  hostSeatId: SeatId;
   pointsToWin: number;
   teamNames?: TeamNames;
 }
@@ -124,9 +101,7 @@ export interface BlowUpdatedPayload {
   declarations: BlowDeclarationContract[];
   actionHistory?: BlowActionContract[];
   currentHighest: BlowDeclarationContract | null;
-  lastPasserSeatId?: SeatId | null;
-  /** @deprecated Use lastPasserSeatId. */
-  lastPasser?: string | null;
+  lastPasserSeatId: SeatId | null;
 }
 
 export interface SyncGameStatePayload {
@@ -157,34 +132,24 @@ export interface RequestAgariPayload {
 export interface RevealAgariPayload {
   agari: string;
   message: string;
-  seatId?: SeatId;
-  /** @deprecated Use seatId. */
-  playerId: string;
+  seatId: SeatId;
 }
 
 export interface BrokenPayload {
-  nextSeatId?: SeatId;
-  /** @deprecated Use nextSeatId. */
-  nextPlayerId: string;
+  nextSeatId: SeatId;
   players: PlayerContract[];
   gamePhase?: TransportGamePhase;
 }
 
 export interface BlowStartedPayload {
-  startingSeatId?: SeatId;
-  /** @deprecated Use startingSeatId. */
-  startingPlayer: string;
+  startingSeatId: SeatId;
   players: PlayerContract[];
 }
 
 export interface FieldCompletePayload {
-  winnerSeatId?: SeatId;
-  /** @deprecated Use winnerSeatId. */
-  winnerId: string;
+  winnerSeatId: SeatId;
   field: CompletedFieldContract;
-  nextSeatId?: SeatId;
-  /** @deprecated Use nextSeatId. */
-  nextPlayerId: string;
+  nextSeatId: SeatId;
 }
 
 export interface PlayCardPayload {
@@ -193,18 +158,14 @@ export interface PlayCardPayload {
 }
 
 export interface CardPlayedPayload {
-  seatId?: SeatId;
-  /** @deprecated Use seatId. */
-  playerId: string;
+  seatId: SeatId;
   card: string;
   field: FieldContract;
   players: PlayerContract[];
   nextSeatId?: SeatId;
-  /** @deprecated Use nextSeatId. */
-  nextPlayerId?: string;
 }
 
-export type UpdateTurnPayload = string;
+export type UpdateTurnPayload = SeatId;
 
 export interface TurnAckPayload {
   roomId?: string;
@@ -215,9 +176,7 @@ export interface RoundResultsPayload {
 }
 
 export interface RoundCancelledPayload {
-  nextDealerSeatId?: SeatId;
-  /** @deprecated Use nextDealerSeatId. */
-  nextDealer: string;
+  nextDealerSeatId: SeatId;
   players: PlayerContract[];
   currentTrump?: TrumpType | null;
   currentHighestDeclaration?: BlowDeclarationContract | null;
@@ -227,16 +186,12 @@ export interface RoundCancelledPayload {
 
 export interface NewRoundStartedPayload {
   players: PlayerContract[];
-  currentTurnSeatId?: SeatId;
-  /** @deprecated Use currentTurnSeatId. */
-  currentTurn: string;
+  currentTurnSeatId: SeatId;
   gamePhase: TransportGamePhase;
   currentField: FieldContract | null;
   completedFields: CompletedFieldContract[];
   negriCard: string | null;
-  negriSeatId?: SeatId | null;
-  /** @deprecated Use negriSeatId. */
-  negriPlayerId: string | null;
+  negriSeatId: SeatId | null;
   revealedAgari: string | null;
   currentTrump: TrumpType | null;
   currentHighestDeclaration: BlowDeclarationContract | null;
@@ -261,9 +216,7 @@ export interface GameStartedPayload {
 
 export interface PlaySetupCompletePayload {
   negriCard: string;
-  startingSeatId?: SeatId;
-  /** @deprecated Use startingSeatId. */
-  startingPlayer: string;
+  startingSeatId: SeatId;
 }
 
 export interface GameMessagePayload {
@@ -271,28 +224,23 @@ export interface GameMessagePayload {
 }
 
 export interface PlayerLeftPayload {
-  seatId?: SeatId;
-  /** @deprecated Use seatId. */
-  playerId: string;
+  seatId: SeatId;
   roomId: string;
 }
 
 export interface PlayerConvertedToComPayload {
-  seatId?: SeatId;
-  /** @deprecated Use seatId. */
-  playerId: string;
+  seatId: SeatId;
   playerName: string;
   message: string;
 }
 
 export interface TurnPingPayload {
   roomId: string;
+  seatId: SeatId;
 }
 
 export interface PlayerIdlePayload {
   roomId: string;
-  seatId?: SeatId;
-  /** @deprecated Use seatId. */
-  playerId: string;
+  seatId: SeatId;
   idleMs?: number;
 }

--- a/contracts/room.ts
+++ b/contracts/room.ts
@@ -33,9 +33,7 @@ export interface UpdateTeamNamesPayload {
 export interface RoomContract {
   id: string;
   name: string;
-  hostSeatId?: SeatId;
-  /** @deprecated Use hostSeatId. */
-  hostId: string;
+  hostSeatId: SeatId;
   status: RoomStatusContract;
   players: RoomPlayerContract[];
   settings: RoomSettingsContract;
@@ -50,17 +48,13 @@ export interface RoomSyncPayload {
 }
 
 export interface RoomPlayerJoinedPayload {
-  seatId?: SeatId;
-  /** @deprecated Use seatId. */
-  playerId: string;
+  seatId: SeatId;
   roomId: string;
   isHost: boolean;
 }
 
 export interface GamePlayerJoinedPayload {
-  seatId?: SeatId;
-  /** @deprecated Use seatId. */
-  playerId: string;
+  seatId: SeatId;
   roomId: string;
   isHost: boolean;
   roomStatus?: RoomStatusContract;

--- a/contracts/socket.ts
+++ b/contracts/socket.ts
@@ -78,9 +78,7 @@ export interface ChangePlayerTeamPayload extends RoomActionPayload {
 
 export interface ModeratePlayerPayload {
   roomId: string;
-  targetSeatId?: SeatId;
-  /** @deprecated Use targetSeatId. */
-  targetPlayerId: string;
+  targetSeatId: SeatId;
   action: 'remove' | 'replace-with-com';
 }
 
@@ -108,9 +106,7 @@ export interface SelectBaseSuitPayload {
 
 export interface RevealBrokenHandPayload {
   roomId: string;
-  targetSeatId?: SeatId;
-  /** @deprecated Use targetSeatId. */
-  playerId: string;
+  targetSeatId: SeatId;
 }
 
 export interface UpdateAuthPayload {
@@ -126,8 +122,6 @@ export type NameUpdatedPayload =
       success: true;
       name: string;
       seatId?: SeatId;
-      /** @deprecated Use seatId. */
-      playerId?: string;
     }
   | {
       success: false;
@@ -259,6 +253,4 @@ export interface ServerToClientEvents {
 export interface SocketData {
   userId?: string;
   seatId?: SeatId;
-  /** @deprecated Use seatId. */
-  playerId?: string;
 }

--- a/mei-tra-backend/src/__tests__/game.gateway.com-recovery.spec.ts
+++ b/mei-tra-backend/src/__tests__/game.gateway.com-recovery.spec.ts
@@ -123,10 +123,8 @@ describe('GameGateway COM recovery integration', () => {
         roomsList: [],
         room: { id: 'room-1', players: [] },
         selfSeatId: 'user-1',
-        selfPlayerId: 'user-1',
         reconnectToken: 'user-1',
         currentTurnSeatId: 'com-1',
-        currentTurnPlayerId: 'com-1',
         gameState: { players: [], gamePhase: 'play' },
       }),
       getActiveGameSnapshot: jest.fn(),
@@ -273,9 +271,9 @@ describe('GameGateway COM recovery integration', () => {
     testGateway.reconnectionUseCase = {
       execute: jest.fn(),
       getActiveGameSnapshot: jest.fn().mockResolvedValue({
-        selfPlayerId: 'user-1',
+        selfSeatId: 'user-1',
         reconnectToken: 'player-1',
-        currentTurnPlayerId: 'player-2',
+        currentTurnSeatId: 'player-2',
         gameState,
       }),
     };

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -1537,13 +1537,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         return { success: false, error: errorMessage };
       }
 
-      const {
-        players,
-        pointsToWin,
-        updatePhase,
-        currentTurnSeatId,
-        currentTurnPlayerId,
-      } = result.data;
+      const { players, pointsToWin, updatePhase, currentTurnSeatId } =
+        result.data;
       const startGameEvents =
         await this.startGameGatewayEffectsService.buildEvents({
           roomId: data.roomId,
@@ -1551,7 +1546,6 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
           pointsToWin,
           updatePhase,
           currentTurnSeatId,
-          currentTurnPlayerId,
         });
 
       this.dispatchGameplayEvents(startGameEvents, playerId);
@@ -1728,7 +1722,6 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         agari: state.agari,
         message: 'Select a card from your hand as Negri',
         seatId: asSeatId(requesterPlayerId),
-        playerId: requesterPlayerId,
       };
       client.emit('reveal-agari', payload);
     } catch (error) {

--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
@@ -297,11 +297,12 @@ describe('SupabaseGameStateRepository', () => {
 
     const state = await repository.findByRoomId(gameStateRow.room_id);
 
-    expect(state?.currentPlayerId).toBe(secondSeatId);
-    expect(state?.currentPlayerIndex).toBe(1);
+    expect(state?.currentSeatId).toBe(secondSeatId);
+    expect(state?.currentPlayerId).toBeUndefined();
+    expect(state?.currentPlayerIndex).toBeUndefined();
   });
 
-  it('restores runtime aliases from canonical seat references', async () => {
+  it('restores canonical seat references', async () => {
     const secondRoomPlayer = {
       ...roomPlayerRow,
       id: secondSeatId,
@@ -374,18 +375,19 @@ describe('SupabaseGameStateRepository', () => {
 
     const state = await repository.findByRoomId(gameStateRow.room_id);
 
-    expect(state?.currentPlayerId).toBe(secondSeatId);
-    expect(state?.blowState.declarations[0]?.playerId).toBe(secondSeatId);
-    expect(state?.blowState.lastPasser).toBe(firstSeatId);
-    expect(state?.playState?.currentField?.playedBy).toEqual([firstSeatId]);
-    expect(state?.playState?.currentField?.dealerId).toBe(secondSeatId);
+    expect(state?.currentSeatId).toBe(secondSeatId);
+    expect(state?.blowState.declarations[0]?.seatId).toBe(secondSeatId);
+    expect(state?.blowState.lastPasserSeatId).toBe(firstSeatId);
+    expect(state?.playState?.currentField?.playedBySeatIds).toEqual([
+      firstSeatId,
+    ]);
+    expect(state?.playState?.currentField?.dealerSeatId).toBe(secondSeatId);
     expect(state?.playState?.negriSeatId).toBe(secondSeatId);
-    expect(state?.playState?.negriPlayerId).toBe(secondSeatId);
-    expect(state?.playState?.fields[0]?.winnerId).toBe(firstSeatId);
-    expect(state?.playState?.fields[0]?.dealerId).toBe(secondSeatId);
-    expect(state?.playState?.lastWinnerId).toBe(firstSeatId);
-    expect(state?.playState?.openDeclarerId).toBe(secondSeatId);
-    expect(state?.pendingBrokenHandReveal?.playerId).toBe(secondSeatId);
+    expect(state?.playState?.fields[0]?.winnerSeatId).toBe(firstSeatId);
+    expect(state?.playState?.fields[0]?.dealerSeatId).toBe(secondSeatId);
+    expect(state?.playState?.lastWinnerSeatId).toBe(firstSeatId);
+    expect(state?.playState?.openDeclarerSeatId).toBe(secondSeatId);
+    expect(state?.pendingBrokenHandReveal?.seatId).toBe(secondSeatId);
   });
 
   it('passes the expected version to atomic state updates', async () => {
@@ -421,7 +423,7 @@ describe('SupabaseGameStateRepository', () => {
     expect(state?.version).toBe(5);
   });
 
-  it('persists current player id with a derived index fallback', async () => {
+  it('persists the canonical current seat id', async () => {
     const order = jest.fn().mockResolvedValue({
       data: [roomPlayerRow],
       error: null,
@@ -441,7 +443,7 @@ describe('SupabaseGameStateRepository', () => {
 
     await repository.update(gameStateRow.room_id, {
       players: createState().players,
-      currentPlayerIndex: 0,
+      currentSeatId: firstSeatId,
     });
 
     expect(rpc).toHaveBeenCalledWith('atomic_update_game_state', {

--- a/mei-tra-backend/src/services/__tests__/com-strategy-inherited-declaration.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy-inherited-declaration.spec.ts
@@ -2,11 +2,15 @@ import { ComStrategyService } from '../com-strategy.service';
 import { IBlowService } from '../interfaces/blow-service.interface';
 import { ICardService } from '../interfaces/card-service.interface';
 import { IPlayService } from '../interfaces/play-service.interface';
-import { BlowDeclaration, DomainPlayer, GameState } from '../../types/game.types';
+import {
+  BlowDeclaration,
+  DomainPlayer,
+  GameState,
+} from '../../types/game.types';
 
 /**
  * A COM that replaces a human inherits that human's blow declaration — the
- * player-reference remap deliberately moves the bid to the seat.
+ * declaration remains attached to that stable seat.
  *
  * Both declare-blow and pass-blow reject a player who has already declared
  * (hasPlayerDeclaredInBlow), so such a seat has NO legal action. If the
@@ -18,7 +22,18 @@ const comPlayer = (over: Partial<DomainPlayer> = {}): DomainPlayer =>
   ({
     playerId: 'com-timeout-0-123',
     name: 'COM',
-    hand: ['A♠', 'K♠', 'Q♠', 'J♠', '10♠', '9♠', '8♠', '7♠', '6♠', '5♠'],
+    hand: [
+      'A♠',
+      'K♠',
+      'Q♠',
+      'J♠',
+      '10♠',
+      '9♠',
+      '8♠',
+      '7♠',
+      '6♠',
+      '5♠',
+    ],
     team: 0,
     isPasser: false,
     isCOM: true,

--- a/mei-tra-backend/src/services/__tests__/disconnect-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/disconnect-gateway-effects.service.spec.ts
@@ -209,7 +209,6 @@ describe('DisconnectGatewayEffectsService', () => {
       expect.objectContaining({
         payload: {
           seatId: 'player-1',
-          playerId: 'player-1',
           playerName: 'Host Display',
           roomId: 'room-1',
         },
@@ -487,8 +486,14 @@ describe('DisconnectGatewayEffectsService', () => {
       payload: {
         declarations: [],
         actionHistory: [],
-        currentHighest: blowState.currentHighestDeclaration,
-        lastPasser: null,
+        currentHighest: {
+          seatId: 'com-timeout',
+          team: undefined,
+          trumpType: 'herz',
+          numberOfPairs: 7,
+          timestamp: 1,
+        },
+        lastPasserSeatId: null,
       },
     });
   });

--- a/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
@@ -3,6 +3,7 @@ import { DomainPlayer } from '../../types/game.types';
 import { TransportPlayer } from '../../types/player-adapters';
 import { IRoomService } from '../interfaces/room-service.interface';
 import { JoinRoomGatewayEffectsService } from '../join-room-gateway-effects.service';
+import { asSeatId } from '../../types/identity.types';
 
 describe('JoinRoomGatewayEffectsService', () => {
   let service: JoinRoomGatewayEffectsService;
@@ -118,7 +119,7 @@ describe('JoinRoomGatewayEffectsService', () => {
           players.map(
             (player): TransportPlayer => ({
               socketId: player.playerId === 'player-1' ? 'socket-1' : '',
-              playerId: player.playerId,
+              seatId: asSeatId(player.playerId),
               name: player.name,
               hand: [...player.hand],
               team: player.team,
@@ -226,7 +227,7 @@ describe('JoinRoomGatewayEffectsService', () => {
           players.map(
             (player): TransportPlayer => ({
               socketId: player.playerId === 'player-1' ? 'socket-1' : '',
-              playerId: player.playerId,
+              seatId: asSeatId(player.playerId),
               name: player.name,
               hand: [...player.hand],
               team: player.team,
@@ -270,7 +271,7 @@ describe('JoinRoomGatewayEffectsService', () => {
             ],
             gamePhase: 'play',
             currentField: null,
-            currentTurn: 'player-1',
+            currentTurnSeatId: asSeatId('player-1'),
             blowState: {
               currentTrump: null,
               currentHighestDeclaration: {
@@ -306,7 +307,6 @@ describe('JoinRoomGatewayEffectsService', () => {
             },
             negriCard: null,
             negriSeatId: null,
-            negriPlayerId: null,
             fields: [],
             roomId: 'room-1',
             pointsToWin: 10,
@@ -328,7 +328,7 @@ describe('JoinRoomGatewayEffectsService', () => {
       payload: {
         declarations: [
           {
-            playerId: 'player-1',
+            seatId: 'player-1',
             trumpType: 'daiya',
             numberOfPairs: 6,
             timestamp: 1,
@@ -337,19 +337,19 @@ describe('JoinRoomGatewayEffectsService', () => {
         actionHistory: [
           {
             type: 'declare',
-            playerId: 'player-1',
+            seatId: 'player-1',
             trumpType: 'daiya',
             numberOfPairs: 6,
             timestamp: 1,
           },
         ],
         currentHighest: {
-          playerId: 'player-1',
+          seatId: 'player-1',
           trumpType: 'daiya',
           numberOfPairs: 6,
           timestamp: 1,
         },
-        lastPasser: null,
+        lastPasserSeatId: null,
       },
     });
     expect(result.events).toContainEqual({
@@ -431,7 +431,7 @@ describe('JoinRoomGatewayEffectsService', () => {
     expect(selfJoinedEvent).toMatchObject({
       socketId: 'socket-1',
       payload: {
-        playerId: 'actual-seat',
+        seatId: 'actual-seat',
         isSelf: true,
       },
     });
@@ -441,7 +441,7 @@ describe('JoinRoomGatewayEffectsService', () => {
     expect(roomPlayerJoinedEvent).toMatchObject({
       scope: 'room',
       roomId: 'room-1',
-      payload: { playerId: 'actual-seat' },
+      payload: { seatId: 'actual-seat' },
     });
   });
 
@@ -485,7 +485,7 @@ describe('JoinRoomGatewayEffectsService', () => {
           players.map(
             (player): TransportPlayer => ({
               socketId: player.playerId === 'actual-seat' ? 'socket-1' : '',
-              playerId: player.playerId,
+              seatId: asSeatId(player.playerId),
               name: player.name,
               hand: [...player.hand],
               team: player.team,
@@ -532,7 +532,7 @@ describe('JoinRoomGatewayEffectsService', () => {
             ],
             gamePhase: 'play',
             currentField: null,
-            currentTurn: 'actual-seat',
+            currentTurnSeatId: asSeatId('actual-seat'),
             blowState: {
               currentTrump: null,
               currentHighestDeclaration: null,
@@ -548,7 +548,6 @@ describe('JoinRoomGatewayEffectsService', () => {
             },
             negriCard: null,
             negriSeatId: null,
-            negriPlayerId: null,
             fields: [],
             roomId: 'room-1',
             pointsToWin: 10,
@@ -561,11 +560,11 @@ describe('JoinRoomGatewayEffectsService', () => {
       (event) => event.event === 'game-state',
     );
 
-    expect((gameStateEvent?.payload as any).you).toBe('actual-seat');
+    expect((gameStateEvent?.payload as any).youSeatId).toBe('actual-seat');
     expect((gameStateEvent?.payload as any).players).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ playerId: 'actual-seat', hand: ['A'] }),
-        expect.objectContaining({ playerId: 'other-seat', hand: [] }),
+        expect.objectContaining({ seatId: 'actual-seat', hand: ['A'] }),
+        expect.objectContaining({ seatId: 'other-seat', hand: [] }),
       ]),
     );
   });
@@ -723,13 +722,13 @@ describe('JoinRoomGatewayEffectsService', () => {
         players: [],
         gamePhase: 'play',
         currentField: null,
-        currentTurn: 'player-1',
+        currentTurnSeatId: asSeatId('player-1'),
         blowState: {
           currentTrump: null,
           currentHighestDeclaration: null,
           declarations: [],
           actionHistory: [],
-          lastPasser: null,
+          lastPasserSeatId: null,
           isRoundCancelled: false,
           currentBlowIndex: 0,
         },
@@ -737,10 +736,12 @@ describe('JoinRoomGatewayEffectsService', () => {
           0: { play: 0, total: 0 },
           1: { play: 0, total: 0 },
         },
-        you: 'player-1',
+        youSeatId: asSeatId('player-1'),
         negriCard: null,
+        negriSeatId: null,
         fields: [],
         roomId: 'room-1',
+        hostSeatId: asSeatId('player-1'),
         pointsToWin: 10,
       },
       reconnectToken: 'player-1',

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -4,10 +4,7 @@ import { IGameStateRepository } from '../../repositories/interfaces/game-state.r
 import { IRoomRepository } from '../../repositories/interfaces/room.repository.interface';
 import { IUserProfileRepository } from '../../repositories/interfaces/user-profile.repository.interface';
 import { GameStateFactory } from '../game-state.factory';
-import {
-  DomainPlayer,
-  GameState,
-} from '../../types/game.types';
+import { DomainPlayer, GameState } from '../../types/game.types';
 import { Room, RoomStatus, RoomPlayer } from '../../types/room.types';
 import { CardService } from '../card.service';
 import { ChomboService } from '../chombo.service';

--- a/mei-tra-backend/src/services/__tests__/room-update-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room-update-gateway-effects.service.spec.ts
@@ -1,6 +1,7 @@
 import { DomainPlayer } from '../../types/game.types';
 import { RoomStatus } from '../../types/room.types';
 import { TransportPlayer } from '../../types/player-adapters';
+import { asSeatId } from '../../types/identity.types';
 import { IRoomService } from '../interfaces/room-service.interface';
 import { RoomUpdateGatewayEffectsService } from '../room-update-gateway-effects.service';
 
@@ -34,7 +35,7 @@ describe('RoomUpdateGatewayEffectsService', () => {
             (players ?? []).map((player) => ({
               socketId:
                 player.playerId === 'player-1' ? 'socket-1' : 'socket-2',
-              playerId: player.playerId,
+              seatId: asSeatId(player.playerId),
               name: player.name,
               hand: [...player.hand],
               team: player.team,
@@ -84,14 +85,14 @@ describe('RoomUpdateGatewayEffectsService', () => {
       expect.objectContaining({
         id: room.id,
         name: room.name,
-        hostId: room.hostId,
+        hostSeatId: room.hostId,
         status: room.status,
         createdAt: room.createdAt.toISOString(),
         updatedAt: room.updatedAt.toISOString(),
         lastActivityAt: room.lastActivityAt.toISOString(),
         players: [
           expect.objectContaining({
-            playerId: 'player-1',
+            seatId: 'player-1',
             socketId: 'socket-1',
             isHost: true,
             isReady: true,
@@ -102,21 +103,22 @@ describe('RoomUpdateGatewayEffectsService', () => {
     );
     expect(roomView.players).toEqual([
       expect.objectContaining({
-        playerId: 'player-1',
+        seatId: 'player-1',
         socketId: 'socket-1',
         isHost: true,
       }),
     ]);
     expect(roomView.currentField).toEqual({
       cards: ['J♠'],
-      playedBy: ['com-player-1'],
+      playedBySeatIds: ['com-player-1'],
       baseCard: 'J♠',
-      dealerId: 'com-player-1',
+      dealerSeatId: 'com-player-1',
+      declaredSuit: undefined,
       isComplete: false,
     });
   });
 
-  it('emits the remapped field after the updated player roster', async () => {
+  it('emits the canonical field after the updated player roster', async () => {
     const currentField = {
       cards: ['J♠'],
       playedBy: ['com-player-1'],
@@ -171,7 +173,15 @@ describe('RoomUpdateGatewayEffectsService', () => {
       scope: 'room',
       roomId: 'room-1',
       event: 'field-updated',
-      payload: currentField,
+      payload: {
+        cards: ['J♠'],
+        playedBySeatIds: ['com-player-1'],
+        baseCard: 'J♠',
+        baseSuit: undefined,
+        dealerSeatId: 'com-player-1',
+        declaredSuit: undefined,
+        isComplete: false,
+      },
     });
   });
 });

--- a/mei-tra-backend/src/services/__tests__/spectator-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/spectator-gateway-effects.service.spec.ts
@@ -1,18 +1,19 @@
 import { Server, Socket } from 'socket.io';
 import { SpectatorGatewayEffectsService } from '../spectator-gateway-effects.service';
+import { asSeatId } from '../../types/identity.types';
 
 describe('SpectatorGatewayEffectsService', () => {
   const gameState = {
     players: [],
     gamePhase: 'play' as const,
     currentField: null,
-    currentTurn: null,
+    currentTurnSeatId: null,
     blowState: {
       currentTrump: null,
       currentHighestDeclaration: null,
       declarations: [],
       actionHistory: [],
-      lastPasser: null,
+      lastPasserSeatId: null,
       isRoundCancelled: false,
       currentBlowIndex: 0,
     },
@@ -20,11 +21,13 @@ describe('SpectatorGatewayEffectsService', () => {
       0: { play: 0, total: 0 },
       1: { play: 0, total: 0 },
     },
-    you: null,
+    youSeatId: null,
     isSpectator: true,
     negriCard: null,
+    negriSeatId: null,
     fields: [],
     roomId: 'room-1',
+    hostSeatId: asSeatId('player-1'),
     pointsToWin: 5,
   };
 

--- a/mei-tra-backend/src/services/__tests__/start-game-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/start-game-gateway-effects.service.spec.ts
@@ -110,7 +110,6 @@ describe('StartGameGatewayEffectsService', () => {
         winner: null,
       },
       currentTurnSeatId: 'player-1' as never,
-      currentTurnPlayerId: 'player-1',
     });
 
     expect(events).toEqual([

--- a/mei-tra-backend/src/services/__tests__/turn-monitor.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/turn-monitor.service.spec.ts
@@ -2,6 +2,7 @@ import { Server } from 'socket.io';
 import { TurnMonitorService } from '../turn-monitor.service';
 import { IRoomService } from '../interfaces/room-service.interface';
 import { RoomStatus } from '../../types/room.types';
+import { asSeatId } from '../../types/identity.types';
 
 describe('TurnMonitorService', () => {
   beforeEach(() => {
@@ -27,6 +28,7 @@ describe('TurnMonitorService', () => {
               name: 'Player 1',
             },
           ],
+          currentSeatId: asSeatId('p1'),
           currentPlayerIndex: 0,
           gamePhase: 'play',
         }),
@@ -49,7 +51,7 @@ describe('TurnMonitorService', () => {
     await service.acknowledge('room-1', 'socket-1', 'user-1');
 
     expect(emit).toHaveBeenCalledWith('player-idle-cleared', {
-      playerId: 'p1',
+      seatId: 'p1',
       roomId: 'room-1',
     });
   });
@@ -72,6 +74,7 @@ describe('TurnMonitorService', () => {
               name: 'Player 1',
             },
           ],
+          currentSeatId: asSeatId('p1'),
           currentPlayerIndex: 0,
           gamePhase: 'play',
         }),
@@ -115,6 +118,7 @@ describe('TurnMonitorService', () => {
               name: 'Player 1',
             },
           ],
+          currentSeatId: asSeatId('p1'),
           currentPlayerIndex: 0,
           gamePhase: 'play',
         }),

--- a/mei-tra-backend/src/services/com-session.service.ts
+++ b/mei-tra-backend/src/services/com-session.service.ts
@@ -62,10 +62,7 @@ export class ComSessionService {
 
   private createActiveCOMReplacement(
     index: number | string,
-    sourcePlayer: Pick<
-      RoomPlayer,
-      'seatId' | 'playerId' | 'team'
-    >,
+    sourcePlayer: Pick<RoomPlayer, 'seatId' | 'playerId' | 'team'>,
   ): RoomPlayer {
     return this.createCOMPlaceholder(
       index,

--- a/mei-tra-backend/src/services/disconnect-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/disconnect-gateway-effects.service.ts
@@ -7,6 +7,7 @@ import { RoomUpdateGatewayEffectsService } from './room-update-gateway-effects.s
 import { RoomMembershipService } from './room-membership.service';
 import { ActiveRoomMembership } from '../types/room-membership.types';
 import { asSeatId } from '../types/identity.types';
+import { toBlowUpdatedPayload } from '../types/game-contract-adapters';
 
 export type DisconnectTimeoutMode = 'convert-to-com' | 'remove-player';
 
@@ -217,7 +218,6 @@ export class DisconnectGatewayEffectsService {
           event: 'player-converted-to-com',
           payload: {
             seatId: asSeatId(playerId),
-            playerId,
             playerName,
             message: 'Player disconnected for too long - converted to COM',
           },
@@ -227,13 +227,7 @@ export class DisconnectGatewayEffectsService {
           scope: 'room',
           roomId,
           event: 'blow-updated',
-          payload: {
-            declarations: blowState.declarations,
-            actionHistory: blowState.actionHistory,
-            currentHighest: blowState.currentHighestDeclaration,
-            lastPasserSeatId: blowState.lastPasserSeatId,
-            lastPasser: blowState.lastPasser,
-          },
+          payload: toBlowUpdatedPayload(blowState),
         },
         this.roomUpdateGatewayEffectsService.buildRoomsListEvent({
           rooms: await this.roomService.listRooms(),
@@ -369,7 +363,6 @@ export class DisconnectGatewayEffectsService {
         event: 'player-left',
         payload: {
           seatId: asSeatId(player.playerId),
-          playerId: player.playerId,
           roomId,
         },
       },
@@ -379,7 +372,6 @@ export class DisconnectGatewayEffectsService {
         event: 'player-disconnected',
         payload: {
           seatId: asSeatId(player.playerId),
-          playerId: player.playerId,
           playerName,
           roomId,
         },

--- a/mei-tra-backend/src/services/game-state-manager.service.ts
+++ b/mei-tra-backend/src/services/game-state-manager.service.ts
@@ -13,10 +13,7 @@ export class GameStateManager {
     private readonly gamePhaseService: GamePhaseService,
   ) {}
 
-  applyState(
-    currentState: GameState,
-    newState: Partial<GameState>,
-  ): GameState {
+  applyState(currentState: GameState, newState: Partial<GameState>): GameState {
     if (Object.prototype.hasOwnProperty.call(newState, 'gamePhase')) {
       this.gamePhaseService.assertTransition(
         currentState.gamePhase,

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -658,7 +658,6 @@ export class GameStateService implements IGameStateService {
       isRoundCancelled: false,
       currentBlowIndex: firstBlowIndex,
     };
-
   }
 
   setDisconnectTimeout(playerId: string, timeout: NodeJS.Timeout): void {

--- a/mei-tra-backend/src/services/interfaces/game-event-log.service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/game-event-log.service.interface.ts
@@ -16,11 +16,7 @@ export interface LogGameEventInput {
   playerId?: string | null;
   state?: Pick<
     GameState,
-    | 'players'
-    | 'currentSeatId'
-    | 'gamePhase'
-    | 'roundNumber'
-    | 'teamScores'
+    'players' | 'currentSeatId' | 'gamePhase' | 'roundNumber' | 'teamScores'
   >;
   actionData?: Record<string, unknown>;
 }

--- a/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
@@ -1,8 +1,8 @@
-import type { GameStatePayload } from '@contracts/game';
 import type {
   GamePlayerJoinedPayload,
   RoomPlayerJoinedPayload,
 } from '@contracts/room';
+import type { GameStatePayload } from '@contracts/game';
 import type { SeatId } from '@contracts/ids';
 import { Inject, Injectable } from '@nestjs/common';
 import { GatewayEvent } from '../use-cases/interfaces/gateway-event.interface';
@@ -17,6 +17,12 @@ import { RoomPlayer, RoomStatus } from '../types/room.types';
 import { IRoomService } from './interfaces/room-service.interface';
 import { RoomUpdateGatewayEffectsService } from './room-update-gateway-effects.service';
 import { asSeatId } from '../types/identity.types';
+import {
+  toBlowStateContract,
+  toBlowUpdatedPayload,
+  toCompletedFieldContract,
+  toFieldContract,
+} from '../types/game-contract-adapters';
 
 interface BuildJoinRoomEffectsParams {
   clientId: string;
@@ -84,8 +90,6 @@ export class JoinRoomGatewayEffectsService {
           seatId: asSeatId(
             previousRoomNotification?.playerId ?? normalizedUser.playerId,
           ),
-          playerId:
-            previousRoomNotification?.playerId ?? normalizedUser.playerId,
           roomId: currentRoomId,
         },
       });
@@ -95,7 +99,6 @@ export class JoinRoomGatewayEffectsService {
 
     const roomPlayerJoinedPayload: RoomPlayerJoinedPayload = {
       seatId: asSeatId(selfPlayerId),
-      playerId: selfPlayerId,
       roomId,
       isHost: joinData.isHost,
     };
@@ -109,7 +112,6 @@ export class JoinRoomGatewayEffectsService {
 
     const selfJoinedPayload: GamePlayerJoinedPayload = {
       seatId: asSeatId(selfPlayerId),
-      playerId: selfPlayerId,
       roomId,
       isHost: joinData.isHost,
       roomStatus: joinData.roomStatus,
@@ -126,7 +128,6 @@ export class JoinRoomGatewayEffectsService {
 
     const otherJoinedPayload: GamePlayerJoinedPayload = {
       seatId: asSeatId(selfPlayerId),
-      playerId: selfPlayerId,
       roomId,
       isHost: joinData.isHost,
       roomStatus: joinData.roomStatus,
@@ -149,7 +150,6 @@ export class JoinRoomGatewayEffectsService {
 
         const existingPlayerJoinedPayload: GamePlayerJoinedPayload = {
           seatId: asSeatId(existingPlayer.playerId),
-          playerId: existingPlayer.playerId,
           roomId,
           isHost: existingPlayer.isHost,
           roomStatus: joinData.roomStatus,
@@ -206,12 +206,15 @@ export class JoinRoomGatewayEffectsService {
       );
       const maskedGameStateForJoiner: GameStatePayload = {
         ...joinData.resumeGame.gameState,
-        currentTurnSeatId: joinData.resumeGame.gameState.currentTurn
-          ? asSeatId(joinData.resumeGame.gameState.currentTurn)
+        currentTurnSeatId:
+          joinData.resumeGame.gameState.currentTurnSeatId ?? null,
+        currentField: joinData.resumeGame.gameState.currentField
+          ? toFieldContract(joinData.resumeGame.gameState.currentField)
           : null,
-        currentField: joinData.resumeGame.gameState.currentField ?? null,
         negriCard: joinData.resumeGame.gameState.negriCard ?? null,
-        fields: joinData.resumeGame.gameState.fields ?? [],
+        fields: (joinData.resumeGame.gameState.fields ?? []).map(
+          toCompletedFieldContract,
+        ),
         players: resolveTransportPlayers(
           roomGameState,
           joinData.resumeGame.gameState.players,
@@ -220,12 +223,12 @@ export class JoinRoomGatewayEffectsService {
           },
         ).map((player) => ({
           ...player,
-          hand: player.playerId === resumeSelfPlayerId ? player.hand : [],
+          hand:
+            player.seatId === asSeatId(resumeSelfPlayerId) ? player.hand : [],
         })),
+        blowState: toBlowStateContract(joinData.resumeGame.gameState.blowState),
         youSeatId: resumeSelfPlayerId ? asSeatId(resumeSelfPlayerId) : null,
-        you: resumeSelfPlayerId,
         hostSeatId: asSeatId(room.hostId),
-        hostId: room.hostId,
       };
 
       events.push({
@@ -259,20 +262,14 @@ export class JoinRoomGatewayEffectsService {
         scope: 'room',
         roomId,
         event: 'blow-updated',
-        payload: {
-          declarations: joinData.resumeGame.gameState.blowState.declarations,
-          actionHistory: joinData.resumeGame.gameState.blowState.actionHistory,
-          currentHighest:
-            joinData.resumeGame.gameState.blowState.currentHighestDeclaration,
-          lastPasser: joinData.resumeGame.gameState.blowState.lastPasser,
-        },
+        payload: toBlowUpdatedPayload(joinData.resumeGame.gameState.blowState),
       });
-      if (joinData.resumeGame.gameState.currentTurn) {
+      if (joinData.resumeGame.gameState.currentTurnSeatId) {
         events.push({
           scope: 'room',
           roomId,
           event: 'update-turn',
-          payload: joinData.resumeGame.gameState.currentTurn,
+          payload: joinData.resumeGame.gameState.currentTurnSeatId,
         });
       }
     }
@@ -341,7 +338,6 @@ export class JoinRoomGatewayEffectsService {
       event: 'game-player-joined',
       payload: {
         seatId: selfPlayer.seatId,
-        playerId: selfPlayer.playerId,
         roomId: room.id,
         isHost,
         roomStatus,

--- a/mei-tra-backend/src/services/room-update-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/room-update-gateway-effects.service.ts
@@ -7,6 +7,7 @@ import { DomainPlayer } from '../types/game.types';
 import { Room } from '../types/room.types';
 import { TransportPlayer } from '../types/player-adapters';
 import { toRoomContract, toRoomContracts } from '../types/room-adapters';
+import { toFieldContract } from '../types/game-contract-adapters';
 import { IRoomService } from './interfaces/room-service.interface';
 
 interface RoomUpdateGatewayView {
@@ -58,11 +59,7 @@ export class RoomUpdateGatewayEffectsService {
       room: toRoomContract(room, { players }),
       currentField:
         state.gamePhase === 'play' && state.playState?.currentField
-          ? {
-              ...state.playState.currentField,
-              cards: [...state.playState.currentField.cards],
-              playedBy: [...state.playState.currentField.playedBy],
-            }
+          ? toFieldContract(state.playState.currentField)
           : null,
     };
   }

--- a/mei-tra-backend/src/services/start-game-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/start-game-gateway-effects.service.ts
@@ -16,8 +16,6 @@ interface BuildStartGameEventsParams {
   pointsToWin: number;
   updatePhase: UpdatePhasePayload;
   currentTurnSeatId: SeatId;
-  /** @deprecated Use currentTurnSeatId. */
-  currentTurnPlayerId: string;
 }
 
 @Injectable()
@@ -33,7 +31,6 @@ export class StartGameGatewayEffectsService {
     pointsToWin,
     updatePhase,
     currentTurnSeatId,
-    currentTurnPlayerId,
   }: BuildStartGameEventsParams): Promise<GatewayEvent[]> {
     const room = await this.roomService.getRoom(roomId);
     const roomGameState = await this.roomService.getRoomGameState(roomId);
@@ -89,7 +86,7 @@ export class StartGameGatewayEffectsService {
         scope: 'room',
         roomId,
         event: 'update-turn',
-        payload: currentTurnSeatId ?? currentTurnPlayerId,
+        payload: currentTurnSeatId,
       },
     ];
   }

--- a/mei-tra-backend/src/services/turn-monitor.service.ts
+++ b/mei-tra-backend/src/services/turn-monitor.service.ts
@@ -3,6 +3,7 @@ import { Server } from 'socket.io';
 import { IRoomService } from './interfaces/room-service.interface';
 import { RoomStatus } from '../types/room.types';
 import { resolveCurrentPlayer } from '../types/current-turn';
+import { asSeatId } from '../types/identity.types';
 
 const TURN_ACK_PING_INTERVAL_MS = 15 * 1000;
 const TURN_IDLE_WARNING_MS = 45 * 1000;
@@ -92,7 +93,7 @@ export class TurnMonitorService implements OnModuleDestroy {
     const emitPing = () => {
       server.to(currentPlayerConnection.socketId).emit('turn-ping', {
         roomId,
-        playerId,
+        seatId: asSeatId(playerId),
       });
     };
 
@@ -117,7 +118,7 @@ export class TurnMonitorService implements OnModuleDestroy {
           if (!monitor.idleEmitted && silenceMs >= TURN_IDLE_WARNING_MS) {
             monitor.idleEmitted = true;
             server.to(roomId).emit('player-idle', {
-              playerId,
+              seatId: asSeatId(playerId),
               playerName: monitor.playerName,
               roomId,
             });
@@ -180,7 +181,7 @@ export class TurnMonitorService implements OnModuleDestroy {
     if (monitor.idleEmitted) {
       monitor.idleEmitted = false;
       monitor.server.to(roomId).emit('player-idle-cleared', {
-        playerId: monitor.playerId,
+        seatId: asSeatId(monitor.playerId),
         roomId,
       });
     }

--- a/mei-tra-backend/src/types/current-turn.ts
+++ b/mei-tra-backend/src/types/current-turn.ts
@@ -7,14 +7,10 @@ function playerSeatId(player: DomainPlayer): SeatId {
   return player.seatId ?? asSeatId(player.playerId);
 }
 
-export function resolveCurrentSeatId(
-  state: CurrentTurnState,
-): SeatId | null {
+export function resolveCurrentSeatId(state: CurrentTurnState): SeatId | null {
   if (
     state.currentSeatId &&
-    state.players.some(
-      (player) => playerSeatId(player) === state.currentSeatId,
-    )
+    state.players.some((player) => playerSeatId(player) === state.currentSeatId)
   ) {
     return state.currentSeatId;
   }

--- a/mei-tra-backend/src/types/game-contract-adapters.ts
+++ b/mei-tra-backend/src/types/game-contract-adapters.ts
@@ -1,0 +1,87 @@
+import type {
+  BlowActionContract,
+  BlowDeclarationContract,
+  BlowStateContract,
+  BlowUpdatedPayload,
+  CompletedFieldContract,
+  FieldContract,
+} from '@contracts/game';
+import type {
+  BlowAction,
+  BlowDeclaration,
+  BlowState,
+  CompletedField,
+  Field,
+} from './game.types';
+import { asSeatId } from './identity.types';
+
+export function toBlowDeclarationContract(
+  declaration: BlowDeclaration,
+): BlowDeclarationContract {
+  return {
+    seatId: declaration.seatId ?? asSeatId(declaration.playerId),
+    team: declaration.team,
+    trumpType: declaration.trumpType,
+    numberOfPairs: declaration.numberOfPairs,
+    timestamp: declaration.timestamp,
+  };
+}
+
+export function toBlowActionContract(action: BlowAction): BlowActionContract {
+  return {
+    type: action.type,
+    seatId: action.seatId ?? asSeatId(action.playerId),
+    trumpType: action.trumpType,
+    numberOfPairs: action.numberOfPairs,
+    timestamp: action.timestamp,
+  };
+}
+
+export function toBlowStateContract(state: BlowState): BlowStateContract {
+  return {
+    currentTrump: state.currentTrump,
+    currentHighestDeclaration: state.currentHighestDeclaration
+      ? toBlowDeclarationContract(state.currentHighestDeclaration)
+      : null,
+    declarations: state.declarations.map(toBlowDeclarationContract),
+    actionHistory: state.actionHistory.map(toBlowActionContract),
+    lastPasserSeatId:
+      state.lastPasserSeatId ??
+      (state.lastPasser ? asSeatId(state.lastPasser) : null),
+    isRoundCancelled: state.isRoundCancelled,
+    currentBlowIndex: state.currentBlowIndex,
+  };
+}
+
+export function toBlowUpdatedPayload(state: BlowState): BlowUpdatedPayload {
+  const contract = toBlowStateContract(state);
+  return {
+    declarations: contract.declarations,
+    actionHistory: contract.actionHistory,
+    currentHighest: contract.currentHighestDeclaration,
+    lastPasserSeatId: contract.lastPasserSeatId,
+  };
+}
+
+export function toFieldContract(field: Field): FieldContract {
+  return {
+    cards: [...field.cards],
+    playedBySeatIds: (field.playedBySeatIds ?? field.playedBy).map(asSeatId),
+    baseCard: field.baseCard,
+    baseSuit: field.baseSuit,
+    dealerSeatId: field.dealerSeatId ?? asSeatId(field.dealerId),
+    declaredSuit: field.declaredSuit,
+    isComplete: field.isComplete,
+  };
+}
+
+export function toCompletedFieldContract(
+  field: CompletedField,
+): CompletedFieldContract {
+  return {
+    cards: [...field.cards],
+    winnerSeatId: field.winnerSeatId ?? asSeatId(field.winnerId),
+    winnerTeam: field.winnerTeam,
+    dealerSeatId: field.dealerSeatId ?? asSeatId(field.dealerId),
+  };
+}

--- a/mei-tra-backend/src/types/player-adapters.spec.ts
+++ b/mei-tra-backend/src/types/player-adapters.spec.ts
@@ -100,7 +100,7 @@ describe('player-adapters', () => {
 
       expect(player).toEqual(
         expect.objectContaining({
-          playerId: 'seat-1',
+          seatId: 'seat-1',
           name: 'COM',
           socketId: '',
           userId: undefined,

--- a/mei-tra-backend/src/types/player-adapters.ts
+++ b/mei-tra-backend/src/types/player-adapters.ts
@@ -6,6 +6,7 @@ import {
 import { RoomPlayer } from './room.types';
 import { SessionUser } from './session.types';
 import { asSeatId, resolveSeatId } from './identity.types';
+import type { PlayerContract } from '@contracts/game';
 
 export type PersistedGamePlayer = DomainPlayer & {
   id?: string;
@@ -23,19 +24,12 @@ export type PersistedPlayerStates = Record<
   PersistedPlayerGameplayState
 >;
 
-export type TransportPlayer = DomainPlayer &
-  PlayerConnectionMetadata & {
-    isHost?: boolean;
-  };
+export type TransportPlayer = PlayerContract;
 
 export function toDomainPlayer(
   player: Pick<
     RoomPlayer | DomainPlayer,
-    | 'seatId'
-    | 'playerId'
-    | 'name'
-    | 'team'
-    | 'isCOM'
+    'seatId' | 'playerId' | 'name' | 'team' | 'isCOM'
   > &
     Partial<PlayerGameplayState>,
 ): DomainPlayer {
@@ -57,8 +51,16 @@ export function withConnectionMetadata(
   player: DomainPlayer,
   connection?: Partial<PlayerConnectionMetadata>,
 ): TransportPlayer {
+  const domainPlayer = toDomainPlayer(player);
   return {
-    ...toDomainPlayer(player),
+    seatId: resolveSeatId(domainPlayer),
+    name: domainPlayer.name,
+    hand: [...domainPlayer.hand],
+    team: domainPlayer.team,
+    isPasser: domainPlayer.isPasser,
+    isCOM: domainPlayer.isCOM,
+    hasBroken: domainPlayer.hasBroken,
+    hasRequiredBroken: domainPlayer.hasRequiredBroken,
     socketId: connection?.socketId ?? '',
     userId: connection?.userId,
     isAuthenticated: connection?.isAuthenticated,

--- a/mei-tra-backend/src/types/room-adapters.ts
+++ b/mei-tra-backend/src/types/room-adapters.ts
@@ -18,7 +18,6 @@ export function toRoomPlayerContract(
   return {
     socketId: transportPlayer?.socketId ?? roomPlayer.socketId,
     seatId: resolveSeatId(roomPlayer),
-    playerId: roomPlayer.playerId,
     name: transportPlayer?.name ?? roomPlayer.name,
     userId: transportPlayer?.userId ?? roomPlayer.userId,
     isAuthenticated:
@@ -40,19 +39,18 @@ export function toRoomContract(
   options?: { players?: TransportPlayer[] },
 ): RoomContract {
   const transportPlayersById = new Map(
-    (options?.players ?? []).map((player) => [player.playerId, player]),
+    (options?.players ?? []).map((player) => [player.seatId, player]),
   );
 
   return {
     id: room.id,
     name: room.name,
     hostSeatId: room.hostSeatId ?? resolveSeatId({ playerId: room.hostId }),
-    hostId: room.hostId,
     status: room.status,
     players: room.players.map((roomPlayer) =>
       toRoomPlayerContract(
         roomPlayer,
-        transportPlayersById.get(roomPlayer.playerId),
+        transportPlayersById.get(resolveSeatId(roomPlayer)),
       ),
     ),
     settings: {

--- a/mei-tra-backend/src/use-cases/__tests__/blow-phase-transition.helper.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/blow-phase-transition.helper.spec.ts
@@ -137,7 +137,7 @@ describe('transitionToPlayPhase', () => {
       event: 'reveal-agari',
       payload: {
         agari: 'H-A',
-        playerId: 'player-1',
+        seatId: 'player-1',
       },
     });
     const updatePhaseEvent = result.delayedEvents.find(

--- a/mei-tra-backend/src/use-cases/__tests__/game-event-instrumentation.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game-event-instrumentation.spec.ts
@@ -5,6 +5,7 @@ import { IRoomService } from '../../services/interfaces/room-service.interface';
 import { IGameEventLogService } from '../../services/interfaces/game-event-log.service.interface';
 import { CardService } from '../../services/card.service';
 import { PlayService } from '../../services/play.service';
+import { asSeatId } from '../../types/identity.types';
 
 describe('Game event instrumentation', () => {
   it('logs game_started when a game begins', async () => {
@@ -36,12 +37,14 @@ describe('Game event instrumentation', () => {
             },
           ],
           teamScores: { 0: { play: 0, total: 0 }, 1: { play: 0, total: 0 } },
+          currentSeatId: asSeatId('host-1'),
           currentPlayerIndex: 0,
           gamePhase: 'blow',
           roundNumber: 1,
           blowState: { currentBlowIndex: 0 },
         }),
         startGame: jest.fn().mockResolvedValue(undefined),
+        saveState: jest.fn().mockResolvedValue(undefined),
         persistRoster: jest.fn().mockResolvedValue(undefined),
         registerPlayerToken: jest.fn(),
       }),

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -491,7 +491,7 @@ describe('Game Use Cases', () => {
       expect(result.success).toBe(true);
       expect(result.data?.updatedPlayers).toEqual([
         expect.objectContaining({
-          playerId: 'player-2',
+          seatId: 'player-2',
           socketId: 'socket-2',
           name: 'Player 2',
           team: 1,
@@ -592,19 +592,19 @@ describe('Game Use Cases', () => {
       expect(result.success).toBe(true);
       expect(result.data?.updatedPlayers).toEqual([
         expect.objectContaining({
-          playerId: 'com-0',
+          seatId: 'com-0',
           socketId: 'com-0',
           isHost: false,
         }),
         expect.objectContaining({
-          playerId: 'player-2',
+          seatId: 'player-2',
           socketId: 'socket-2',
           isHost: true,
         }),
       ]);
       expect(result.data?.updatedPlayers).toContainEqual(
         expect.objectContaining({
-          playerId: 'player-2',
+          seatId: 'player-2',
           isHost: true,
         }),
       );
@@ -698,11 +698,11 @@ describe('Game Use Cases', () => {
       expect(result.success).toBe(true);
       expect(result.data?.updatedPlayers).toEqual([
         expect.objectContaining({
-          playerId: expect.stringContaining('com-'),
+          seatId: expect.stringContaining('com-'),
           team: 0,
         }),
         expect.objectContaining({
-          playerId: 'player-2',
+          seatId: 'player-2',
           socketId: 'socket-2',
           team: 1,
         }),
@@ -800,7 +800,7 @@ describe('Game Use Cases', () => {
 
       expect(result.success).toBe(true);
       expect(result.data?.players.length).toBe(2);
-      expect(result.data?.currentTurnPlayerId).toBe('player-1');
+      expect(result.data?.currentTurnSeatId).toBe('player-1');
 
       const updateRoomStatusMock = roomService.updateRoomStatus as jest.Mock;
       expect(updateRoomStatusMock).toHaveBeenCalledWith(
@@ -877,7 +877,7 @@ describe('Game Use Cases', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(result.data?.currentTurnPlayerId).toBe('player-2');
+      expect(result.data?.currentTurnSeatId).toBe('player-2');
       expect(state.blowState.currentBlowIndex).toBe(1);
       expect(roomGameState.updateState).toHaveBeenCalledWith({
         currentSeatId: 'player-2',
@@ -1700,8 +1700,7 @@ describe('Game Use Cases', () => {
                 null),
         ),
         isPlayerTurn: jest.fn(
-          (playerId: string) =>
-            state.currentSeatId === asSeatId(playerId),
+          (playerId: string) => state.currentSeatId === asSeatId(playerId),
         ),
       } as unknown as GameStateService;
 
@@ -1718,14 +1717,14 @@ describe('Game Use Cases', () => {
         (evt) => evt.event === 'card-played',
       );
       expect(cardPlayedEvent?.payload).toMatchObject({
-        playerId: 'player-1',
+        seatId: 'player-1',
         card: 'C1',
         field: expect.objectContaining({
           cards: ['C1'],
-          playedBy: ['player-1'],
+          playedBySeatIds: ['player-1'],
         }),
         players: expect.any(Array),
-        nextPlayerId: 'player-2',
+        nextSeatId: 'player-2',
       });
       const updateTurnEvent = result.events?.find(
         (evt) => evt.event === 'update-turn',
@@ -1832,8 +1831,7 @@ describe('Game Use Cases', () => {
               null),
         ),
         isPlayerTurn: jest.fn(
-          (playerId: string) =>
-            state.currentSeatId === asSeatId(playerId),
+          (playerId: string) => state.currentSeatId === asSeatId(playerId),
         ),
       } as unknown as GameStateService;
 
@@ -1928,7 +1926,7 @@ describe('Game Use Cases', () => {
       expect(cardPlayedEvent?.payload).toMatchObject({
         players: expect.arrayContaining([
           expect.objectContaining({
-            playerId: 'player-2',
+            seatId: 'player-2',
             name: 'COM',
             socketId: '',
             isCOM: true,
@@ -2332,7 +2330,7 @@ describe('Game Use Cases', () => {
             event: 'play-setup-complete',
             payload: {
               negriCard: '6♥',
-              startingPlayer: 'com-timeout-1',
+              startingSeatId: 'com-timeout-1',
             },
           },
         ],
@@ -2358,7 +2356,7 @@ describe('Game Use Cases', () => {
           event: 'play-setup-complete',
           payload: {
             negriCard: '6♥',
-            startingPlayer: 'com-timeout-1',
+            startingSeatId: 'com-timeout-1',
           },
         },
       ]);
@@ -2636,7 +2634,7 @@ describe('Game Use Cases', () => {
             event: 'play-setup-complete',
             payload: expect.objectContaining({
               negriCard: '6♥',
-              startingPlayer: 'com-timeout-1',
+              startingSeatId: 'com-timeout-1',
             }),
           }),
         ]),
@@ -3123,14 +3121,14 @@ describe('Game Use Cases', () => {
         declarations: [],
         actionHistory: [],
         currentHighest: null,
-        lastPasser: null,
+        lastPasserSeatId: null,
       });
 
       const brokenEvent = completion.events?.find(
         (evt) => evt.event === 'broken',
       );
       expect(brokenEvent?.payload).toMatchObject({
-        nextPlayerId: 'player-3',
+        nextSeatId: 'player-3',
         gamePhase: 'blow',
       });
 
@@ -3643,10 +3641,11 @@ describe('Game Use Cases', () => {
       ).toEqual(
         expect.objectContaining({
           field: expect.objectContaining({
-            winnerId: 'player-3',
+            winnerSeatId: 'player-3',
             winnerTeam: 0,
           }),
-          winnerId: 'player-3',
+          winnerSeatId: 'player-3',
+          nextSeatId: 'player-3',
         }),
       );
       expect(scoreService.calculatePlayPoints).toHaveBeenCalledWith(6, 0);

--- a/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
@@ -4,6 +4,7 @@ import { IGameStateService } from '../../services/interfaces/game-state-service.
 import { RoomStatus } from '../../types/room.types';
 import { UserProfile } from '../../types/user.types';
 import { RoomMembershipService } from '../../services/room-membership.service';
+import { asSeatId } from '../../types/identity.types';
 
 const createRoomMembershipService = (): RoomMembershipService =>
   ({
@@ -334,7 +335,7 @@ describe('ReconnectionUseCase', () => {
       expect.objectContaining({
         success: true,
         mode: 'active-game',
-        selfPlayerId: 'seat-1',
+        selfSeatId: 'seat-1',
       }),
     );
     if (!result.success || result.mode !== 'active-game') {
@@ -376,6 +377,7 @@ describe('ReconnectionUseCase', () => {
           },
         ],
         gamePhase: 'play',
+        currentSeatId: asSeatId('player-2'),
         currentPlayerIndex: 1,
         blowState: {
           declarations: [],
@@ -465,16 +467,15 @@ describe('ReconnectionUseCase', () => {
       },
     });
 
-    expect(snapshot?.selfPlayerId).toBe('seat-1');
     expect(snapshot?.reconnectToken).toBe('seat-1');
-    expect(snapshot?.currentTurnPlayerId).toBe('player-2');
-    expect(snapshot?.gameState.currentTurn).toBe('player-2');
-    expect(snapshot?.gameState.you).toBe('seat-1');
+    expect(snapshot?.currentTurnSeatId).toBe('player-2');
+    expect(snapshot?.gameState.currentTurnSeatId).toBe('player-2');
+    expect(snapshot?.gameState.youSeatId).toBe('seat-1');
     expect(snapshot?.gameState.revealedAgari).toBe('J♠');
     expect(snapshot?.gameState.players).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ playerId: 'seat-1', hand: ['A♠'] }),
-        expect.objectContaining({ playerId: 'player-2', hand: [] }),
+        expect.objectContaining({ seatId: 'seat-1', hand: ['A♠'] }),
+        expect.objectContaining({ seatId: 'player-2', hand: [] }),
       ]),
     );
     expect(roomService.handlePlayerReconnection).not.toHaveBeenCalled();
@@ -482,7 +483,7 @@ describe('ReconnectionUseCase', () => {
     expect(gameState.upsertSessionUser).not.toHaveBeenCalled();
   });
 
-  it('prefers currentPlayerId over a stale currentPlayerIndex in active snapshots', async () => {
+  it('uses currentSeatId and ignores stale legacy turn fields', async () => {
     const roomGameState = {
       findPlayerByActorId: jest.fn().mockReturnValue(null),
       getState: () => ({
@@ -507,6 +508,7 @@ describe('ReconnectionUseCase', () => {
           },
         ],
         gamePhase: 'blow',
+        currentSeatId: asSeatId('seat-1'),
         currentPlayerId: 'seat-1',
         currentPlayerIndex: 1,
         blowState: {
@@ -575,8 +577,8 @@ describe('ReconnectionUseCase', () => {
       },
     });
 
-    expect(snapshot?.currentTurnPlayerId).toBe('seat-1');
-    expect(snapshot?.gameState.currentTurn).toBe('seat-1');
+    expect(snapshot?.currentTurnSeatId).toBe('seat-1');
+    expect(snapshot?.gameState.currentTurnSeatId).toBe('seat-1');
   });
 
   it('reconciles persisted players before reconnecting to a waiting room', async () => {
@@ -686,7 +688,7 @@ describe('ReconnectionUseCase', () => {
       expect.objectContaining({
         success: true,
         mode: 'waiting-room',
-        selfPlayerId: 'p1',
+        selfSeatId: 'p1',
       }),
     );
   });
@@ -763,7 +765,7 @@ describe('ReconnectionUseCase', () => {
       expect.objectContaining({
         success: true,
         mode: 'waiting-room',
-        selfPlayerId: 'seat-1',
+        selfSeatId: 'seat-1',
       }),
     );
     expect(roomService.handlePlayerReconnection).toHaveBeenCalledWith(

--- a/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
@@ -6,7 +6,6 @@ import { AuthenticatedUser } from '../../types/user.types';
 import { Room, RoomStatus } from '../../types/room.types';
 import { GameStateService } from '../../services/game-state.service';
 import { PlayerConnectionState, SessionUser } from '../../types/session.types';
-import { TransportPlayer } from '../../types/player-adapters';
 
 describe('UpdateAuthUseCase', () => {
   const createAuthServiceMock = () =>
@@ -78,7 +77,7 @@ describe('UpdateAuthUseCase', () => {
           hand: [],
           team: 0,
           isPasser: false,
-        } as TransportPlayer,
+        },
       ],
     };
     const roomGameState = {
@@ -102,9 +101,10 @@ describe('UpdateAuthUseCase', () => {
         .mockImplementation(
           async (_playerId: string, connectionState: PlayerConnectionState) => {
             roomState.players[0].socketId = connectionState.socketId;
-            roomState.players[0].userId = connectionState.userId;
-            roomState.players[0].isAuthenticated =
-              connectionState.isAuthenticated;
+            roomState.players[0].userId = connectionState.userId ?? '';
+            roomState.players[0].isAuthenticated = Boolean(
+              connectionState.isAuthenticated,
+            );
           },
         ),
       saveState: jest.fn().mockResolvedValue(undefined),
@@ -192,7 +192,7 @@ describe('UpdateAuthUseCase', () => {
         payload: [
           expect.objectContaining({
             socketId: 'socket-1',
-            playerId: 'player-1',
+            seatId: 'player-1',
             name: 'User Display',
             userId: 'user-1',
             isAuthenticated: true,
@@ -207,7 +207,7 @@ describe('UpdateAuthUseCase', () => {
     expect(roomUpdatedEvent).toBeDefined();
     expect(roomUpdatedEvent?.payload).toMatchObject({
       id: updatedRoom.id,
-      hostId: updatedRoom.hostId,
+      hostSeatId: updatedRoom.hostId,
       name: updatedRoom.name,
       status: updatedRoom.status,
     });
@@ -218,12 +218,12 @@ describe('UpdateAuthUseCase', () => {
     expect(roomSyncEvent?.payload).toMatchObject({
       room: {
         id: 'room-1',
-        hostId: 'player-1',
+        hostSeatId: 'player-1',
       },
       players: [
         {
           socketId: 'socket-1',
-          playerId: 'player-1',
+          seatId: 'player-1',
           name: 'User Display',
         },
       ],

--- a/mei-tra-backend/src/use-cases/__tests__/watch-room.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/watch-room.use-case.spec.ts
@@ -7,6 +7,7 @@ import {
   Team,
 } from '../../types/game.types';
 import { TransportPlayer } from '../../types/player-adapters';
+import { asSeatId } from '../../types/identity.types';
 import { Room, RoomStatus } from '../../types/room.types';
 
 describe('WatchRoomUseCase', () => {
@@ -100,7 +101,7 @@ describe('WatchRoomUseCase', () => {
         (players: DomainPlayer[]): TransportPlayer[] =>
           players.map((domainPlayer) => ({
             socketId: `${domainPlayer.playerId}-socket`,
-            playerId: domainPlayer.playerId,
+            seatId: asSeatId(domainPlayer.playerId),
             name: domainPlayer.name,
             userId: domainPlayer.playerId,
             isAuthenticated: true,
@@ -126,7 +127,7 @@ describe('WatchRoomUseCase', () => {
 
     expect(result.success).toBe(true);
     expect(result.data?.gameState.isSpectator).toBe(true);
-    expect(result.data?.gameState.you).toBeNull();
+    expect(result.data?.gameState.youSeatId).toBeNull();
     expect(result.data?.gameState.negriCard).toBe('A♠');
     expect(result.data?.gameState.players.map((p) => p.hand)).toEqual([
       ['A♠', 'K♠'],

--- a/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
+++ b/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
@@ -1,4 +1,4 @@
-import type { RevealAgariPayload, UpdatePhasePayload } from '@contracts/game';
+import type { UpdatePhasePayload } from '@contracts/game';
 import { GameState } from '../types/game.types';
 import { Room } from '../types/room.types';
 import { GameStateService } from '../services/game-state.service';
@@ -9,6 +9,8 @@ import { buildPlayerSyncEvents } from './helpers/player-resolution.helper';
 import { GatewayEvent } from './interfaces/gateway-event.interface';
 import { asSeatId } from '../types/identity.types';
 import { setCurrentSeat } from '../types/current-turn';
+import type { RevealAgariPayload } from '@contracts/game';
+import { toBlowDeclarationContract } from '../types/game-contract-adapters';
 
 export interface TransitionResult {
   events: GatewayEvent[];
@@ -67,7 +69,9 @@ export async function transitionToPlayPhase({
     phase: 'play',
     scores: nextState.teamScores,
     winner: winningPlayer.team,
-    currentHighestDeclaration: nextState.blowState.currentHighestDeclaration,
+    currentHighestDeclaration: nextState.blowState.currentHighestDeclaration
+      ? toBlowDeclarationContract(nextState.blowState.currentHighestDeclaration)
+      : null,
   };
 
   const delayedEvents: GatewayEvent[] = [
@@ -75,7 +79,7 @@ export async function transitionToPlayPhase({
       scope: 'room',
       roomId,
       event: 'update-turn',
-      payload: winningPlayer.playerId,
+      payload: asSeatId(winningPlayer.playerId),
       delayMs: 3000,
     },
     {
@@ -100,7 +104,6 @@ export async function transitionToPlayPhase({
       agari: state.agari,
       message: 'Select a card from your hand as Negri',
       seatId: asSeatId(winningPlayer.playerId),
-      playerId: winningPlayer.playerId,
     };
     delayedEvents.unshift({
       scope: 'socket',

--- a/mei-tra-backend/src/use-cases/complete-field.use-case.ts
+++ b/mei-tra-backend/src/use-cases/complete-field.use-case.ts
@@ -1,10 +1,12 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import type {
-  FieldCompletePayload,
   GameOverPayload,
-  NewRoundStartedPayload,
   RoundResultsPayload,
   UpdatePhasePayload,
+} from '@contracts/game';
+import type {
+  FieldCompletePayload,
+  NewRoundStartedPayload,
 } from '@contracts/game';
 import {
   ICompleteFieldUseCase,
@@ -24,6 +26,7 @@ import {
   buildPlayerSyncEvents,
   resolveTransportPlayers,
 } from './helpers/player-resolution.helper';
+import { toCompletedFieldContract } from '../types/game-contract-adapters';
 import { asSeatId } from '../types/identity.types';
 import { setCurrentSeat } from '../types/current-turn';
 
@@ -107,10 +110,8 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
 
       const fieldCompletePayload: FieldCompletePayload = {
         winnerSeatId: asSeatId(winner.playerId),
-        winnerId: winner.playerId,
-        field: completedField,
+        field: toCompletedFieldContract(completedField),
         nextSeatId: asSeatId(winner.playerId),
-        nextPlayerId: winner.playerId,
       };
       const room = await this.roomService.getRoom(roomId);
 
@@ -424,13 +425,11 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
         roomPlayers: room?.players,
       }),
       currentTurnSeatId: asSeatId(nextBlowPlayer.playerId),
-      currentTurn: nextBlowPlayer.playerId,
       gamePhase: 'blow',
       currentField: null,
       completedFields: [],
       negriCard: null,
       negriSeatId: null,
-      negriPlayerId: null,
       revealedAgari: null,
       currentTrump: null,
       currentHighestDeclaration: null,

--- a/mei-tra-backend/src/use-cases/declare-blow.use-case.ts
+++ b/mei-tra-backend/src/use-cases/declare-blow.use-case.ts
@@ -27,6 +27,7 @@ import {
   hasPlayerPassedInBlow,
 } from './helpers/blow-action.helper';
 import { asSeatId } from '../types/identity.types';
+import { toBlowUpdatedPayload } from '../types/game-contract-adapters';
 import { resolveCurrentPlayer } from '../types/current-turn';
 
 @Injectable()
@@ -137,12 +138,7 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
           scope: 'room',
           roomId,
           event: 'blow-updated',
-          payload: {
-            declarations: state.blowState.declarations,
-            actionHistory: state.blowState.actionHistory,
-            currentHighest: state.blowState.currentHighestDeclaration,
-            lastPasser: state.blowState.lastPasser,
-          },
+          payload: toBlowUpdatedPayload(state.blowState),
         },
       ];
       events.push(

--- a/mei-tra-backend/src/use-cases/interfaces/join-room.use-case.interface.ts
+++ b/mei-tra-backend/src/use-cases/interfaces/join-room.use-case.interface.ts
@@ -32,12 +32,11 @@ export interface ResumeGamePayload {
     players: DomainPlayer[];
     gamePhase: GamePhase;
     currentField: Field | null;
-    currentTurn: string | null;
+    currentTurnSeatId: SeatId | null;
     blowState: BlowState;
     teamScores: TeamScores;
     negriCard: string | null;
     negriSeatId: SeatId | null;
-    negriPlayerId: string | null;
     fields: CompletedField[] | undefined;
     roomId: string;
     pointsToWin: number;

--- a/mei-tra-backend/src/use-cases/interfaces/play-card.use-case.interface.ts
+++ b/mei-tra-backend/src/use-cases/interfaces/play-card.use-case.interface.ts
@@ -1,10 +1,7 @@
 import { GatewayEvent } from './gateway-event.interface';
 import { Field } from '../../types/game.types';
-import type {
-  CardPlayedPayload,
-  PlayCardPayload,
-  UpdateTurnPayload,
-} from '@contracts/game';
+import type { PlayCardPayload, UpdateTurnPayload } from '@contracts/game';
+import type { CardPlayedPayload } from '@contracts/game';
 
 export interface PlayCardRequest extends PlayCardPayload {
   actorId: string;

--- a/mei-tra-backend/src/use-cases/interfaces/start-game.use-case.interface.ts
+++ b/mei-tra-backend/src/use-cases/interfaces/start-game.use-case.interface.ts
@@ -12,8 +12,6 @@ export interface StartGameSuccessData {
   pointsToWin: number;
   updatePhase: UpdatePhasePayload;
   currentTurnSeatId: SeatId;
-  /** @deprecated Use currentTurnSeatId. */
-  currentTurnPlayerId: string;
 }
 
 export interface StartGameResponse {

--- a/mei-tra-backend/src/use-cases/join-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/join-room.use-case.ts
@@ -192,7 +192,7 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
     // COMが残っていても、ゲーム中フェーズ（blow/play）でも game-state を送る
     // （プレイ中ルームへの途中参加・COM引き継ぎに対応）
 
-    const currentTurn = resolveCurrentSeatId(state);
+    const currentTurnSeatId = resolveCurrentSeatId(state);
 
     return {
       message: 'Joined active game.',
@@ -200,15 +200,11 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
         players: state.players,
         gamePhase: state.gamePhase,
         currentField: state.playState?.currentField ?? null,
-        currentTurn,
+        currentTurnSeatId,
         blowState: state.blowState,
         teamScores: state.teamScores,
         negriCard: state.playState?.negriCard ?? null,
         negriSeatId: state.playState?.negriSeatId ?? null,
-        negriPlayerId:
-          state.playState?.negriSeatId ??
-          state.playState?.negriPlayerId ??
-          null,
         fields: state.playState?.fields,
         roomId,
         pointsToWin: room.settings.pointsToWin,

--- a/mei-tra-backend/src/use-cases/pass-blow.use-case.ts
+++ b/mei-tra-backend/src/use-cases/pass-blow.use-case.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import type { RoundCancelledPayload } from '@contracts/game';
+import { toBlowUpdatedPayload } from '../types/game-contract-adapters';
 import {
   IPassBlowUseCase,
   PassBlowRequest,
@@ -126,12 +127,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
           scope: 'room',
           roomId,
           event: 'blow-updated',
-          payload: {
-            declarations: state.blowState.declarations,
-            actionHistory: state.blowState.actionHistory,
-            currentHighest: state.blowState.currentHighestDeclaration,
-            lastPasser: player.playerId,
-          },
+          payload: toBlowUpdatedPayload(state.blowState),
         },
       ];
       events.push(
@@ -279,7 +275,6 @@ export class PassBlowUseCase implements IPassBlowUseCase {
     );
     const roundCancelledPayload: RoundCancelledPayload = {
       nextDealerSeatId: asSeatId(firstBlowPlayer.playerId),
-      nextDealer: firstBlowPlayer.playerId,
       players: resolveTransportPlayers(roomGameState, state.players, {
         roomPlayers: room?.players,
       }),
@@ -295,7 +290,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
           declarations: [],
           actionHistory: [],
           currentHighest: null,
-          lastPasser: null,
+          lastPasserSeatId: null,
         },
       },
       {

--- a/mei-tra-backend/src/use-cases/play-card.use-case.ts
+++ b/mei-tra-backend/src/use-cases/play-card.use-case.ts
@@ -16,6 +16,7 @@ import {
 import { IPlayService } from '../services/interfaces/play-service.interface';
 import { asSeatId } from '../types/identity.types';
 import { resolveCurrentPlayer } from '../types/current-turn';
+import { toFieldContract } from '../types/game-contract-adapters';
 
 @Injectable()
 export class PlayCardUseCase implements IPlayCardUseCase {
@@ -120,9 +121,8 @@ export class PlayCardUseCase implements IPlayCardUseCase {
 
       const cardPlayedPayload: CardPlayedPayload = {
         seatId: asSeatId(player.playerId),
-        playerId: player.playerId,
         card,
-        field: currentField,
+        field: toFieldContract(currentField),
         players: resolveTransportPlayers(roomGameState, state.players, {
           roomPlayers: room?.players,
         }),
@@ -162,12 +162,11 @@ export class PlayCardUseCase implements IPlayCardUseCase {
       const nextPlayer = resolveCurrentPlayer(state);
       if (nextPlayer) {
         cardPlayedPayload.nextSeatId = asSeatId(nextPlayer.playerId);
-        cardPlayedPayload.nextPlayerId = nextPlayer.playerId;
         events.push({
           scope: 'room',
           roomId,
           event: 'update-turn',
-          payload: nextPlayer.playerId,
+          payload: asSeatId(nextPlayer.playerId),
         });
       }
 

--- a/mei-tra-backend/src/use-cases/reconnection.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reconnection.use-case.ts
@@ -1,7 +1,4 @@
-import type {
-  GameStatePayload,
-  ReconnectionFailureCode,
-} from '@contracts/game';
+import type { ReconnectionFailureCode } from '@contracts/game';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { IRoomService } from '../services/interfaces/room-service.interface';
 import { IGameStateService } from '../services/interfaces/game-state-service.interface';
@@ -16,6 +13,12 @@ import { DomainPlayer, Team } from '../types/game.types';
 import { RoomMembershipService } from '../services/room-membership.service';
 import { asSeatId, type SeatId } from '../types/identity.types';
 import { resolveCurrentSeatId } from '../types/current-turn';
+import type { GameStatePayload } from '@contracts/game';
+import {
+  toBlowStateContract,
+  toCompletedFieldContract,
+  toFieldContract,
+} from '../types/game-contract-adapters';
 
 export type ReconnectionResult =
   | {
@@ -25,8 +28,6 @@ export type ReconnectionResult =
       mode: 'waiting-room';
       room: NonNullable<Awaited<ReturnType<IRoomService['getRoom']>>>;
       selfSeatId: SeatId;
-      /** @deprecated Use selfSeatId. */
-      selfPlayerId: string;
       selfName: string;
       selfTeam: Team;
       isHost: boolean;
@@ -40,11 +41,7 @@ export type ReconnectionResult =
       gameState: GameStatePayload;
       reconnectToken: string;
       currentTurnSeatId: SeatId | null;
-      /** @deprecated Use currentTurnSeatId. */
-      currentTurnPlayerId: string | null;
       selfSeatId: SeatId;
-      /** @deprecated Use selfSeatId. */
-      selfPlayerId: string;
     }
   | {
       success: false;
@@ -60,12 +57,7 @@ type ActiveGameReconnection = Extract<
 
 export type ActiveGameSnapshot = Pick<
   ActiveGameReconnection,
-  | 'gameState'
-  | 'reconnectToken'
-  | 'currentTurnSeatId'
-  | 'currentTurnPlayerId'
-  | 'selfSeatId'
-  | 'selfPlayerId'
+  'gameState' | 'reconnectToken' | 'currentTurnSeatId' | 'selfSeatId'
 >;
 
 type ActiveRoom = NonNullable<Awaited<ReturnType<IRoomService['getRoom']>>>;
@@ -209,7 +201,6 @@ export class ReconnectionUseCase {
           roomsList: await this.roomService.listRooms(),
           room: reconnectedRoom,
           selfSeatId: asSeatId(reconnectedPlayer.playerId),
-          selfPlayerId: reconnectedPlayer.playerId,
           selfName: reconnectedPlayer.name,
           selfTeam: reconnectedPlayer.team,
           isHost: reconnectedRoom.hostId === reconnectedPlayer.playerId,
@@ -386,40 +377,32 @@ export class ReconnectionUseCase {
     player: DomainPlayer,
   ): ActiveGameSnapshot {
     const state = roomGameState.getState();
-    const currentTurnPlayerId = resolveCurrentSeatId(state);
+    const currentTurnSeatId = resolveCurrentSeatId(state);
 
     return {
       selfSeatId: asSeatId(player.playerId),
-      selfPlayerId: player.playerId,
       reconnectToken: player.playerId,
-      currentTurnSeatId: currentTurnPlayerId
-        ? asSeatId(currentTurnPlayerId)
-        : null,
-      currentTurnPlayerId,
+      currentTurnSeatId: currentTurnSeatId ? asSeatId(currentTurnSeatId) : null,
       gameState: {
         players: resolveTransportPlayers(roomGameState, state.players, {
           roomPlayers: room.players,
           mapHand: (transportPlayer) =>
-            transportPlayer.playerId === player.playerId
+            transportPlayer.seatId === asSeatId(player.playerId)
               ? transportPlayer.hand
               : [],
         }),
         gamePhase: state.gamePhase || 'waiting',
-        currentField: state.playState?.currentField ?? null,
-        currentTurnSeatId: currentTurnPlayerId
-          ? asSeatId(currentTurnPlayerId)
+        currentField: state.playState?.currentField
+          ? toFieldContract(state.playState.currentField)
           : null,
-        currentTurn: currentTurnPlayerId,
-        blowState: state.blowState,
+        currentTurnSeatId: currentTurnSeatId
+          ? asSeatId(currentTurnSeatId)
+          : null,
+        blowState: toBlowStateContract(state.blowState),
         teamScores: state.teamScores,
         youSeatId: asSeatId(player.playerId),
-        you: player.playerId,
         negriCard: state.playState?.negriCard ?? null,
         negriSeatId: state.playState?.negriSeatId ?? null,
-        negriPlayerId:
-          state.playState?.negriSeatId ??
-          state.playState?.negriPlayerId ??
-          null,
         revealedAgari:
           state.gamePhase === 'play' &&
           !state.playState?.negriCard &&
@@ -427,10 +410,9 @@ export class ReconnectionUseCase {
             player.playerId
             ? (state.agari ?? null)
             : null,
-        fields: state.playState?.fields ?? [],
+        fields: (state.playState?.fields ?? []).map(toCompletedFieldContract),
         roomId,
         hostSeatId: asSeatId(room.hostId),
-        hostId: room.hostId,
         pointsToWin: state.pointsToWin,
         teamNames: room.settings.teamNames,
       },

--- a/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
@@ -170,13 +170,12 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
             declarations: [],
             actionHistory: [],
             currentHighest: null,
-            lastPasser: null,
+            lastPasserSeatId: null,
           },
         });
 
         const brokenPayload: BrokenPayload = {
           nextSeatId: asSeatId(firstBlowPlayer.playerId),
-          nextPlayerId: firstBlowPlayer.playerId,
           players: resolveTransportPlayers(roomGameState, nextState.players, {
             roomPlayers: room?.players,
           }),

--- a/mei-tra-backend/src/use-cases/select-negri.use-case.ts
+++ b/mei-tra-backend/src/use-cases/select-negri.use-case.ts
@@ -102,7 +102,6 @@ export class SelectNegriUseCase implements ISelectNegriUseCase {
           payload: {
             negriCard: card,
             startingSeatId: asSeatId(state.players[winnerIndex].playerId),
-            startingPlayer: state.players[winnerIndex].playerId,
           },
         },
         {

--- a/mei-tra-backend/src/use-cases/start-game.use-case.ts
+++ b/mei-tra-backend/src/use-cases/start-game.use-case.ts
@@ -188,7 +188,6 @@ export class StartGameUseCase implements IStartGameUseCase {
             winner: null,
           },
           currentTurnSeatId: asSeatId(currentTurnPlayer.playerId),
-          currentTurnPlayerId: currentTurnPlayer.playerId,
         },
       };
     } catch (error) {

--- a/mei-tra-backend/src/use-cases/watch-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/watch-room.use-case.ts
@@ -11,6 +11,11 @@ import {
 import { resolveTransportPlayers } from './helpers/player-resolution.helper';
 import { asSeatId } from '../types/identity.types';
 import { resolveCurrentSeatId } from '../types/current-turn';
+import {
+  toBlowStateContract,
+  toCompletedFieldContract,
+  toFieldContract,
+} from '../types/game-contract-adapters';
 
 @Injectable()
 export class WatchRoomUseCase implements IWatchRoomUseCase {
@@ -85,22 +90,19 @@ export class WatchRoomUseCase implements IWatchRoomUseCase {
     return {
       players: spectatorPlayers,
       gamePhase: state.gamePhase ?? 'waiting',
-      currentField: state.playState?.currentField ?? null,
+      currentField: state.playState?.currentField
+        ? toFieldContract(state.playState.currentField)
+        : null,
       currentTurnSeatId: currentTurn ? asSeatId(currentTurn) : null,
-      currentTurn,
-      blowState: state.blowState,
+      blowState: toBlowStateContract(state.blowState),
       teamScores: state.teamScores,
       youSeatId: null,
-      you: null,
       isSpectator: true,
       negriCard: state.playState?.negriCard ?? null,
       negriSeatId: state.playState?.negriSeatId ?? null,
-      negriPlayerId:
-        state.playState?.negriSeatId ?? state.playState?.negriPlayerId ?? null,
-      fields: state.playState?.fields ?? [],
+      fields: (state.playState?.fields ?? []).map(toCompletedFieldContract),
       roomId: room.id,
       hostSeatId: asSeatId(room.hostId),
-      hostId: room.hostId,
       pointsToWin: room.settings.pointsToWin,
       teamNames: room.settings.teamNames,
     };

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -53,8 +53,8 @@ import { fromRoomContract, fromRoomSyncPayload } from '../types/room.types';
 import { clearPlayerProfileCache } from '../lib/utils/profileUtils';
 import { inferNextTurnAfterCardPlayed } from '../lib/utils/turnInference';
 import { getTeamDisplayName } from '../lib/utils/teamLabels';
-import { resolveSeatAlias } from '@meitra/game-client/identity';
 import { resolveSelfPlayerId } from '../lib/utils/playerIdentity';
+import { asSeatId } from '@contracts/ids';
 
 interface ProfileUpdatedPayload {
   userId: string;
@@ -95,12 +95,12 @@ const toUiGamePhase = (phase: TransportGamePhase): GamePhase =>
 const toUiBlowDeclaration = (
   declaration: BlowDeclarationContract,
 ): BlowDeclaration => {
-  const seatId = resolveSeatAlias(declaration.seatId, declaration.playerId)!;
+  const seatId = declaration.seatId;
   return { ...declaration, seatId, playerId: seatId };
 };
 
 const toUiBlowAction = (action: BlowActionContract): BlowAction => {
-  const seatId = resolveSeatAlias(action.seatId, action.playerId)!;
+  const seatId = action.seatId;
   return { ...action, seatId, playerId: seatId };
 };
 
@@ -109,10 +109,8 @@ const toUiField = (field: FieldContract | null): Field | null => {
     return null;
   }
 
-  const dealerSeatId = resolveSeatAlias(field.dealerSeatId, field.dealerId)!;
-  const playedBySeatIds = (field.playedBySeatIds ?? field.playedBy).map(
-    (seatId) => resolveSeatAlias(seatId, seatId)!,
-  );
+  const dealerSeatId = field.dealerSeatId;
+  const playedBySeatIds = [...field.playedBySeatIds];
   return {
     cards: field.cards,
     playedBySeatIds,
@@ -128,8 +126,8 @@ const toUiField = (field: FieldContract | null): Field | null => {
 const toUiCompletedField = (
   field: CompletedFieldContract,
 ): CompletedField => {
-  const winnerSeatId = resolveSeatAlias(field.winnerSeatId, field.winnerId)!;
-  const dealerSeatId = resolveSeatAlias(field.dealerSeatId, field.dealerId)!;
+  const winnerSeatId = field.winnerSeatId;
+  const dealerSeatId = field.dealerSeatId;
   return {
     cards: field.cards,
     winnerSeatId,
@@ -543,7 +541,7 @@ export const useGame = () => {
             const existingIndex = prev.findIndex((u) => u.playerId === playerId);
             const baseUser = {
               socketId: '',
-              seatId: resolveSeatAlias(undefined, playerId)!,
+              seatId: asSeatId(playerId),
               playerId,
               name,
               isAuthenticated: false,
@@ -657,29 +655,19 @@ export const useGame = () => {
         gamePhase,
         currentField,
         currentTurnSeatId,
-        currentTurn,
         blowState,
         teamScores,
         youSeatId,
-        you,
         negriCard,
         negriSeatId,
-        negriPlayerId: legacyNegriPlayerId,
         revealedAgari: syncedRevealedAgari,
         fields,
         roomId,
         hostSeatId,
-        hostId,
         pointsToWin,
         teamNames,
         isSpectator,
       }: GameStatePayload) => {
-        const resolvedCurrentTurn = resolveSeatAlias(
-          currentTurnSeatId,
-          currentTurn,
-        );
-        const resolvedYou = resolveSeatAlias(youSeatId, you);
-        const resolvedHost = resolveSeatAlias(hostSeatId, hostId);
         const nextPlayers = mergePlayersPreservingIdentity(
           playersRef.current,
           fromPlayerContracts(playerContracts),
@@ -687,11 +675,11 @@ export const useGame = () => {
         commitPlayers(nextPlayers);
         syncDisconnectedPlayerIdsFromPlayers(nextPlayers);
         if (!isSpectator) {
-          syncCurrentPlayerIdentity(nextPlayers, currentPlayerId, resolvedYou);
+          syncCurrentPlayerIdentity(nextPlayers, currentPlayerId, youSeatId);
         }
         setGamePhase(toUiGamePhase(gamePhase));
         setRevealedAgari(syncedRevealedAgari ?? null);
-        setWhoseTurn(resolvedCurrentTurn);
+        setWhoseTurn(currentTurnSeatId);
         setCurrentField(toUiField(currentField));
         setCurrentTrump(blowState.currentTrump);
         setCurrentHighestDeclaration(
@@ -707,11 +695,9 @@ export const useGame = () => {
         setIsSpectator(Boolean(isSpectator));
         setNegriCard(negriCard);
         setCompletedFields(toUiCompletedFields(fields));
-        setNegriPlayerId(
-          resolveSeatAlias(negriSeatId, legacyNegriPlayerId),
-        );
+        setNegriPlayerId(negriSeatId);
         setCurrentRoomId(roomId);
-        setCurrentHostId(resolvedHost);
+        setCurrentHostId(hostSeatId);
         if (isSpectator) {
           setIsHost(false);
         }
@@ -725,7 +711,7 @@ export const useGame = () => {
         );
       },
       'game-player-joined': (data: GamePlayerJoinedPayload) => {
-        const joinedSeatId = resolveSeatAlias(data.seatId, data.playerId)!;
+        const joinedSeatId = data.seatId;
         // isSelf: true means the backend confirmed "this is YOUR player ID".
         // Only set currentPlayerId from this explicit self-identification event.
         if (data.isSelf) {
@@ -881,7 +867,7 @@ export const useGame = () => {
 
         // Keep ref set until the next game starts (game-started handler clears it)
       },
-      'blow-started': ({ startingSeatId, startingPlayer, players: playerContracts }: BlowStartedPayload) => {
+      'blow-started': ({ startingSeatId, players: playerContracts }: BlowStartedPayload) => {
         setGamePhase('blow');
         const nextPlayers = mergePlayersPreservingIdentity(
           playersRef.current,
@@ -889,7 +875,7 @@ export const useGame = () => {
         );
         commitPlayers(nextPlayers);
         syncDisconnectedPlayerIdsFromPlayers(nextPlayers);
-        setWhoseTurn(resolveSeatAlias(startingSeatId, startingPlayer));
+        setWhoseTurn(startingSeatId);
       },
       'blow-updated': ({ declarations, actionHistory, currentHighest }: { declarations: BlowDeclarationContract[]; actionHistory?: BlowActionContract[]; currentHighest: BlowDeclarationContract | null }) => {
         setBlowDeclarations(declarations.map(toUiBlowDeclaration));
@@ -900,7 +886,7 @@ export const useGame = () => {
         // Note: Player state updates (including isPasser) are handled by 'update-players' event
         // This prevents race conditions and ensures consistency across all blow phase operations
       },
-      'broken': ({ nextSeatId, nextPlayerId, players: playerContracts, gamePhase }: BrokenPayload) => {
+      'broken': ({ nextSeatId, players: playerContracts, gamePhase }: BrokenPayload) => {
         setNotification({
           message: 'Broken happened, reset the game',
           type: 'warning'
@@ -912,7 +898,7 @@ export const useGame = () => {
         );
         commitPlayers(nextPlayers);
         syncDisconnectedPlayerIdsFromPlayers(nextPlayers);
-        setWhoseTurn(resolveSeatAlias(nextSeatId, nextPlayerId));
+        setWhoseTurn(nextSeatId);
         setGamePhase(toUiGamePhase(gamePhase ?? 'blow'));
         setCurrentTrump(null);
       },
@@ -930,7 +916,6 @@ export const useGame = () => {
       },
       'round-cancelled': ({
         nextDealerSeatId,
-        nextDealer,
         players: playerContracts,
         currentTrump,
         currentHighestDeclaration,
@@ -948,7 +933,7 @@ export const useGame = () => {
         );
         commitPlayers(nextPlayers);
         syncDisconnectedPlayerIdsFromPlayers(nextPlayers);
-        setWhoseTurn(resolveSeatAlias(nextDealerSeatId, nextDealer));
+        setWhoseTurn(nextDealerSeatId);
         setCurrentTrump(currentTrump ?? null);
         setCurrentHighestDeclaration(
           currentHighestDeclaration
@@ -965,10 +950,10 @@ export const useGame = () => {
           type: 'success'
         });
       },
-      'play-setup-complete': ({ negriCard, startingSeatId, startingPlayer }: PlaySetupCompletePayload) => {
+      'play-setup-complete': ({ negriCard, startingSeatId }: PlaySetupCompletePayload) => {
         setRevealedAgari(null);
         setNegriCard(negriCard);
-        setNegriPlayerId(resolveSeatAlias(startingSeatId, startingPlayer));
+        setNegriPlayerId(startingSeatId);
         const selfPlayerId = getCurrentUserPlayerId();
         // Remove Negri card from player's hand
         updatePlayersLocally((prev) =>
@@ -987,7 +972,6 @@ export const useGame = () => {
         field,
         players: updatedPlayers,
         nextSeatId,
-        nextPlayerId,
       }: CardPlayedPayload) => {
         const nextField = toUiField(field)!;
         setCurrentField(nextField);
@@ -998,8 +982,7 @@ export const useGame = () => {
         commitPlayers(nextPlayers);
         syncDisconnectedPlayerIdsFromPlayers(nextPlayers);
         const resolvedNextPlayerId =
-          resolveSeatAlias(nextSeatId, nextPlayerId) ??
-          inferNextTurnAfterCardPlayed(nextPlayers, nextField);
+          nextSeatId ?? inferNextTurnAfterCardPlayed(nextPlayers, nextField);
         if (resolvedNextPlayerId) {
           setWhoseTurn(resolvedNextPlayerId);
         }
@@ -1007,8 +990,8 @@ export const useGame = () => {
       'field-updated': (field: FieldContract) => {
         setCurrentField(toUiField(field));
       },
-      'field-complete': ({ field, nextSeatId, nextPlayerId }: FieldCompletePayload) => {
-        const resolvedNextSeatId = resolveSeatAlias(nextSeatId, nextPlayerId)!;
+      'field-complete': ({ field, nextSeatId }: FieldCompletePayload) => {
+        const resolvedNextSeatId = nextSeatId;
         setCompletedFields((prev) =>
           dedupeCompletedFields([...prev, toUiCompletedField(field)]),
         );
@@ -1028,13 +1011,11 @@ export const useGame = () => {
       'new-round-started': ({
         players: playerContracts,
         currentTurnSeatId,
-        currentTurn,
         gamePhase,
         currentField,
         completedFields,
         negriCard,
         negriSeatId,
-        negriPlayerId: legacyNegriPlayerId,
         revealedAgari,
         currentTrump,
         currentHighestDeclaration,
@@ -1046,14 +1027,12 @@ export const useGame = () => {
         );
         commitPlayers(nextPlayers);
         syncDisconnectedPlayerIdsFromPlayers(nextPlayers);
-        setWhoseTurn(resolveSeatAlias(currentTurnSeatId, currentTurn));
+        setWhoseTurn(currentTurnSeatId);
         setGamePhase(toUiGamePhase(gamePhase));
         setCurrentField(toUiField(currentField));
         setCompletedFields(toUiCompletedFields(completedFields));
         setNegriCard(negriCard);
-        setNegriPlayerId(
-          resolveSeatAlias(negriSeatId, legacyNegriPlayerId),
-        );
+        setNegriPlayerId(negriSeatId);
         setRevealedAgari(revealedAgari);
         setCurrentTrump(currentTrump);
         setCurrentHighestDeclaration(

--- a/mei-tra-frontend/hooks/useRoom.ts
+++ b/mei-tra-frontend/hooks/useRoom.ts
@@ -18,7 +18,7 @@ import { ConnectionUser, Team } from '../types/game.types';
 import { RoomStatus } from '../types/room.types';
 import { clearPlayerProfileCache } from '../lib/utils/profileUtils';
 import { resolveSelfPlayerId } from '../lib/utils/playerIdentity';
-import { resolveSeatAlias } from '@meitra/game-client/identity';
+import { asSeatId } from '@contracts/ids';
 
 interface UseRoomOptions {
   users?: ConnectionUser[];
@@ -219,11 +219,10 @@ export const useRoom = (options: UseRoomOptions = {}) => {
     // プレイヤー参加（ルーム関連）
     const handleRoomPlayerJoined = ({
       seatId,
-      playerId,
       roomId,
       isHost,
     }: RoomPlayerJoinedPayload) => {
-      const joinedSeatId = resolveSeatAlias(seatId, playerId)!;
+      const joinedSeatId = seatId;
       setAvailableRooms(prevRooms => {
         const updatedRooms = prevRooms.map(room => {
           if (room.id !== roomId) return room;
@@ -232,7 +231,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
             if (typeof p === 'string') {
               return {
                 socketId: '',
-                seatId: resolveSeatAlias(undefined, p)!,
+                seatId: asSeatId(p),
                 playerId: p,
                 name: p,
                 hand: [],
@@ -353,7 +352,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
           status: RoomStatus.PLAYING,
           players: currentRoomRef.current.players.map(p => {
             const updatedPlayer = players.find(
-              (player) => player.playerId === p.playerId,
+              (player) => player.seatId === p.seatId,
             );
             return updatedPlayer ? { ...p, hand: updatedPlayer.hand } : p;
           })
@@ -380,7 +379,9 @@ export const useRoom = (options: UseRoomOptions = {}) => {
         const updatedRoom = {
           ...currentRoomRef.current,
           players: currentRoomRef.current.players.map(roomPlayer => {
-            const updatedPlayer = players.find(p => p.playerId === roomPlayer.playerId);
+            const updatedPlayer = players.find(
+              (player) => player.seatId === roomPlayer.seatId,
+            );
             if (updatedPlayer) {
               return {
                 ...roomPlayer,

--- a/mei-tra-mobile/src/components/game/BlowControls.tsx
+++ b/mei-tra-mobile/src/components/game/BlowControls.tsx
@@ -1,7 +1,6 @@
 import type {
   BlowActionContract,
   BlowDeclarationContract,
-  PlayerContract,
   TrumpType,
 } from '@meitra/contracts/game';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -11,6 +10,7 @@ import { Button } from '@/components/ui/Button';
 import { TRUMP_LABELS } from '@/lib/trump-labels';
 import { colors } from '@/theme/colors';
 import { getValidBlowPairValues } from '@meitra/game-client/blow';
+import type { MobilePlayer } from '@/types/game';
 
 const TRUMP_ORDER: TrumpType[] = ['zuppe', 'club', 'daiya', 'herz', 'tra'];
 
@@ -27,7 +27,7 @@ const declarationLabel = (declaration: BlowDeclarationContract | null) => {
 };
 
 interface BlowControlsProps {
-  players: PlayerContract[];
+  players: MobilePlayer[];
   currentTurn: string | null;
   currentPlayerId: string | null;
   highest: BlowDeclarationContract | null;
@@ -179,11 +179,11 @@ export function BlowControls({
           >
             {actionHistory.map((action, index) => {
               const name =
-                players.find((p) => p.playerId === action.playerId)?.name ??
+                players.find((p) => p.seatId === action.seatId)?.name ??
                 '—';
               const isHighest =
                 action.type === 'declare' &&
-                highest?.playerId === action.playerId &&
+                highest?.seatId === action.seatId &&
                 highest?.trumpType === action.trumpType &&
                 highest?.numberOfPairs === action.numberOfPairs;
               const trump = action.trumpType

--- a/mei-tra-mobile/src/components/game/GameBoard.tsx
+++ b/mei-tra-mobile/src/components/game/GameBoard.tsx
@@ -1,4 +1,4 @@
-import type { PlayerContract, TrumpType } from '@meitra/contracts/game';
+import type { TrumpType } from '@meitra/contracts/game';
 import type {
   GameHistoryReplayViewContract,
   GameHistorySummaryContract,
@@ -37,6 +37,7 @@ import { colors, teamColors } from '@/theme/colors';
 import type {
   MobileGameOver,
   MobileGameSnapshot,
+  MobilePlayer,
 } from '@/types/game';
 
 interface GameHistoryData {
@@ -102,7 +103,7 @@ export function GameBoard({
     null;
   const perspectivePlayerId = game.isSpectator
     ? spectatorPerspectiveId ?? hostPlayerId
-    : game.you;
+    : game.youSeatId;
 
   useEffect(() => {
     if (!game.isSpectator) return;
@@ -117,7 +118,7 @@ export function GameBoard({
   );
   const { width: windowWidth } = useWindowDimensions();
   // Size the fan from the hand it actually renders. Spectators have no
-  // `game.you`, so keying off that collapsed the count to 0 and the metrics
+  // `game.youSeatId`, so keying off that collapsed the count to 0 and the metrics
   // fell through to the single-card branch (max width, zero overlap).
   const selfHandCount = self?.hand.length ?? 0;
   // board padding (20) + self panel (~86) + fan padding (20)
@@ -141,7 +142,7 @@ export function GameBoard({
         (
           slot,
         ): slot is {
-          player: PlayerContract;
+          player: MobilePlayer;
           position: 'left' | 'top' | 'right';
         } =>
           slot.player != null,
@@ -159,9 +160,10 @@ export function GameBoard({
   const mustSelectNegri =
     !game.isSpectator &&
     game.gamePhase === 'play' &&
-    highest?.playerId === game.you &&
+    highest?.playerId === game.youSeatId &&
     !game.negriCard;
-  const isMyTurn = !game.isSpectator && game.currentTurn === game.you;
+  const isMyTurn =
+    !game.isSpectator && game.currentTurnSeatId === game.youSeatId;
   const phaseLabel =
     game.gamePhase === 'blow'
       ? '吹き'
@@ -193,7 +195,7 @@ export function GameBoard({
   useEffect(() => {
     setSelectedCard(null);
     setPendingAction(null);
-  }, [game.gamePhase, game.you]);
+  }, [game.gamePhase, game.youSeatId]);
 
   useEffect(() => {
     setPendingAction(null);
@@ -202,7 +204,7 @@ export function GameBoard({
     }
   }, [
     actionsDisabled,
-    game.currentTurn,
+    game.currentTurnSeatId,
     fieldCardsKey,
     game.blowState.currentHighestDeclaration?.timestamp,
     game.negriCard,
@@ -291,7 +293,7 @@ export function GameBoard({
           {opponentSlots.map(({ player, position }) => {
             const hasNegri =
               game.gamePhase === 'play' &&
-              game.negriPlayerId === player.playerId;
+              game.negriSeatId === player.playerId;
             const blowWinnerId = highest?.playerId;
             const hasAgari =
               game.gamePhase === 'play' &&
@@ -311,7 +313,7 @@ export function GameBoard({
                   player.playerId,
                 )}
                 isIdle={game.idlePlayerIds.includes(player.playerId)}
-                isTurn={game.currentTurn === player.playerId}
+                isTurn={game.currentTurnSeatId === player.playerId}
                 negriCard={hasNegri ? 'hidden' : undefined}
                 onPress={
                   game.isSpectator
@@ -363,7 +365,7 @@ export function GameBoard({
             const showReplacePanel =
               isHost &&
               !player.isCOM &&
-              player.playerId !== game.you &&
+              player.playerId !== game.youSeatId &&
               (isDisconnected || isIdle);
             return (
               <View key={player.playerId} style={posStyle}>
@@ -461,8 +463,8 @@ export function GameBoard({
           <BlowControls
             actionHistory={game.blowState.actionHistory}
             actionsDisabled={actionsDisabled || game.isSpectator}
-            currentPlayerId={game.you}
-            currentTurn={game.currentTurn}
+            currentPlayerId={game.youSeatId}
+            currentTurn={game.currentTurnSeatId}
             highest={highest}
             onDeclare={onDeclare}
             onPass={onPass}
@@ -477,7 +479,7 @@ export function GameBoard({
                 style={[
                   styles.selfCard,
                   (game.isSpectator
-                    ? game.currentTurn === self.playerId
+                    ? game.currentTurnSeatId === self.playerId
                     : isMyTurn) && styles.selfCardTurn,
                 ]}
               >

--- a/mei-tra-mobile/src/components/game/GameHistory.tsx
+++ b/mei-tra-mobile/src/components/game/GameHistory.tsx
@@ -1,4 +1,4 @@
-import type { PlayerContract, TeamNames } from '@meitra/contracts/game';
+import type { TeamNames } from '@meitra/contracts/game';
 import type {
   GameHistoryReplayViewContract,
   GameHistorySummaryContract,
@@ -15,6 +15,7 @@ import {
 
 import { buildRoundTableRows, type RoundRow } from '@/lib/game-log-rows';
 import { colors, teamColors } from '@/theme/colors';
+import type { MobilePlayer } from '@/types/game';
 
 interface GameHistoryProps {
   replay: GameHistoryReplayViewContract | null;
@@ -22,7 +23,7 @@ interface GameHistoryProps {
   loading: boolean;
   error: string | null;
   onRefresh: () => void;
-  players?: PlayerContract[];
+  players?: MobilePlayer[];
   teamNames?: TeamNames;
 }
 

--- a/mei-tra-mobile/src/components/game/PlayerSeat.tsx
+++ b/mei-tra-mobile/src/components/game/PlayerSeat.tsx
@@ -1,4 +1,4 @@
-import type { PlayerContract, TeamNames } from '@meitra/contracts/game';
+import type { TeamNames } from '@meitra/contracts/game';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { PlayingCard } from '@/components/game/PlayingCard';
@@ -6,9 +6,10 @@ import { TurnClock } from '@/components/game/TurnClock';
 import { getTeamDisplayName } from '@/lib/team-labels';
 import { CARD_BASE_WIDTHS, cardStackMargin } from '@/theme/cards';
 import { colors, teamColors } from '@/theme/colors';
+import type { MobilePlayer } from '@/types/game';
 
 interface PlayerSeatProps {
-  player: PlayerContract;
+  player: MobilePlayer;
   isTurn: boolean;
   isSelf?: boolean;
   declaration?: string;

--- a/mei-tra-mobile/src/components/game/WaitingRoom.tsx
+++ b/mei-tra-mobile/src/components/game/WaitingRoom.tsx
@@ -1,5 +1,4 @@
 import type { TeamNames } from '@meitra/contracts/game';
-import type { RoomContract } from '@meitra/contracts/room';
 import { useEffect, useRef, useState } from 'react';
 import {
   Alert,
@@ -16,9 +15,10 @@ import { ChatPanel } from '@/components/social/ChatPanel';
 import { Button } from '@/components/ui/Button';
 import { getTeamDisplayName } from '@/lib/team-labels';
 import { colors, teamColors } from '@/theme/colors';
+import type { MobileRoom } from '@/types/game';
 
 interface WaitingRoomProps {
-  room: RoomContract;
+  room: MobileRoom;
   currentPlayerId: string | null;
   isHost: boolean;
   onShuffle: () => void;

--- a/mei-tra-mobile/src/context/GameContext.tsx
+++ b/mei-tra-mobile/src/context/GameContext.tsx
@@ -13,6 +13,7 @@ import type {
   RoomActionPayload,
 } from '@meitra/contracts/socket';
 import type { RoomContract } from '@meitra/contracts/room';
+import { asSeatId } from '@meitra/contracts/ids';
 import { io } from 'socket.io-client';
 import {
   createContext,
@@ -32,7 +33,6 @@ import {
   normalizeFieldIdentity,
   normalizePlayerIdentities,
   normalizeRoomIdentity,
-  resolveSeatAlias,
 } from '@meitra/game-client/identity';
 
 import { useAuth } from '@/context/AuthContext';
@@ -57,11 +57,12 @@ import type {
   ConnectionStatus,
   MobileGameOver,
   MobileGameSnapshot,
+  MobileRoom,
 } from '@/types/game';
 
 interface MobileState {
-  rooms: RoomContract[];
-  currentRoom: RoomContract | null;
+  rooms: MobileRoom[];
+  currentRoom: MobileRoom | null;
   game: MobileGameSnapshot | null;
   pendingGamePatches: Partial<MobileGameSnapshot> | null;
   connectionStatus: ConnectionStatus;
@@ -609,10 +610,9 @@ export function GameProvider({ children }: PropsWithChildren) {
       finishResyncFlight(payload.roomId);
     });
     socket.on('reconnect-token', (playerId) => {
-      const youSeatId = resolveSeatAlias(undefined, playerId);
       dispatch({
         type: 'patchGame',
-        patch: { youSeatId, you: youSeatId },
+        patch: { youSeatId: asSeatId(playerId) },
       });
     });
     socket.on('game-started', (payload) => {
@@ -626,9 +626,7 @@ export function GameProvider({ children }: PropsWithChildren) {
         game: createStartedGameSnapshot(
           payload,
           currentPlayerId,
-          stateRef.current.currentRoom?.hostSeatId ??
-            stateRef.current.currentRoom?.hostId ??
-            null,
+          stateRef.current.currentRoom?.hostSeatId ?? null,
         ),
       });
       void roomStorage.set(payload.roomId);
@@ -647,20 +645,22 @@ export function GameProvider({ children }: PropsWithChildren) {
                     ? (payload.currentHighestDeclaration?.trumpType ?? null)
                     : null,
                 currentHighestDeclaration:
-                  payload.currentHighestDeclaration ??
+                  (payload.currentHighestDeclaration
+                    ? normalizeBlowDeclarationIdentity(
+                        payload.currentHighestDeclaration,
+                      )
+                    : null) ??
                   stateRef.current.game.blowState.currentHighestDeclaration,
               }
             : createEmptyBlowState(),
         },
       });
     });
-    socket.on('update-turn', (playerId) => {
-      const currentTurnSeatId = resolveSeatAlias(undefined, playerId);
+    socket.on('update-turn', (currentTurnSeatId) => {
       dispatch({
         type: 'patchGame',
         patch: {
           currentTurnSeatId,
-          currentTurn: currentTurnSeatId,
         },
       });
       const roomId = stateRef.current.game?.roomId;
@@ -668,18 +668,13 @@ export function GameProvider({ children }: PropsWithChildren) {
         socket.emit('turn-ack', { roomId });
       }
     });
-    socket.on('blow-started', ({ startingSeatId, startingPlayer, players }) => {
-      const currentTurnSeatId = resolveSeatAlias(
-        startingSeatId,
-        startingPlayer,
-      );
+    socket.on('blow-started', ({ startingSeatId, players }) => {
       dispatch({ type: 'players', players });
       dispatch({
         type: 'patchGame',
         patch: {
           gamePhase: 'blow',
-          currentTurnSeatId,
-          currentTurn: currentTurnSeatId,
+          currentTurnSeatId: startingSeatId,
         },
       });
     });
@@ -709,20 +704,17 @@ export function GameProvider({ children }: PropsWithChildren) {
         });
       },
     );
-    socket.on('broken', ({ nextSeatId, nextPlayerId, players, gamePhase }) => {
-      const currentTurnSeatId = resolveSeatAlias(nextSeatId, nextPlayerId);
+    socket.on('broken', ({ nextSeatId, players, gamePhase }) => {
       dispatch({ type: 'players', players });
       dispatch({
         type: 'patchGame',
         patch: {
-          currentTurnSeatId,
-          currentTurn: currentTurnSeatId,
+          currentTurnSeatId: nextSeatId,
           gamePhase: gamePhase ?? 'blow',
           currentField: null,
           blowState: createEmptyBlowState(),
           negriCard: null,
           negriSeatId: null,
-          negriPlayerId: null,
           revealedAgari: null,
           fields: [],
         } as Partial<MobileGameSnapshot>,
@@ -733,28 +725,21 @@ export function GameProvider({ children }: PropsWithChildren) {
       'round-cancelled',
       ({
         nextDealerSeatId,
-        nextDealer,
         players,
         currentTrump,
         currentHighestDeclaration,
         blowDeclarations,
         actionHistory,
       }) => {
-        const currentTurnSeatId = resolveSeatAlias(
-          nextDealerSeatId,
-          nextDealer,
-        );
         dispatch({ type: 'players', players });
         dispatch({
           type: 'patchGame',
           patch: {
             gamePhase: 'blow',
-            currentTurnSeatId,
-            currentTurn: currentTurnSeatId,
+            currentTurnSeatId: nextDealerSeatId,
             currentField: null,
             negriCard: null,
             negriSeatId: null,
-            negriPlayerId: null,
             revealedAgari: null,
             fields: [],
             blowState: {
@@ -786,16 +771,11 @@ export function GameProvider({ children }: PropsWithChildren) {
       ({
         negriCard,
         startingSeatId,
-        startingPlayer,
       }) => {
-        const resolvedStartingSeatId = resolveSeatAlias(
-          startingSeatId,
-          startingPlayer,
-        );
         const game = stateRef.current.game;
         const players = game
           ? game.players.map((player) =>
-              player.playerId === game.you
+              player.seatId === game.youSeatId
                 ? {
                     ...player,
                     hand: player.hand.filter((card) => card !== negriCard),
@@ -808,22 +788,20 @@ export function GameProvider({ children }: PropsWithChildren) {
           type: 'patchGame',
           patch: {
             negriCard,
-            negriSeatId: resolvedStartingSeatId,
-            negriPlayerId: resolvedStartingSeatId,
+            negriSeatId: startingSeatId,
             revealedAgari: null,
-            currentTurnSeatId: resolvedStartingSeatId,
-            currentTurn: resolvedStartingSeatId,
+            currentTurnSeatId: startingSeatId,
           },
         });
       },
     );
-    socket.on('card-played', ({ field, players, nextSeatId, nextPlayerId }) => {
+    socket.on('card-played', ({ field, players, nextSeatId }) => {
       const normalizedField = normalizeFieldIdentity(field);
       dispatch({ type: 'players', players });
       const resolvedNextPlayerId =
-        resolveSeatAlias(nextSeatId, nextPlayerId) ??
+        nextSeatId ??
         inferNextTurnAfterCardPlayed(
-          stateRef.current.game?.players ?? players,
+          stateRef.current.game?.players ?? normalizePlayerIdentities(players),
           normalizedField,
         );
       dispatch({
@@ -832,11 +810,7 @@ export function GameProvider({ children }: PropsWithChildren) {
           currentField: normalizedField,
           ...(resolvedNextPlayerId
             ? {
-                currentTurnSeatId: resolveSeatAlias(
-                  undefined,
-                  resolvedNextPlayerId,
-                ),
-                currentTurn: resolvedNextPlayerId,
+                currentTurnSeatId: asSeatId(resolvedNextPlayerId),
               }
             : {}),
         },
@@ -850,9 +824,9 @@ export function GameProvider({ children }: PropsWithChildren) {
     });
     socket.on(
       'field-complete',
-      ({ field, nextSeatId, nextPlayerId }) => {
+      ({ field, nextSeatId }) => {
         const normalizedField = normalizeCompletedFieldIdentity(field);
-        const nextTurnSeatId = resolveSeatAlias(nextSeatId, nextPlayerId)!;
+        const nextTurnSeatId = nextSeatId;
         const fields = dedupeCompletedFields([
           ...(stateRef.current.game?.fields ?? []),
           normalizedField,
@@ -862,7 +836,6 @@ export function GameProvider({ children }: PropsWithChildren) {
           patch: {
             fields,
             currentTurnSeatId: nextTurnSeatId,
-            currentTurn: nextTurnSeatId,
             currentField: {
               cards: [],
               playedBy: [],
@@ -880,28 +853,18 @@ export function GameProvider({ children }: PropsWithChildren) {
       dispatch({ type: 'patchGame', patch: { teamScores: scores } });
     });
     socket.on('new-round-started', (payload) => {
-      const currentTurnSeatId = resolveSeatAlias(
-        payload.currentTurnSeatId,
-        payload.currentTurn,
-      );
-      const negriSeatId = resolveSeatAlias(
-        payload.negriSeatId,
-        payload.negriPlayerId,
-      );
       dispatch({ type: 'players', players: payload.players });
       dispatch({
         type: 'patchGame',
         patch: {
-          currentTurnSeatId,
-          currentTurn: currentTurnSeatId,
+          currentTurnSeatId: payload.currentTurnSeatId,
           gamePhase: payload.gamePhase,
           currentField: payload.currentField
             ? normalizeFieldIdentity(payload.currentField)
             : null,
           fields: dedupeCompletedFields(payload.completedFields),
           negriCard: payload.negriCard,
-          negriSeatId,
-          negriPlayerId: negriSeatId,
+          negriSeatId: payload.negriSeatId,
           revealedAgari: payload.revealedAgari,
           blowState: {
             ...createEmptyBlowState(),
@@ -941,8 +904,8 @@ export function GameProvider({ children }: PropsWithChildren) {
         dispatch({ type: 'notice', message: reconnectMessages[payload.code] });
       }
     });
-    socket.on('player-left', ({ playerId }) => {
-      if (playerId === resolveCurrentPlayerId()) {
+    socket.on('player-left', ({ seatId }) => {
+      if (seatId === asSeatId(resolveCurrentPlayerId() ?? '')) {
         void roomStorage.clear();
         dispatch({ type: 'resetRoom' });
       }
@@ -961,7 +924,7 @@ export function GameProvider({ children }: PropsWithChildren) {
       });
     });
     socket.on('player-disconnected', (payload) => {
-      const { playerId } = payload;
+      const playerId = payload.seatId;
       const playerName = (payload as { playerName?: string }).playerName;
       dispatch({ type: 'playerDisconnected', playerId });
       dispatch({
@@ -970,7 +933,7 @@ export function GameProvider({ children }: PropsWithChildren) {
       });
     });
     socket.on('player-idle', (payload) => {
-      const { playerId } = payload;
+      const playerId = payload.seatId;
       const playerName = (payload as { playerName?: string }).playerName;
       dispatch({ type: 'playerIdle', playerId });
       dispatch({
@@ -978,28 +941,28 @@ export function GameProvider({ children }: PropsWithChildren) {
         message: `${playerName ?? playerId} が無操作です`,
       });
     });
-    socket.on('player-idle-cleared', ({ playerId }) => {
-      dispatch({ type: 'playerIdleCleared', playerId });
+    socket.on('player-idle-cleared', ({ seatId }) => {
+      dispatch({ type: 'playerIdleCleared', playerId: seatId });
     });
     socket.on(
       'player-converted-to-com',
-      ({ playerId, playerName, message }) => {
-        dispatch({ type: 'playerConvertedToCom', playerId });
-        if (playerId === resolveCurrentPlayerId()) {
+      ({ seatId, playerName, message }) => {
+        dispatch({ type: 'playerConvertedToCom', playerId: seatId });
+        if (seatId === asSeatId(resolveCurrentPlayerId() ?? '')) {
           void roomStorage.clear();
           dispatch({ type: 'resetRoom' });
         }
-        dispatch({ type: 'notice', message: message ?? `${playerName ?? playerId} がCOMに置換されました` });
+        dispatch({ type: 'notice', message: message ?? `${playerName ?? seatId} がCOMに置換されました` });
       },
     );
     socket.on('name-updated', (payload) => {
-      if (!payload.success || !payload.playerId || !payload.name) return;
+      if (!payload.success || !payload.seatId || !payload.name) return;
       const game = stateRef.current.game;
       if (!game) return;
       dispatch({
         type: 'players',
         players: game.players.map((p) =>
-          p.playerId === payload.playerId
+          p.seatId === payload.seatId
             ? { ...p, name: payload.name! }
             : p,
         ),
@@ -1043,26 +1006,25 @@ export function GameProvider({ children }: PropsWithChildren) {
   useEffect(() => {
     const game = state.game;
     if (!canSendServerAction(false)) return;
-    if (!game || game.gamePhase !== 'blow' || !game.you) {
+    if (!game || game.gamePhase !== 'blow' || !game.youSeatId) {
       brokenRequestRef.current = null;
       return;
     }
 
     const currentPlayer = game.players.find(
-      (player) => player.playerId === game.you,
+      (player) => player.seatId === game.youSeatId,
     );
     if (!currentPlayer?.hasRequiredBroken) {
       brokenRequestRef.current = null;
       return;
     }
 
-    const key = `${game.roomId}:${game.you}:${currentPlayer.hand.join(',')}`;
+    const key = `${game.roomId}:${game.youSeatId}:${currentPlayer.hand.join(',')}`;
     if (brokenRequestRef.current === key) return;
     brokenRequestRef.current = key;
     socketRef.current?.emit('reveal-broken-hand', {
       roomId: game.roomId,
-      targetSeatId: resolveSeatAlias(undefined, game.you)!,
-      playerId: game.you,
+      targetSeatId: game.youSeatId,
     });
   }, [canSendServerAction, state.connectionStatus, state.game]);
 
@@ -1073,8 +1035,8 @@ export function GameProvider({ children }: PropsWithChildren) {
     if (
       !game ||
       game.gamePhase !== 'play' ||
-      !game.you ||
-      declaration?.playerId !== game.you ||
+      !game.youSeatId ||
+      declaration?.seatId !== game.youSeatId ||
       game.revealedAgari ||
       game.negriCard
     ) {
@@ -1229,7 +1191,7 @@ export function GameProvider({ children }: PropsWithChildren) {
       const actionKey = [
         actionName,
         roomId,
-        game?.currentTurn ?? '',
+        game?.currentTurnSeatId ?? '',
         game?.currentField?.cards.join(',') ?? '',
         game?.blowState.actionHistory.length ?? 0,
       ].join(':');
@@ -1244,7 +1206,7 @@ export function GameProvider({ children }: PropsWithChildren) {
   const declareBlow = useCallback(
     (trumpType: TrumpType, numberOfPairs: number) => {
       const game = stateRef.current.game;
-      if (!game || game.currentTurn !== game.you) {
+      if (!game || game.currentTurnSeatId !== game.youSeatId) {
         dispatch({ type: 'error', message: 'あなたの宣言順ではありません' });
         return;
       }
@@ -1260,7 +1222,7 @@ export function GameProvider({ children }: PropsWithChildren) {
 
   const passBlow = useCallback(() => {
     const game = stateRef.current.game;
-    if (!game || game.currentTurn !== game.you) {
+    if (!game || game.currentTurnSeatId !== game.youSeatId) {
       dispatch({ type: 'error', message: 'あなたの宣言順ではありません' });
       return;
     }
@@ -1279,7 +1241,7 @@ export function GameProvider({ children }: PropsWithChildren) {
 
   const playCard = useCallback((card: string) => {
     const game = stateRef.current.game;
-    if (!game || game.currentTurn !== game.you) {
+    if (!game || game.currentTurnSeatId !== game.youSeatId) {
       dispatch({ type: 'error', message: 'あなたのプレイ順ではありません' });
       return;
     }
@@ -1301,13 +1263,12 @@ export function GameProvider({ children }: PropsWithChildren) {
 
   const revealBrokenHand = useCallback(() => {
     const game = stateRef.current.game;
-    if (!game?.you) return;
-    const playerId = game.you;
+    if (!game?.youSeatId) return;
+    const selfSeatId = game.youSeatId;
     emitOneWayAction('reveal-broken-hand', game.roomId, () => {
       socketRef.current?.emit('reveal-broken-hand', {
         roomId: game.roomId,
-        targetSeatId: resolveSeatAlias(undefined, playerId)!,
-        playerId,
+        targetSeatId: selfSeatId,
       });
     });
   }, [emitOneWayAction]);
@@ -1320,8 +1281,7 @@ export function GameProvider({ children }: PropsWithChildren) {
       if (!roomId) return;
       const payload: ModeratePlayerPayload = {
         roomId,
-        targetSeatId: resolveSeatAlias(undefined, targetPlayerId)!,
-        targetPlayerId,
+        targetSeatId: asSeatId(targetPlayerId),
         action: 'remove',
       };
       void emitAck('moderate-player', payload);
@@ -1337,8 +1297,7 @@ export function GameProvider({ children }: PropsWithChildren) {
       if (!roomId) return;
       const payload: ModeratePlayerPayload = {
         roomId,
-        targetSeatId: resolveSeatAlias(undefined, targetPlayerId)!,
-        targetPlayerId,
+        targetSeatId: asSeatId(targetPlayerId),
         action: 'replace-with-com',
       };
       void emitAck('moderate-player', payload);
@@ -1374,15 +1333,16 @@ export function GameProvider({ children }: PropsWithChildren) {
     () => resolvePlayerId(state.game, state.currentRoom, user?.id),
     [state.currentRoom, state.game, user?.id],
   );
-  // Prefer the room's hostId: room-sync/room-updated keep it current, while
-  // game.hostId is captured once at game start and never refreshed. Without
+  // Prefer the room's host seat: room-sync/room-updated keep it current, while
+  // the game snapshot is captured once at game start and never refreshed. Without
   // this, a host transfer (e.g. the host disconnects) leaves every client
   // believing the departed player is still host, so nobody can replace them
   // with a COM. The web client reads a single currentHostId that both room and
   // game events write, which is the behaviour mirrored here.
   const isHost =
     Boolean(currentPlayerId) &&
-    (state.currentRoom?.hostId ?? state.game?.hostId) === currentPlayerId;
+    (state.currentRoom?.hostSeatId ?? state.game?.hostSeatId) ===
+      currentPlayerId;
 
   const value = useMemo<GameContextValue>(
     () => ({

--- a/mei-tra-mobile/src/context/__tests__/GameContext.test.tsx
+++ b/mei-tra-mobile/src/context/__tests__/GameContext.test.tsx
@@ -1,4 +1,5 @@
 import type { GameStatePayload, PlayerContract } from '@meitra/contracts/game';
+import { asSeatId } from '@meitra/contracts/ids';
 import type { RoomContract, RoomPlayerContract } from '@meitra/contracts/room';
 import React, { useEffect } from 'react';
 import { AppState } from 'react-native';
@@ -120,7 +121,7 @@ const createMockSocket = () => {
 
 const player = (overrides: Partial<PlayerContract> = {}): PlayerContract => ({
   socketId: 'socket-1',
-  playerId: 'player-1',
+  seatId: asSeatId('player-1'),
   userId: 'user-1',
   name: 'Player 1',
   team: 0,
@@ -144,11 +145,11 @@ const roomPlayer = (
 const createRoom = (): RoomContract => ({
   id: 'room-1',
   name: 'Test Room',
-  hostId: 'player-1',
+  hostSeatId: asSeatId('player-1'),
   status: 'playing',
   players: [
     roomPlayer(),
-    roomPlayer({ playerId: 'player-2', userId: 'user-2', team: 1 }),
+    roomPlayer({ seatId: asSeatId('player-2'), userId: 'user-2', team: 1 }),
   ],
   settings: {
     maxPlayers: 4,
@@ -167,23 +168,23 @@ const createGameState = (): GameStatePayload => ({
   roomId: 'room-1',
   players: [
     player(),
-    player({ playerId: 'player-2', userId: 'user-2', team: 1, hand: [] }),
+    player({ seatId: asSeatId('player-2'), userId: 'user-2', team: 1, hand: [] }),
   ],
   gamePhase: 'play',
   currentField: {
     cards: [],
-    playedBy: [],
+    playedBySeatIds: [],
     baseCard: '',
-    dealerId: 'player-1',
+    dealerSeatId: asSeatId('player-1'),
     isComplete: false,
   },
-  currentTurn: 'player-1',
+  currentTurnSeatId: asSeatId('player-1'),
   blowState: {
     currentTrump: 'zuppe',
     currentHighestDeclaration: null,
     declarations: [],
     actionHistory: [],
-    lastPasser: null,
+    lastPasserSeatId: null,
     isRoundCancelled: false,
     currentBlowIndex: 0,
   },
@@ -191,11 +192,12 @@ const createGameState = (): GameStatePayload => ({
     0: { play: 0, total: 0 },
     1: { play: 0, total: 0 },
   },
-  you: 'player-1',
+  youSeatId: asSeatId('player-1'),
   isSpectator: false,
   negriCard: null,
+  negriSeatId: null,
   fields: [],
-  hostId: 'player-1',
+  hostSeatId: asSeatId('player-1'),
   pointsToWin: 5,
 });
 
@@ -399,10 +401,10 @@ describe('GameProvider realtime resync safety', () => {
     await screen.unmount();
   });
 
-  it('applies the remapped field after a player is replaced with COM', async () => {
+  it('keeps the seat identity after a player is replaced with COM', async () => {
     const screen = await renderProvider();
     const comPlayer = player({
-      playerId: 'com-player-2',
+      seatId: asSeatId('player-2'),
       userId: undefined,
       name: 'COM 2',
       team: 1,
@@ -420,9 +422,9 @@ describe('GameProvider realtime resync safety', () => {
       mockSocket.trigger('update-players', [player(), comPlayer]);
       mockSocket.trigger('field-updated', {
         cards: ['J♠'],
-        playedBy: ['com-player-2'],
+        playedBySeatIds: [asSeatId('player-2')],
         baseCard: 'J♠',
-        dealerId: 'com-player-2',
+        dealerSeatId: asSeatId('player-2'),
         isComplete: false,
       });
       await flushPromises();
@@ -431,13 +433,13 @@ describe('GameProvider realtime resync safety', () => {
     expect(screen.latestGame.game?.players).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          playerId: 'com-player-2',
+          playerId: 'player-2',
           isCOM: true,
         }),
       ]),
     );
     expect(screen.latestGame.game?.currentField?.playedBy).toEqual([
-      'com-player-2',
+      'player-2',
     ]);
 
     await screen.unmount();

--- a/mei-tra-mobile/src/lib/__tests__/blow-ranking.test.ts
+++ b/mei-tra-mobile/src/lib/__tests__/blow-ranking.test.ts
@@ -1,4 +1,5 @@
 import type { BlowDeclarationContract } from '@meitra/contracts/game';
+import { asSeatId } from '@meitra/contracts/ids';
 
 import {
   getValidBlowPairValues,
@@ -9,7 +10,7 @@ import {
 const declaration = (
   overrides: Partial<BlowDeclarationContract> = {},
 ): BlowDeclarationContract => ({
-  playerId: 'player-1',
+  seatId: asSeatId('player-1'),
   trumpType: 'zuppe',
   numberOfPairs: 6,
   timestamp: 1,

--- a/mei-tra-mobile/src/lib/__tests__/cards.test.ts
+++ b/mei-tra-mobile/src/lib/__tests__/cards.test.ts
@@ -1,12 +1,13 @@
 import type { FieldContract } from '@meitra/contracts/game';
+import { asSeatId } from '@meitra/contracts/ids';
 
 import { isCardPlayable, parseCard } from '@/lib/cards';
 
 const field = (baseCard: string, cards = [baseCard]): FieldContract => ({
   cards,
-  playedBy: ['player-1'],
+  playedBySeatIds: [asSeatId('player-1')],
   baseCard,
-  dealerId: 'player-1',
+  dealerSeatId: asSeatId('player-1'),
   isComplete: false,
 });
 

--- a/mei-tra-mobile/src/lib/__tests__/game-state.test.ts
+++ b/mei-tra-mobile/src/lib/__tests__/game-state.test.ts
@@ -1,8 +1,8 @@
 import type {
   CompletedFieldContract,
-  PlayerContract,
 } from '@meitra/contracts/game';
 import { asSeatId } from '@meitra/contracts/ids';
+import { normalizeCompletedFieldIdentity } from '@meitra/game-client/identity';
 
 import {
   createEmptyBlowState,
@@ -13,14 +13,15 @@ import {
   resolvePlayerId,
   shouldAckTurn,
 } from '@/lib/game-state';
+import type { MobilePlayer } from '@/types/game';
 
 const player = (
   playerId: string,
-  overrides: Partial<PlayerContract> = {},
-): PlayerContract => ({
+  overrides: Partial<MobilePlayer> = {},
+): MobilePlayer => ({
   socketId: `socket-${playerId}`,
   seatId: asSeatId(playerId),
-  playerId,
+  playerId: asSeatId(playerId),
   name: playerId,
   userId: `user-${playerId}`,
   team: 0,
@@ -34,10 +35,8 @@ const completedField = (
 ): CompletedFieldContract => ({
   cards,
   winnerSeatId: asSeatId('player-1'),
-  winnerId: 'player-1',
   winnerTeam: 0,
   dealerSeatId: asSeatId('player-2'),
-  dealerId: 'player-2',
   ...overrides,
 });
 
@@ -79,12 +78,11 @@ describe('dedupeCompletedFields', () => {
     const duplicate = completedField(['J♠', 'Q♠']);
     const differentDealer = completedField(['J♠', 'Q♠'], {
       dealerSeatId: asSeatId('player-3'),
-      dealerId: 'player-3',
     });
 
     expect(dedupeCompletedFields([first, duplicate, differentDealer])).toEqual([
-      first,
-      differentDealer,
+      normalizeCompletedFieldIdentity(first),
+      normalizeCompletedFieldIdentity(differentDealer),
     ]);
   });
 });
@@ -97,38 +95,34 @@ describe('recovery helpers', () => {
       gamePhase: 'play',
       currentField: null,
       currentTurnSeatId: asSeatId('server-player'),
-      currentTurn: 'server-player',
       blowState: {
         currentTrump: 'club',
         currentHighestDeclaration: null,
         declarations: [],
         actionHistory: [],
-        lastPasser: null,
+        lastPasserSeatId: null,
         isRoundCancelled: false,
         currentBlowIndex: 0,
       },
       teamScores: { 0: { play: 1, total: 2 }, 1: { play: 0, total: 1 } },
       youSeatId: asSeatId('server-player'),
-      you: 'server-player',
       isSpectator: false,
       negriCard: '5♣',
       negriSeatId: asSeatId('server-player'),
-      negriPlayerId: 'stale-player',
       revealedAgari: 'J♣',
       fields: [completedField(['J♠', 'Q♠']), completedField(['J♠', 'Q♠'])],
+      hostSeatId: asSeatId('server-player'),
       pointsToWin: 5,
     });
 
     expect(snapshot.players).toEqual([expect.objectContaining({ playerId: 'server-player' })]);
     expect(snapshot.fields).toHaveLength(1);
-    expect(snapshot.you).toBe('server-player');
     expect(snapshot.youSeatId).toBe('server-player');
     expect(snapshot.negriSeatId).toBe('server-player');
-    expect(snapshot.negriPlayerId).toBe('server-player');
     expect(snapshot.revealedAgari).toBe('J♣');
   });
 
-  it('resolves the current player by playerId before userId', () => {
+  it('resolves the current seat from game state before userId', () => {
     expect(
       resolvePlayerId(
         {
@@ -137,27 +131,24 @@ describe('recovery helpers', () => {
           gamePhase: 'waiting',
           currentField: null,
           currentTurnSeatId: null,
-          currentTurn: null,
           blowState: {
             currentTrump: null,
             currentHighestDeclaration: null,
             declarations: [],
             actionHistory: [],
+            lastPasserSeatId: null,
             lastPasser: null,
             isRoundCancelled: false,
             currentBlowIndex: 0,
           },
           teamScores: { 0: { play: 0, total: 0 }, 1: { play: 0, total: 0 } },
           youSeatId: asSeatId('player-from-state'),
-          you: 'player-from-state',
           isSpectator: false,
           negriCard: null,
           negriSeatId: null,
-          negriPlayerId: null,
           revealedAgari: null,
           fields: [],
           hostSeatId: null,
-          hostId: null,
           pointsToWin: 5,
           paused: false,
           disconnectedPlayerIds: [],
@@ -167,7 +158,7 @@ describe('recovery helpers', () => {
           id: 'room-1',
           name: 'room',
           hostSeatId: asSeatId('host'),
-          hostId: 'host',
+          hostId: asSeatId('host'),
           status: 'waiting',
           players: [
             {
@@ -198,53 +189,27 @@ describe('recovery helpers', () => {
     expect(shouldAckTurn(null, 'room-1')).toBe(false);
   });
 
-  it('prefers canonical seat fields over legacy aliases', () => {
+  it('preserves canonical seat fields', () => {
     const snapshot = normalizeGameStatePayload({
       roomId: 'room-1',
-      players: [
-        player('legacy-player', { seatId: asSeatId('canonical-seat') }),
-      ],
+      players: [player('canonical-seat')],
       gamePhase: 'blow',
       currentField: null,
       currentTurnSeatId: asSeatId('canonical-seat'),
-      currentTurn: 'legacy-player',
       blowState: createEmptyBlowState(),
       teamScores: createEmptyScores(),
       youSeatId: asSeatId('canonical-seat'),
-      you: 'legacy-player',
       isSpectator: false,
       negriCard: null,
+      negriSeatId: null,
       fields: [],
       hostSeatId: asSeatId('canonical-seat'),
-      hostId: 'legacy-player',
       pointsToWin: 5,
     });
 
     expect(snapshot.players[0].playerId).toBe('canonical-seat');
-    expect(snapshot.currentTurn).toBe('canonical-seat');
-    expect(snapshot.you).toBe('canonical-seat');
-    expect(snapshot.hostId).toBe('canonical-seat');
-  });
-
-  it('falls back to legacy aliases when canonical fields are absent', () => {
-    const snapshot = normalizeGameStatePayload({
-      roomId: 'room-1',
-      players: [player('legacy-player', { seatId: undefined })],
-      gamePhase: 'blow',
-      currentField: null,
-      currentTurn: 'legacy-player',
-      blowState: createEmptyBlowState(),
-      teamScores: createEmptyScores(),
-      you: 'legacy-player',
-      isSpectator: false,
-      negriCard: null,
-      fields: [],
-      hostId: 'legacy-player',
-      pointsToWin: 5,
-    });
-
-    expect(snapshot.currentTurnSeatId).toBe('legacy-player');
-    expect(snapshot.youSeatId).toBe('legacy-player');
-    expect(snapshot.hostSeatId).toBe('legacy-player');
+    expect(snapshot.currentTurnSeatId).toBe('canonical-seat');
+    expect(snapshot.youSeatId).toBe('canonical-seat');
+    expect(snapshot.hostSeatId).toBe('canonical-seat');
   });
 });

--- a/mei-tra-mobile/src/lib/__tests__/socket-contract.test.ts
+++ b/mei-tra-mobile/src/lib/__tests__/socket-contract.test.ts
@@ -6,6 +6,7 @@ import type {
   NameUpdatedPayload,
   RoomActionPayload,
 } from '@meitra/contracts/socket';
+import { asSeatId } from '@meitra/contracts/ids';
 
 describe('socket contract client payload shapes', () => {
   it('keeps lobby action identity out of client payloads', () => {
@@ -18,7 +19,7 @@ describe('socket contract client payload shapes', () => {
     };
     const moderationPayload: ModeratePlayerPayload = {
       roomId: 'room-1',
-      targetPlayerId: 'player-2',
+      targetSeatId: asSeatId('player-2'),
       action: 'remove',
     };
 
@@ -31,7 +32,7 @@ describe('socket contract client payload shapes', () => {
     });
     expect(moderationPayload).toEqual({
       roomId: 'room-1',
-      targetPlayerId: 'player-2',
+      targetSeatId: 'player-2',
       action: 'remove',
     });
   });

--- a/mei-tra-mobile/src/lib/__tests__/table-order.test.ts
+++ b/mei-tra-mobile/src/lib/__tests__/table-order.test.ts
@@ -1,17 +1,11 @@
-import type { PlayerContract } from '@meitra/contracts/game';
-
 import {
   getCardSeatPosition,
   getSeatOrderWithSelfBottom,
 } from '@/lib/table-order';
 
-const player = (id: string): PlayerContract => ({
-  socketId: `socket-${id}`,
+const player = (id: string) => ({
   playerId: id,
-  name: id,
-  userId: `user-${id}`,
   team: 0,
-  hand: [],
 });
 
 describe('getSeatOrderWithSelfBottom', () => {

--- a/mei-tra-mobile/src/lib/game-log-rows.ts
+++ b/mei-tra-mobile/src/lib/game-log-rows.ts
@@ -2,7 +2,8 @@ import type {
   GameHistoryReplayEventContract,
   GameHistoryReplayViewContract,
 } from '@meitra/contracts/game-history';
-import type { PlayerContract, Team, TeamNames } from '@meitra/contracts/game';
+import type { Team, TeamNames } from '@meitra/contracts/game';
+import type { MobilePlayer } from '@/types/game';
 
 import { getTeamDisplayName } from './team-labels';
 import { trumpLabel } from './trump-labels';
@@ -132,7 +133,7 @@ function formatDelta(delta: number | undefined): string {
 
 export function buildRoundTableRows(
   replay: GameHistoryReplayViewContract | null,
-  players: PlayerContract[] = [],
+  players: MobilePlayer[] = [],
   teamNames?: TeamNames,
 ): RoundRow[] {
   if (!replay) return [];

--- a/mei-tra-mobile/src/lib/game-state.ts
+++ b/mei-tra-mobile/src/lib/game-state.ts
@@ -1,5 +1,4 @@
 import type {
-  BlowStateContract,
   CompletedFieldContract,
   GameStartedPayload,
   GameStatePayload,
@@ -7,35 +6,42 @@ import type {
   TransportTeamScores,
 } from '@meitra/contracts/game';
 import type { RoomContract } from '@meitra/contracts/room';
+import { asSeatId } from '@meitra/contracts/ids';
 import {
+  type CanonicalBlowState,
+  type CanonicalCompletedFieldContract,
   normalizeCompletedFieldIdentity,
   normalizeGameStateIdentity,
   normalizePlayerIdentities,
   normalizeRoomIdentity,
-  resolveSeatAlias,
 } from '@meitra/game-client/identity';
 
-import type { MobileGameSnapshot } from '@/types/game';
+import type {
+  MobileGameSnapshot,
+  MobilePlayer,
+  MobileRoom,
+} from '@/types/game';
 
 export const createEmptyScores = (): TransportTeamScores => ({
   0: { play: 0, total: 0 },
   1: { play: 0, total: 0 },
 });
 
-export const createEmptyBlowState = (): BlowStateContract => ({
+export const createEmptyBlowState = (): CanonicalBlowState => ({
   currentTrump: null,
   currentHighestDeclaration: null,
   declarations: [],
   actionHistory: [],
+  lastPasserSeatId: null,
   lastPasser: null,
   isRoundCancelled: false,
   currentBlowIndex: 0,
 });
 
 export const mergePlayersByIdentity = (
-  previous: PlayerContract[],
+  previous: MobilePlayer[],
   next: PlayerContract[],
-): PlayerContract[] => {
+): MobilePlayer[] => {
   const normalizedPrevious = normalizePlayerIdentities(previous);
   const normalizedNext = normalizePlayerIdentities(next);
   const previousByPlayerId = new Map(
@@ -60,7 +66,7 @@ export const mergePlayersByIdentity = (
 
 export const dedupeCompletedFields = (
   fields: CompletedFieldContract[],
-): CompletedFieldContract[] => {
+): CanonicalCompletedFieldContract[] => {
   const seen = new Set<string>();
   return fields.map(normalizeCompletedFieldIdentity).filter((field) => {
     const key = [
@@ -77,10 +83,10 @@ export const dedupeCompletedFields = (
 
 export const resolvePlayerId = (
   game: MobileGameSnapshot | null,
-  room: RoomContract | null,
+  room: MobileRoom | RoomContract | null,
   authenticatedUserId?: string | null,
 ): string | null => {
-  if (game?.youSeatId ?? game?.you) return game?.youSeatId ?? game?.you ?? null;
+  if (game?.youSeatId) return game.youSeatId;
   if (!authenticatedUserId) return null;
 
   if (!room) return null;
@@ -119,37 +125,33 @@ export const createStartedGameSnapshot = (
   hostId: string | null,
 ): MobileGameSnapshot => {
   const players = normalizePlayerIdentities(payload.players);
-  const youSeatId = resolveSeatAlias(undefined, currentPlayerId);
-  const hostSeatId = resolveSeatAlias(undefined, hostId);
+  const youSeatId = currentPlayerId ? asSeatId(currentPlayerId) : null;
+  const hostSeatId = hostId ? asSeatId(hostId) : null;
   return {
-  roomId: payload.roomId,
-  players,
-  gamePhase: 'blow',
-  currentField: null,
-  currentTurnSeatId: null,
-  currentTurn: null,
-  blowState: createEmptyBlowState(),
-  teamScores: createEmptyScores(),
-  youSeatId,
-  you: youSeatId,
-  isSpectator: false,
-  negriCard: null,
-  negriSeatId: null,
-  negriPlayerId: null,
-  revealedAgari: null,
-  fields: [],
-  hostSeatId,
-  hostId: hostSeatId,
-  pointsToWin: payload.pointsToWin,
-  paused: false,
-  disconnectedPlayerIds: [],
-  idlePlayerIds: [],
-  teamNames: payload.teamNames,
+    roomId: payload.roomId,
+    players,
+    gamePhase: 'blow',
+    currentField: null,
+    currentTurnSeatId: null,
+    blowState: createEmptyBlowState(),
+    teamScores: createEmptyScores(),
+    youSeatId,
+    isSpectator: false,
+    negriCard: null,
+    negriSeatId: null,
+    revealedAgari: null,
+    fields: [],
+    hostSeatId,
+    pointsToWin: payload.pointsToWin,
+    paused: false,
+    disconnectedPlayerIds: [],
+    idlePlayerIds: [],
+    teamNames: payload.teamNames,
   };
 };
 
 export const inferNextTurnAfterCardPlayed = (
-  players: PlayerContract[],
+  players: MobilePlayer[],
   field: { isComplete: boolean; cards: string[]; playedBy: string[]; baseCard: string; baseSuit?: string },
 ): string | null => {
   if (

--- a/mei-tra-mobile/src/types/game.ts
+++ b/mei-tra-mobile/src/types/game.ts
@@ -1,34 +1,36 @@
 import type {
-  BlowStateContract,
-  CompletedFieldContract,
-  FieldContract,
   PlayerContract,
   TeamNames,
   TransportGamePhase,
   TransportTeamScores,
 } from '@meitra/contracts/game';
 import type { SeatId } from '@meitra/contracts/ids';
+import type {
+  CanonicalBlowState,
+  CanonicalCompletedFieldContract,
+  CanonicalFieldContract,
+  CanonicalPlayerContract,
+  CanonicalRoomContract,
+} from '@meitra/game-client/identity';
+
+export type MobilePlayer = CanonicalPlayerContract<PlayerContract>;
+export type MobileRoom = CanonicalRoomContract;
 
 export interface MobileGameSnapshot {
   roomId: string;
-  players: PlayerContract[];
+  players: MobilePlayer[];
   gamePhase: TransportGamePhase;
-  currentField: FieldContract | null;
+  currentField: CanonicalFieldContract | null;
   currentTurnSeatId: SeatId | null;
-  currentTurn: string | null;
-  blowState: BlowStateContract;
+  blowState: CanonicalBlowState;
   teamScores: TransportTeamScores;
   youSeatId: SeatId | null;
-  you: string | null;
   isSpectator: boolean;
   negriCard: string | null;
   negriSeatId: SeatId | null;
-  /** @deprecated Use negriSeatId. */
-  negriPlayerId: string | null;
   revealedAgari: string | null;
-  fields: CompletedFieldContract[];
+  fields: CanonicalCompletedFieldContract[];
   hostSeatId: SeatId | null;
-  hostId: string | null;
   pointsToWin: number;
   paused: boolean;
   disconnectedPlayerIds: string[];

--- a/shared/game-client/identity.ts
+++ b/shared/game-client/identity.ts
@@ -8,7 +8,6 @@ import type {
   GameStatePayload,
 } from '@meitra/contracts/game';
 import type { SeatId } from '@meitra/contracts/ids';
-import { asSeatId } from '@meitra/contracts/ids';
 import type { RoomContract } from '@meitra/contracts/room';
 
 export type CanonicalPlayerContract<T extends ConnectionUserContract> = T & {
@@ -16,64 +15,58 @@ export type CanonicalPlayerContract<T extends ConnectionUserContract> = T & {
   playerId: SeatId;
 };
 
-export type CanonicalRoomContract = Omit<
-  RoomContract,
-  'hostSeatId' | 'hostId' | 'players'
-> & {
-  hostSeatId: SeatId;
+export type CanonicalRoomContract = Omit<RoomContract, 'players'> & {
   hostId: SeatId;
   players: Array<CanonicalPlayerContract<RoomContract['players'][number]>>;
+};
+
+export type CanonicalBlowDeclaration = BlowDeclarationContract & {
+  playerId: SeatId;
+};
+
+export type CanonicalBlowAction = BlowActionContract & {
+  playerId: SeatId;
+};
+
+export type CanonicalBlowState = Omit<
+  BlowStateContract,
+  'currentHighestDeclaration' | 'declarations' | 'actionHistory'
+> & {
+  currentHighestDeclaration: CanonicalBlowDeclaration | null;
+  declarations: CanonicalBlowDeclaration[];
+  actionHistory: CanonicalBlowAction[];
+  lastPasser: SeatId | null;
+};
+
+export type CanonicalFieldContract = FieldContract & {
+  playedBy: SeatId[];
+  dealerId: SeatId;
+};
+
+export type CanonicalCompletedFieldContract = CompletedFieldContract & {
+  winnerId: SeatId;
+  dealerId: SeatId;
 };
 
 export type CanonicalGameStatePayload = Omit<
   GameStatePayload,
   | 'players'
-  | 'currentTurnSeatId'
-  | 'currentTurn'
-  | 'youSeatId'
-  | 'you'
-  | 'hostSeatId'
-  | 'hostId'
-  | 'negriSeatId'
-  | 'negriPlayerId'
   | 'blowState'
   | 'currentField'
   | 'fields'
 > & {
   players: Array<CanonicalPlayerContract<GameStatePayload['players'][number]>>;
-  currentTurnSeatId: SeatId | null;
-  currentTurn: SeatId | null;
-  youSeatId: SeatId | null;
-  you: SeatId | null;
-  hostSeatId: SeatId | null;
-  hostId: SeatId | null;
-  negriSeatId: SeatId | null;
-  negriPlayerId: SeatId | null;
-  blowState: BlowStateContract;
-  currentField: FieldContract | null;
-  fields: CompletedFieldContract[];
-};
-
-export const resolveSeatAlias = (
-  seatId: SeatId | string | null | undefined,
-  legacyPlayerId: string | null | undefined,
-): SeatId | null => {
-  const value = seatId ?? legacyPlayerId;
-  return value ? asSeatId(value) : null;
+  blowState: CanonicalBlowState;
+  currentField: CanonicalFieldContract | null;
+  fields: CanonicalCompletedFieldContract[];
 };
 
 export const normalizePlayerIdentity = <T extends ConnectionUserContract>(
   player: T,
 ): CanonicalPlayerContract<T> => {
-  const seatId = resolveSeatAlias(player.seatId, player.playerId);
-  if (!seatId) {
-    throw new Error('Player payload omitted both seatId and playerId');
-  }
-
   return {
     ...player,
-    seatId,
-    playerId: seatId,
+    playerId: player.seatId,
   };
 };
 
@@ -84,21 +77,19 @@ export const normalizePlayerIdentities = <T extends ConnectionUserContract>(
 
 export const normalizeBlowDeclarationIdentity = (
   declaration: BlowDeclarationContract,
-): BlowDeclarationContract & { seatId: SeatId; playerId: SeatId } => {
-  const seatId = resolveSeatAlias(declaration.seatId, declaration.playerId)!;
-  return { ...declaration, seatId, playerId: seatId };
+): CanonicalBlowDeclaration => {
+  return { ...declaration, playerId: declaration.seatId };
 };
 
 export const normalizeBlowActionIdentity = (
   action: BlowActionContract,
-): BlowActionContract & { seatId: SeatId; playerId: SeatId } => {
-  const seatId = resolveSeatAlias(action.seatId, action.playerId)!;
-  return { ...action, seatId, playerId: seatId };
+): CanonicalBlowAction => {
+  return { ...action, playerId: action.seatId };
 };
 
 export const normalizeBlowStateIdentity = (
   blowState: BlowStateContract,
-): BlowStateContract => {
+): CanonicalBlowState => {
   const declarations = (blowState.declarations ?? []).map(
     normalizeBlowDeclarationIdentity,
   );
@@ -108,46 +99,32 @@ export const normalizeBlowStateIdentity = (
   const currentHighestDeclaration = blowState.currentHighestDeclaration
     ? normalizeBlowDeclarationIdentity(blowState.currentHighestDeclaration)
     : null;
-  const lastPasserSeatId = resolveSeatAlias(
-    blowState.lastPasserSeatId,
-    blowState.lastPasser,
-  );
-
   return {
     ...blowState,
     declarations,
     actionHistory,
     currentHighestDeclaration,
-    lastPasserSeatId,
-    lastPasser: lastPasserSeatId,
+    lastPasser: blowState.lastPasserSeatId,
   };
 };
 
-export const normalizeFieldIdentity = (field: FieldContract): FieldContract => {
-  const playedBySeatIds = (field.playedBySeatIds ?? field.playedBy).map(
-    (seatId) => asSeatId(seatId),
-  );
-  const dealerSeatId = resolveSeatAlias(field.dealerSeatId, field.dealerId)!;
+export const normalizeFieldIdentity = (
+  field: FieldContract,
+): CanonicalFieldContract => {
   return {
     ...field,
-    playedBy: playedBySeatIds,
-    playedBySeatIds,
-    dealerSeatId,
-    dealerId: dealerSeatId,
+    playedBy: [...field.playedBySeatIds],
+    dealerId: field.dealerSeatId,
   };
 };
 
 export const normalizeCompletedFieldIdentity = (
   field: CompletedFieldContract,
-): CompletedFieldContract => {
-  const winnerSeatId = resolveSeatAlias(field.winnerSeatId, field.winnerId)!;
-  const dealerSeatId = resolveSeatAlias(field.dealerSeatId, field.dealerId)!;
+): CanonicalCompletedFieldContract => {
   return {
     ...field,
-    winnerSeatId,
-    winnerId: winnerSeatId,
-    dealerSeatId,
-    dealerId: dealerSeatId,
+    winnerId: field.winnerSeatId,
+    dealerId: field.dealerSeatId,
   };
 };
 
@@ -155,15 +132,10 @@ export const normalizeRoomIdentity = (
   room: RoomContract,
 ): CanonicalRoomContract => {
   const players = normalizePlayerIdentities(room.players);
-  const hostSeatId = resolveSeatAlias(room.hostSeatId, room.hostId);
-  if (!hostSeatId) {
-    throw new Error(`Room payload omitted host identity: ${room.id}`);
-  }
 
   return {
     ...room,
-    hostSeatId,
-    hostId: hostSeatId,
+    hostId: room.hostSeatId,
     players,
   };
 };
@@ -171,33 +143,11 @@ export const normalizeRoomIdentity = (
 export const normalizeGameStateIdentity = (
   payload: GameStatePayload,
 ): CanonicalGameStatePayload => {
-  const currentTurnSeatId = resolveSeatAlias(
-    payload.currentTurnSeatId,
-    payload.currentTurn,
-  );
-  const youSeatId = resolveSeatAlias(payload.youSeatId, payload.you);
-  const hostSeatId = resolveSeatAlias(payload.hostSeatId, payload.hostId);
   const blowState = normalizeBlowStateIdentity(payload.blowState);
-  const negriSeatId =
-    resolveSeatAlias(payload.negriSeatId, payload.negriPlayerId) ??
-    (payload.negriCard && blowState.currentHighestDeclaration
-      ? resolveSeatAlias(
-          blowState.currentHighestDeclaration.seatId,
-          blowState.currentHighestDeclaration.playerId,
-        )
-      : null);
 
   return {
     ...payload,
     players: normalizePlayerIdentities(payload.players),
-    currentTurnSeatId,
-    currentTurn: currentTurnSeatId,
-    youSeatId,
-    you: youSeatId,
-    hostSeatId,
-    hostId: hostSeatId,
-    negriSeatId,
-    negriPlayerId: negriSeatId,
     blowState,
     currentField: payload.currentField
       ? normalizeFieldIdentity(payload.currentField)


### PR DESCRIPTION
## Summary

Use Case内部はseat UUIDのcanonical payloadだけを扱い、旧`playerId`系aliasはSocket送信境界で再帰的に付与します。公開契約の旧alias必須保証は維持しました。

## User-facing change

Web・Mobileの旧版を含め、従来のSocket項目を受け取ったまま対局できます。

## User benefit

互換処理がゲーム進行へ混ざらず、再接続や手番変更の参照ずれを防ぎやすくなります。

## Validation

- Backend: 64 suites / 396 tests
- Backend build
- changed-file ESLint / Prettier / `git diff --check`
- Frontend production build
- Mobile typecheck
