### PR TITLE
空席snapshotをseat UUIDで管理

### DIFF
--- a/mei-tra-backend/src/services/__tests__/com-session.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-session.service.spec.ts
@@ -2,6 +2,8 @@ import { ComSessionService } from '../com-session.service';
 import { IComPlayerService } from '../interfaces/com-player-service.interface';
 import { GameStateService } from '../game-state.service';
 import { Room } from '../../types/room.types';
+import type { VacantSeats } from '../../types/vacant-seat.types';
+import { asSeatId } from '../../types/identity.types';
 
 const HUMAN_ID = 'human-1';
 
@@ -79,13 +81,14 @@ describe('ComSessionService.convertPlayerToCOM', () => {
       createComPlayer: jest.fn(),
     } as unknown as IComPlayerService);
     const { gameState } = createGameStateStub();
+    const vacantSeats: VacantSeats = {};
 
     const converted = await service.convertPlayerToCOM(
       'room-1',
       HUMAN_ID,
       createRoom(),
       gameState,
-      {},
+      vacantSeats,
     );
 
     expect(converted).toBe(true);
@@ -98,6 +101,10 @@ describe('ComSessionService.convertPlayerToCOM', () => {
     expect(state.playState!.currentField!.dealerId).toBe(comId);
     expect(state.teamAssignments[comId]).toBe(0);
     expect(state.currentPlayerId).toBe(comId);
+    expect(Object.keys(vacantSeats['room-1'])).toEqual([HUMAN_ID]);
+    expect(vacantSeats['room-1'][asSeatId(HUMAN_ID)].roomPlayer.playerId).toBe(
+      HUMAN_ID,
+    );
   });
 
   it('keeps the seat owner only for a disconnect-timeout COM replacement', async () => {

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -727,7 +727,7 @@ describe('Reconnection Token Management', () => {
         expect(tokenMap.get(playerId)).toBe(playerId);
       });
 
-      it('should remap current play state references to the COM player', async () => {
+      it('should keep current play references on the stable seat', async () => {
         const roomId = 'room-123';
         const playerId = 'player-1';
 
@@ -821,7 +821,7 @@ describe('Reconnection Token Management', () => {
         expect(gameState.getState().teamAssignments[comPlayerId]).toBe(0);
       });
 
-      it('should remap current blow state references to the COM player', async () => {
+      it('should keep current blow references on the stable seat', async () => {
         const roomId = 'room-123';
         const playerId = 'player-1';
 
@@ -1225,10 +1225,10 @@ describe('Reconnection Token Management', () => {
         ];
         (
           roomService as unknown as {
-            vacantSeats: Record<string, Record<number, unknown>>;
+            vacantSeats: Record<string, Record<string, unknown>>;
           }
         ).vacantSeats[roomId] = {
-          0: {
+          [seatId]: {
             roomPlayer: {
               ...timeoutCOM,
               socketId: '',
@@ -1238,7 +1238,6 @@ describe('Reconnection Token Management', () => {
               name: 'Owner',
               isCOM: false,
             },
-            replacementPlayerId: seatId,
           },
         };
 
@@ -1281,7 +1280,7 @@ describe('Reconnection Token Management', () => {
         // Setup: player left, vacantSeat exists with their playerId
         const comPlayer: RoomPlayer = {
           socketId: 'com-0',
-          playerId: 'com-0',
+          playerId,
           name: 'COM',
           team: 0,
           hand: [],
@@ -1299,11 +1298,18 @@ describe('Reconnection Token Management', () => {
         };
 
         const roomState = bindRoomRepositoryToState(room);
+        const gameState = await roomService.getRoomGameState(roomId);
+        gameState.getState().players = [
+          makeGamePlayer(playerId, 'COM', 0, {
+            hand: ['H2', 'D3', 'C4'],
+            isCOM: true,
+          }),
+        ];
 
         // Manually set vacantSeat (simulating previous leave)
 
         (roomService as any)['vacantSeats'][roomId] = {
-          0: {
+          [playerId]: {
             roomPlayer: {
               socketId: '',
               playerId,
@@ -1524,7 +1530,7 @@ describe('Reconnection Token Management', () => {
 
         const targetCom: RoomPlayer = {
           socketId: 'com-target',
-          playerId: 'com-target',
+          playerId,
           name: 'COM',
           team: 0,
           hand: [],
@@ -1567,11 +1573,10 @@ describe('Reconnection Token Management', () => {
           },
         ];
 
-        // Simulate a stored vacant seat that used to be index 0, while the
-        // current repository order now places the replacement com at index 1.
+        // The current repository order places the vacant seat at index 1.
 
         (roomService as any)['vacantSeats'][roomId] = {
-          0: {
+          [playerId]: {
             roomPlayer: {
               socketId: '',
               playerId,
@@ -1595,7 +1600,6 @@ describe('Reconnection Token Management', () => {
               hasBroken: false,
               hasRequiredBroken: false,
             },
-            replacementPlayerId: targetCom.playerId,
           },
         };
 
@@ -1630,7 +1634,7 @@ describe('Reconnection Token Management', () => {
 
         const targetCom: RoomPlayer = {
           socketId: 'com-target',
-          playerId: 'com-target',
+          playerId,
           name: 'COM',
           team: 0,
           hand: ['H2', 'D3'],
@@ -1668,7 +1672,7 @@ describe('Reconnection Token Management', () => {
         // played one and only holds two.
 
         (roomService as any)['vacantSeats'][roomId] = {
-          0: {
+          [playerId]: {
             roomPlayer: {
               socketId: '',
               playerId,
@@ -1692,7 +1696,6 @@ describe('Reconnection Token Management', () => {
               hasBroken: false,
               hasRequiredBroken: false,
             },
-            replacementPlayerId: targetCom.playerId,
           },
         };
 
@@ -1709,7 +1712,7 @@ describe('Reconnection Token Management', () => {
         expect(gameState.getState().players[0].isPasser).toBe(true);
       });
 
-      it('should remap com ids in current field and completed fields on rejoin', async () => {
+      it('should keep field references on the stable seat when a player rejoins', async () => {
         const roomId = 'room-123';
         const playerId = 'player-1';
         const user = {
@@ -1720,7 +1723,7 @@ describe('Reconnection Token Management', () => {
 
         const targetCom: RoomPlayer = {
           socketId: 'com-target',
-          playerId: 'com-target',
+          playerId,
           name: 'COM',
           team: 0,
           hand: ['H2', 'D3'],
@@ -1783,7 +1786,7 @@ describe('Reconnection Token Management', () => {
         gameState.getState().teamAssignments[targetCom.playerId] = 0;
 
         (roomService as any)['vacantSeats'][roomId] = {
-          0: {
+          [playerId]: {
             roomPlayer: {
               socketId: '',
               playerId,
@@ -1807,7 +1810,6 @@ describe('Reconnection Token Management', () => {
               hasBroken: false,
               hasRequiredBroken: false,
             },
-            replacementPlayerId: targetCom.playerId,
           },
         };
 
@@ -1843,7 +1845,7 @@ describe('Reconnection Token Management', () => {
         );
       });
 
-      it('should remap blow state references from COM back to the player on rejoin', async () => {
+      it('should keep blow references on the stable seat when a player rejoins', async () => {
         const roomId = 'room-123';
         const playerId = 'player-1';
         const user = {
@@ -1854,7 +1856,7 @@ describe('Reconnection Token Management', () => {
 
         const targetCom: RoomPlayer = {
           socketId: 'com-target',
-          playerId: 'com-target',
+          playerId,
           name: 'COM',
           team: 0,
           hand: ['H2', 'D3'],
@@ -1923,7 +1925,7 @@ describe('Reconnection Token Management', () => {
         };
 
         (roomService as any)['vacantSeats'][roomId] = {
-          0: {
+          [playerId]: {
             roomPlayer: {
               socketId: '',
               playerId,
@@ -1947,7 +1949,6 @@ describe('Reconnection Token Management', () => {
               hasBroken: false,
               hasRequiredBroken: false,
             },
-            replacementPlayerId: targetCom.playerId,
           },
         };
 
@@ -2097,8 +2098,7 @@ describe('Reconnection Token Management', () => {
 
       it('should inherit the original seat blow action when a different player takes a vacant blow seat', async () => {
         const roomId = 'room-123';
-        const originalPlayerId = 'player-left';
-        const replacingComId = 'com-left';
+        const seatId = 'seat-left';
         const joiningPlayerId = 'player-join';
         const nextPlayerId = 'player-next';
         const user = {
@@ -2108,7 +2108,7 @@ describe('Reconnection Token Management', () => {
         };
         const comPlayer: RoomPlayer = {
           socketId: 'com-socket',
-          playerId: replacingComId,
+          playerId: seatId,
           name: 'COM',
           team: 0,
           hand: ['H2', 'D3'],
@@ -2152,7 +2152,7 @@ describe('Reconnection Token Management', () => {
         gameState.getState().gamePhase = 'blow';
         gameState.getState().players = [
           {
-            playerId: replacingComId,
+            playerId: seatId,
             name: 'COM',
             team: 0,
             hand: ['H2', 'D3'],
@@ -2171,18 +2171,18 @@ describe('Reconnection Token Management', () => {
             hasRequiredBroken: false,
           },
         ];
-        gameState.getState().currentSeatId = asSeatId(replacingComId);
+        gameState.getState().currentSeatId = asSeatId(seatId);
         gameState.getState().blowState = {
           currentTrump: null,
           currentHighestDeclaration: {
-            playerId: replacingComId,
+            playerId: seatId,
             trumpType: 'club',
             numberOfPairs: 7,
             timestamp: 1,
           },
           declarations: [
             {
-              playerId: replacingComId,
+              playerId: seatId,
               trumpType: 'club',
               numberOfPairs: 7,
               timestamp: 1,
@@ -2191,7 +2191,7 @@ describe('Reconnection Token Management', () => {
           actionHistory: [
             {
               type: 'declare',
-              playerId: replacingComId,
+              playerId: seatId,
               trumpType: 'club',
               numberOfPairs: 7,
               timestamp: 1,
@@ -2207,17 +2207,17 @@ describe('Reconnection Token Management', () => {
         gameStateRepository.persistRoomRoster.mockImplementationOnce(
           async (_roomId, _roomPlayers, state) => ({
             ...state,
-            currentPlayerId: replacingComId,
+            currentPlayerId: seatId,
             currentPlayerIndex: 0,
             blowState: stalePersistedBlowState,
             version: (state.version ?? 0) + 1,
           }),
         );
         (roomService as any)['vacantSeats'][roomId] = {
-          0: {
+          [seatId]: {
             roomPlayer: {
               socketId: 'socket-left',
-              playerId: originalPlayerId,
+              playerId: seatId,
               name: 'Left Player',
               team: 0,
               hand: ['H2', 'D3'],
@@ -2229,7 +2229,7 @@ describe('Reconnection Token Management', () => {
               joinedAt: new Date('2026-03-13T09:59:00.000Z'),
             },
             gamePlayer: {
-              playerId: originalPlayerId,
+              playerId: seatId,
               name: 'Left Player',
               team: 0,
               hand: ['H2', 'D3'],
@@ -2237,22 +2237,21 @@ describe('Reconnection Token Management', () => {
               hasBroken: false,
               hasRequiredBroken: false,
             },
-            replacementPlayerId: replacingComId,
           },
         };
 
         const result = await roomService.joinRoom(roomId, user);
 
         expect(result).toBe(true);
-        expect(gameState.getState().players[0]?.playerId).toBe(replacingComId);
+        expect(gameState.getState().players[0]?.playerId).toBe(seatId);
         expect(
           gameState.getState().blowState.currentHighestDeclaration?.playerId,
-        ).toBe(replacingComId);
+        ).toBe(seatId);
         expect(gameState.getState().blowState.declarations[0]?.playerId).toBe(
-          replacingComId,
+          seatId,
         );
         expect(gameState.getState().blowState.actionHistory[0]?.playerId).toBe(
-          replacingComId,
+          seatId,
         );
         expect(gameState.getState().currentSeatId).toBe(nextPlayerId);
         expect(gameState.getCurrentPlayerIndex()).toBe(1);
@@ -2264,13 +2263,12 @@ describe('Reconnection Token Management', () => {
         expect(
           gameStateRepository.update.mock.calls.some(
             ([, update]) =>
-              update.blowState?.currentHighestDeclaration?.playerId ===
-              replacingComId,
+              update.blowState?.currentHighestDeclaration?.playerId === seatId,
           ),
         ).toBe(true);
       });
 
-      it('should allow different player to take vacant seat and remove original token', async () => {
+      it('should let a different player claim a vacant seat without changing its id', async () => {
         const roomId = 'room-123';
         const originalPlayerId = 'player-1';
         const newUser = {
@@ -2281,7 +2279,7 @@ describe('Reconnection Token Management', () => {
 
         const comPlayer: RoomPlayer = {
           socketId: 'com-0',
-          playerId: 'com-0',
+          playerId: originalPlayerId,
           name: 'COM',
           team: 0,
           hand: [],
@@ -2305,7 +2303,7 @@ describe('Reconnection Token Management', () => {
         gameState.registerPlayerToken(originalPlayerId, originalPlayerId);
 
         (roomService as any)['vacantSeats'][roomId] = {
-          0: {
+          [originalPlayerId]: {
             roomPlayer: {
               socketId: '',
               playerId: originalPlayerId,
@@ -2343,14 +2341,13 @@ describe('Reconnection Token Management', () => {
         expect(updatedRoom?.players[0].hand).toEqual([]);
         expect(gameState.getState().players[0].hand).toEqual(['H2', 'D3']);
 
-        // Original player's token should be removed
-        // Token is gone, so findPlayerByReconnectToken uses fallback (playerId direct search)
-        // But original player is not in players array, so it should be null
-        expect(
-          gameState
-            .getState()
-            .players.find((p) => p.playerId === originalPlayerId),
-        ).toBeUndefined();
+        expect(gameState.getState().players[0]).toEqual(
+          expect.objectContaining({
+            playerId: originalPlayerId,
+            name: 'New Player',
+            isCOM: false,
+          }),
+        );
       });
     });
 
@@ -2392,12 +2389,11 @@ describe('Reconnection Token Management', () => {
       (
         roomService as unknown as { vacantSeats: Record<string, unknown> }
       ).vacantSeats[roomId] = {
-        0: {
+        [playerId]: {
           roomPlayer: {
             ...roomState.getPersistedRoom()!.players[0],
             name: 'Original Player',
           },
-          replacementPlayerId: playerId,
         },
       };
 
@@ -2434,7 +2430,7 @@ describe('Reconnection Token Management', () => {
 
         const comPlayer: RoomPlayer = {
           socketId: 'com-0',
-          playerId: 'com-0',
+          playerId,
           name: 'COM',
           team: 0,
           hand: [],
@@ -2458,7 +2454,7 @@ describe('Reconnection Token Management', () => {
         const gameState = await roomService.getRoomGameState(roomId);
         gameState.getState().players = [
           {
-            playerId: 'com-0',
+            playerId,
             name: 'COM',
             team: 0,
             hand: [],
@@ -2494,7 +2490,7 @@ describe('Reconnection Token Management', () => {
         };
 
         (roomService as any)['vacantSeats'][roomId] = {
-          0: {
+          [playerId]: {
             roomPlayer: roomSnapshot,
             gamePlayer: gameSnapshot,
           },
@@ -2861,6 +2857,9 @@ describe('Reconnection Token Management', () => {
         // Verify vacantSeats contains the player's data
         /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument */
         expect((roomService as any)['vacantSeats'][roomId]).toBeDefined();
+        expect(
+          Object.keys((roomService as any)['vacantSeats'][roomId]),
+        ).toEqual([playerId]);
         const vacantSeat = Object.values(
           (roomService as any)['vacantSeats'][roomId],
         )[0] as any;

--- a/mei-tra-backend/src/services/__tests__/room.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room.service.spec.ts
@@ -1,7 +1,8 @@
 import { RoomService } from '../room.service';
 import { Room, RoomPlayer, RoomStatus } from '../../types/room.types';
 import { DomainPlayer, Team } from '../../types/game.types';
-import { VacantSeats } from '../com-session.service';
+import type { VacantSeats } from '../../types/vacant-seat.types';
+import { asSeatId } from '../../types/identity.types';
 
 const createRoomPlayer = (overrides: Partial<RoomPlayer> = {}): RoomPlayer => ({
   socketId: 'socket-1',
@@ -144,10 +145,11 @@ describe('RoomService join rollback', () => {
       name: 'Vacant',
       isHost: false,
     });
+    const vacantSeatId = asSeatId(originalVacantSeat.playerId);
     (
       service as unknown as { vacantSeats: Record<string, unknown> }
     ).vacantSeats['room-1'] = {
-      2: {
+      [vacantSeatId]: {
         roomPlayer: originalVacantSeat,
       },
     };
@@ -164,14 +166,16 @@ describe('RoomService join rollback', () => {
 
     const internals = service as unknown as {
       roomGameStates: Map<string, unknown>;
-      vacantSeats: Record<string, Record<number, { roomPlayer: RoomPlayer }>>;
+      vacantSeats: VacantSeats;
     };
     expect(internals.roomGameStates.get('room-1')).toBe(reloadedGameState);
-    expect(internals.vacantSeats['room-1'][2].roomPlayer).toMatchObject({
+    expect(
+      internals.vacantSeats['room-1'][vacantSeatId].roomPlayer,
+    ).toMatchObject({
       playerId: 'vacant-player',
       userId: 'vacant-user',
     });
-    expect(internals.vacantSeats['room-1'][2].roomPlayer).not.toBe(
+    expect(internals.vacantSeats['room-1'][vacantSeatId].roomPlayer).not.toBe(
       originalVacantSeat,
     );
     expect(reloadedGameState.loadState).toHaveBeenCalledWith('room-1');

--- a/mei-tra-backend/src/services/com-session.service.ts
+++ b/mei-tra-backend/src/services/com-session.service.ts
@@ -8,18 +8,7 @@ import { randomUUID } from 'crypto';
 import { asSeatId, resolveSeatId } from '../types/identity.types';
 import { RosterMembershipMutation } from '../types/room-membership.types';
 import { upsertRuntimeSeat } from './runtime-seat-roster';
-
-export type VacantSeats = Record<
-  string,
-  Record<
-    number,
-    {
-      roomPlayer: RoomPlayer;
-      gamePlayer?: DomainPlayer;
-      replacementPlayerId?: string;
-    }
-  >
->;
+import type { VacantSeats } from '../types/vacant-seat.types';
 
 @Injectable()
 export class ComSessionService {
@@ -222,13 +211,13 @@ export class ComSessionService {
       comPlayer.participantKey = room.players[playerIndex].participantKey;
     }
 
-    vacantSeats[roomId][playerIndex] = {
+    const seatId = resolveSeatId(room.players[playerIndex]);
+    vacantSeats[roomId][seatId] = {
       roomPlayer: this.cloneRoomPlayer(room.players[playerIndex]),
       gamePlayer:
         gsIndex !== -1
           ? this.cloneGamePlayer(state.players[gsIndex])
           : undefined,
-      replacementPlayerId: comPlayer.playerId,
     };
 
     upsertRuntimeSeat(room, state, comPlayer, {

--- a/mei-tra-backend/src/services/com-strategy.service.ts
+++ b/mei-tra-backend/src/services/com-strategy.service.ts
@@ -77,7 +77,7 @@ export class ComStrategyService implements IComStrategyService {
     // A seat that already declared has no legal action left: declare-blow and
     // pass-blow both reject it (hasPlayerDeclaredInBlow). This is reachable
     // because a COM inherits the declaration of the human it replaced — the
-    // remap correctly moves the bid to the seat, so the COM sees its own bid.
+    // The bid already belongs to the stable seat, so the COM sees it directly.
     // Returning 'skip' lets the caller advance the turn instead of retrying an
     // action the rules forbid.
     if (hasPlayerDeclaredInBlow(state.blowState, comPlayer.playerId)) {

--- a/mei-tra-backend/src/services/room-join.service.ts
+++ b/mei-tra-backend/src/services/room-join.service.ts
@@ -2,7 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { BlowState, DomainPlayer, GameState, Team } from '../types/game.types';
 import { Room, RoomPlayer } from '../types/room.types';
 import { GameStateService } from './game-state.service';
-import { VacantSeats } from './com-session.service';
+import type {
+  VacantSeats,
+  VacantSeatSnapshot,
+} from '../types/vacant-seat.types';
 import { SessionUser } from '../types/session.types';
 import { randomUUID } from 'crypto';
 import { asSeatId, resolveSeatId } from '../types/identity.types';
@@ -21,11 +24,7 @@ interface JoinRoomParams {
   vacantSeats: VacantSeats;
 }
 
-interface RestoredSeatData {
-  roomPlayer: RoomPlayer;
-  gamePlayer?: DomainPlayer;
-  replacementPlayerId?: string;
-}
+type RestoredSeatData = VacantSeatSnapshot;
 
 @Injectable()
 export class RoomJoinService {
@@ -36,7 +35,6 @@ export class RoomJoinService {
     user,
     vacantSeats,
   }: JoinRoomParams): Promise<boolean> {
-    void roomId;
     const state = gameState.getState();
 
     const existingPlayer = this.findExistingRoomPlayer(room.players, user);
@@ -50,10 +48,10 @@ export class RoomJoinService {
         return false;
       }
 
-      const reclaimingVacantSeatIndex = Object.entries(
+      const reclaimingVacantSeatId = Object.entries(
         vacantSeats[roomId] ?? {},
-      ).find(([, seatData]) => {
-        if (seatData.replacementPlayerId !== existingPlayer.playerId) {
+      ).find(([seatId, seatData]) => {
+        if (seatId !== existingPlayer.playerId) {
           return false;
         }
         return user.userId
@@ -63,7 +61,7 @@ export class RoomJoinService {
       const reclaimingCOMSeat = Boolean(
         existingPlayer.isCOM &&
           ((user.userId && existingPlayer.userId === user.userId) ||
-            reclaimingVacantSeatIndex !== undefined),
+            reclaimingVacantSeatId !== undefined),
       );
       const updatedPlayer: RoomPlayer = {
         ...existingPlayer,
@@ -102,8 +100,8 @@ export class RoomJoinService {
         room.hostId,
         this.buildMembershipClaim(user),
       );
-      if (reclaimingVacantSeatIndex !== undefined) {
-        delete vacantSeats[roomId][Number(reclaimingVacantSeatIndex)];
+      if (reclaimingVacantSeatId !== undefined) {
+        delete vacantSeats[roomId][asSeatId(reclaimingVacantSeatId)];
         if (Object.keys(vacantSeats[roomId] ?? {}).length === 0) {
           delete vacantSeats[roomId];
         }
@@ -119,54 +117,52 @@ export class RoomJoinService {
     }
 
     const roomVacant = vacantSeats[roomId] || {};
-    const vacantIndexes = Object.keys(roomVacant).map(Number);
+    const vacantEntries = Object.entries(roomVacant);
     let assignedIndex = -1;
     let gsAssignedIndex = -1;
     let team: Team = 0;
     let replacingComId: string | null = null;
     let restoredSeatData: RestoredSeatData | null = null;
 
-    const matchingVacantIndex = vacantIndexes.find(
-      (index) => roomVacant[index]?.roomPlayer.playerId === user.playerId,
+    const matchingVacantEntry = vacantEntries.find(
+      ([, seatData]) => seatData.roomPlayer.playerId === user.playerId,
     );
 
-    if (matchingVacantIndex !== undefined) {
-      assignedIndex = matchingVacantIndex;
-      const seatData = roomVacant[assignedIndex];
-      const seatRoomPlayer = seatData?.roomPlayer;
+    if (matchingVacantEntry) {
+      const [vacantSeatId, seatData] = matchingVacantEntry;
+      assignedIndex = this.resolveVacantSeatIndex(room, vacantSeatId);
+      if (assignedIndex === -1) {
+        return false;
+      }
+      const seatRoomPlayer = seatData.roomPlayer;
 
       team = seatRoomPlayer ? seatRoomPlayer.team : team;
-      restoredSeatData = seatData ?? null;
+      restoredSeatData = seatData;
       gameState.clearDisconnectTimeout(user.playerId);
-      delete roomVacant[assignedIndex];
+      delete roomVacant[asSeatId(vacantSeatId)];
       if (Object.keys(roomVacant).length === 0) {
         delete vacantSeats[roomId];
       }
     } else {
-      const availableVacantIndex = vacantIndexes.find((index) => {
-        const seatData = roomVacant[index];
-        const currentSeat = seatData?.replacementPlayerId
-          ? room.players.find(
-              (player) => player.playerId === seatData.replacementPlayerId,
-            )
-          : room.players[index];
-        return !currentSeat?.userId;
+      const availableVacantEntry = vacantEntries.find(([vacantSeatId]) => {
+        const currentSeat = room.players.find(
+          (player) => player.playerId === vacantSeatId,
+        );
+        return Boolean(currentSeat && !currentSeat.userId);
       });
 
-      if (availableVacantIndex !== undefined) {
-        assignedIndex = availableVacantIndex;
-        const seatData = roomVacant[assignedIndex];
-        const seatRoomPlayer = seatData?.roomPlayer;
-        team = seatRoomPlayer ? seatRoomPlayer.team : team;
+      if (availableVacantEntry) {
+        const [vacantSeatId, seatData] = availableVacantEntry;
+        assignedIndex = this.resolveVacantSeatIndex(room, vacantSeatId);
+        const seatRoomPlayer = seatData.roomPlayer;
+        team = seatRoomPlayer.team;
 
-        const originalPlayerId = seatRoomPlayer?.playerId;
-        if (originalPlayerId) {
-          gameState.removePlayerToken(originalPlayerId);
-          gameState.clearDisconnectTimeout(originalPlayerId);
-        }
+        const originalPlayerId = seatRoomPlayer.playerId;
+        gameState.removePlayerToken(originalPlayerId);
+        gameState.clearDisconnectTimeout(originalPlayerId);
 
-        restoredSeatData = seatData ?? null;
-        delete roomVacant[assignedIndex];
+        restoredSeatData = seatData;
+        delete roomVacant[asSeatId(vacantSeatId)];
         if (Object.keys(roomVacant).length === 0) {
           delete vacantSeats[roomId];
         }
@@ -219,17 +215,8 @@ export class RoomJoinService {
 
     const seatRoomSnapshot = restoredSeatData?.roomPlayer;
     const seatGameSnapshot = restoredSeatData?.gamePlayer;
-    const replacementPlayerId = restoredSeatData?.replacementPlayerId;
 
-    if (replacementPlayerId) {
-      const currentRoomSeatIndex = room.players.findIndex(
-        (player) => player.playerId === replacementPlayerId,
-      );
-      if (currentRoomSeatIndex !== -1) {
-        assignedIndex = currentRoomSeatIndex;
-        replacingComId = replacementPlayerId;
-      }
-    } else if (assignedIndex !== -1) {
+    if (assignedIndex !== -1) {
       replacingComId = room.players[assignedIndex]?.playerId || null;
     }
 
@@ -265,11 +252,6 @@ export class RoomJoinService {
         : new Date(),
     };
 
-    if (replacementPlayerId) {
-      gsAssignedIndex = state.players.findIndex(
-        (statePlayer) => statePlayer.playerId === replacementPlayerId,
-      );
-    }
     if (gsAssignedIndex === -1 && replacingComId) {
       gsAssignedIndex = state.players.findIndex(
         (statePlayer) => statePlayer.playerId === replacingComId,
@@ -316,6 +298,10 @@ export class RoomJoinService {
 
   private countActualPlayers(players: RoomPlayer[]): number {
     return players.filter((player) => !player.isCOM).length;
+  }
+
+  private resolveVacantSeatIndex(room: Room, vacantSeatId: string): number {
+    return room.players.findIndex((player) => player.playerId === vacantSeatId);
   }
 
   private buildMembershipClaim(

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -16,7 +16,7 @@ import { IUserProfileRepository } from '../repositories/interfaces/user-profile.
 import { IRoomService } from './interfaces/room-service.interface';
 import { IComPlayerService } from './interfaces/com-player-service.interface';
 import { UserGameStatsService } from './user-game-stats.service';
-import { ComSessionService, VacantSeats } from './com-session.service';
+import { ComSessionService } from './com-session.service';
 import { SeatRestorationService } from './seat-restoration.service';
 import { RoomJoinService } from './room-join.service';
 import { PlayerConnectionState, SessionUser } from '../types/session.types';
@@ -26,14 +26,15 @@ import {
   RosterMembershipMutation,
 } from '../types/room-membership.types';
 import { randomUUID } from 'crypto';
-import { asSeatId } from '../types/identity.types';
+import { asSeatId, resolveSeatId } from '../types/identity.types';
 import { upsertRuntimeSeat } from './runtime-seat-roster';
+import type { VacantSeats } from '../types/vacant-seat.types';
 
 @Injectable()
 export class RoomService implements IRoomService, OnModuleDestroy {
   private readonly logger = new Logger(RoomService.name);
   private roomGameStates: Map<string, GameStateService> = new Map();
-  // 退出席情報（ルームIDごとに席番号ベースで元プレイヤーのスナップショットを保存）
+  // 退出席情報（ルームIDごとに不変の席UUIDをキーとして保存）
   private vacantSeats: VacantSeats = {};
 
   private readonly ROOM_EXPIRY_TIME = 6 * 60 * 60 * 1000; // 6時間
@@ -437,21 +438,21 @@ export class RoomService implements IRoomService, OnModuleDestroy {
 
         const gsIndex = state.players.findIndex((p) => p.playerId === playerId);
 
-        // プレイヤーをCOMに置き換え（手札を引き継いでCOMが続行できるようにする）
-        // タイムスタンプ付きIDで既存COMとのID衝突を防ぐ
+        // 席UUIDを維持したまま占有者をCOMへ切り替える。
+        // uniqueIdxはsocket/participant metadataだけを識別する。
         const uniqueIdx = `left-${Date.now()}`;
         const comPlayer = this.createActiveCOMReplacement(
           uniqueIdx,
           room.players[playerIndex],
         );
 
-        this.vacantSeats[roomId][playerIndex] = {
+        const seatId = resolveSeatId(room.players[playerIndex]);
+        this.vacantSeats[roomId][seatId] = {
           roomPlayer: this.cloneRoomPlayer(room.players[playerIndex]),
           gamePlayer:
             gsIndex !== -1
               ? this.cloneGamePlayer(state.players[gsIndex])
               : undefined,
-          replacementPlayerId: comPlayer.playerId,
         };
 
         upsertRuntimeSeat(room, state, comPlayer, {
@@ -562,8 +563,8 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     }
 
     return Object.fromEntries(
-      Object.entries(roomVacantSeats).map(([seatIndex, seatData]) => [
-        Number(seatIndex),
+      Object.entries(roomVacantSeats).map(([seatId, seatData]) => [
+        seatId,
         {
           roomPlayer: {
             ...seatData.roomPlayer,
@@ -574,9 +575,6 @@ export class RoomService implements IRoomService, OnModuleDestroy {
               ...seatData.gamePlayer,
               hand: [...seatData.gamePlayer.hand],
             },
-          }),
-          ...(seatData.replacementPlayerId && {
-            replacementPlayerId: seatData.replacementPlayerId,
           }),
         },
       ]),
@@ -918,12 +916,9 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       return;
     }
 
-    for (const [seatIndex, seatData] of Object.entries(roomVacantSeats)) {
-      if (
-        seatData.roomPlayer.playerId === playerId ||
-        seatData.replacementPlayerId === playerId
-      ) {
-        delete roomVacantSeats[Number(seatIndex)];
+    for (const [seatId, seatData] of Object.entries(roomVacantSeats)) {
+      if (seatId === playerId || seatData.roomPlayer.playerId === playerId) {
+        delete roomVacantSeats[asSeatId(seatId)];
       }
     }
 

--- a/mei-tra-backend/src/services/seat-restoration.service.ts
+++ b/mei-tra-backend/src/services/seat-restoration.service.ts
@@ -3,8 +3,8 @@ import { BlowState, DomainPlayer, GameState } from '../types/game.types';
 import { toDomainPlayer } from '../types/player-adapters';
 import { Room, RoomPlayer } from '../types/room.types';
 import { GameStateService } from './game-state.service';
-import { VacantSeats } from './com-session.service';
-import { resolveSeatId } from '../types/identity.types';
+import type { VacantSeats } from '../types/vacant-seat.types';
+import { asSeatId, resolveSeatId } from '../types/identity.types';
 import {
   resolveCurrentPlayerIndex,
   setCurrentSeat,
@@ -32,14 +32,10 @@ export class SeatRestorationService {
       return false;
     }
 
-    const [seatIndexKey, seatData] = vacancyEntry;
-    const seatIndex = Number(seatIndexKey);
-    const currentSeatPlayer =
-      seatData.replacementPlayerId != null
-        ? room.players.find(
-            (player) => player.playerId === seatData.replacementPlayerId,
-          )
-        : room.players[seatIndex];
+    const [vacantSeatId, seatData] = vacancyEntry;
+    const currentSeatPlayer = room.players.find(
+      (player) => player.playerId === vacantSeatId,
+    );
     if (!currentSeatPlayer || !currentSeatPlayer.isCOM) {
       return false;
     }
@@ -90,7 +86,7 @@ export class SeatRestorationService {
 
     gameState.registerPlayerToken(seatId, seatId);
     gameState.clearDisconnectTimeout(seatId);
-    delete vacantSeatsForRoom[seatIndex];
+    delete vacantSeatsForRoom[asSeatId(vacantSeatId)];
     if (Object.keys(vacantSeatsForRoom).length === 0) {
       delete vacantSeats[roomId];
     }

--- a/mei-tra-backend/src/types/vacant-seat.types.ts
+++ b/mei-tra-backend/src/types/vacant-seat.types.ts
@@ -1,0 +1,12 @@
+import type { SeatId } from '@contracts/ids';
+import type { DomainPlayer } from './game.types';
+import type { RoomPlayer } from './room.types';
+
+export interface VacantSeatSnapshot {
+  roomPlayer: RoomPlayer;
+  gamePlayer?: DomainPlayer;
+}
+
+export type RoomVacantSeats = Record<SeatId, VacantSeatSnapshot>;
+
+export type VacantSeats = Record<string, RoomVacantSeats>;


### PR DESCRIPTION
## Summary

空席snapshotのMapキーを可変な配列indexから不変のseat UUIDへ変更しました。`seatIndex`は表示順のfallbackとしてsnapshot内だけに保持します。

## User-facing change

退出後に席順をシャッフルしても、再入室時に元の席・手札・チームへ戻ります。

## User benefit

別のCOM席へ誤復元される事故を防ぎ、対局途中の復帰が安定します。

## Validation

- Backend: 64 suites / 396 tests
- reorder後の席復元テスト
- seat UUIDキー保存テスト
- Backend build
- changed-file ESLint / `git diff --check`
