### PR TITLE
観戦者も対局ログを閲覧できるようにする

### DIFF
--- a/mei-tra-backend/src/controllers/game-history.controller.spec.ts
+++ b/mei-tra-backend/src/controllers/game-history.controller.spec.ts
@@ -168,6 +168,141 @@ describe('GameHistoryController', () => {
     );
   });
 
+  it('allows an authenticated spectator to read active room history', async () => {
+    const summary = {
+      roomId: 'room-1',
+      totalEntries: 1,
+      byActionType: { card_played: 1 },
+      playerIds: ['player-1'],
+      playerNames: { 'player-1': 'Player 1' },
+      status: 'in_progress' as const,
+      winningTeam: null,
+      lastActionType: 'card_played' as const,
+      roundNumbers: [1],
+      firstTimestamp: new Date('2026-04-16T00:00:00.000Z'),
+      lastTimestamp: new Date('2026-04-16T00:05:00.000Z'),
+    };
+    const getGameHistoryUseCase: IGetGameHistoryUseCase = {
+      execute: jest.fn(),
+      replay: jest.fn(),
+      summarize: jest.fn().mockResolvedValue(summary),
+    };
+    const roomRepository = createRoomRepository({
+      ...room,
+      status: RoomStatus.PLAYING,
+      settings: { ...room.settings, allowSpectators: true },
+      players: [
+        {
+          ...room.players[0],
+          userId: 'other-user',
+        },
+      ],
+    });
+    const controller = new GameHistoryController(
+      getGameHistoryUseCase,
+      roomRepository,
+    );
+
+    await expect(
+      controller.summarizeByRoomId('room-1', {}, currentUser),
+    ).resolves.toEqual({
+      ...summary,
+      teamNames: { 0: '111', 1: '222' },
+    });
+    expect(getGameHistoryUseCase.summarize).toHaveBeenCalledWith(
+      'room-1',
+      {
+        actionType: undefined,
+        limit: undefined,
+        playerId: undefined,
+        roundNumber: undefined,
+        since: undefined,
+        until: undefined,
+      },
+      { 'player-1': 'Player 1' },
+    );
+  });
+
+  it('does not expose starting hands to spectators', async () => {
+    const replay = {
+      roomId: 'room-1',
+      totalEntries: 1,
+      rounds: [
+        {
+          roundNumber: 1,
+          startedAt: new Date('2026-04-16T00:00:00.000Z'),
+          endedAt: null,
+          actionTypes: ['game_started' as const],
+          playerIds: [],
+          entries: [
+            {
+              id: 'history-1',
+              roomId: 'room-1',
+              gameStateId: 'state-1',
+              actionType: 'game_started' as const,
+              playerId: 'player-1',
+              actionData: {
+                startingHandsBySeatId: { 'player-1': ['S-A'] },
+              },
+              timestamp: new Date('2026-04-16T00:00:00.000Z'),
+            },
+          ],
+          events: [
+            {
+              id: 'history-1',
+              timestamp: new Date('2026-04-16T00:00:00.000Z'),
+              actionType: 'game_started' as const,
+              kind: 'lifecycle' as const,
+              playerId: 'player-1',
+              roundNumber: 1,
+              gamePhase: 'blow' as const,
+              summary: 'Game started',
+              details: {},
+              detailItems: [],
+              actionData: {
+                startingHandsBySeatId: { 'player-1': ['S-A'] },
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const getGameHistoryUseCase: IGetGameHistoryUseCase = {
+      execute: jest.fn(),
+      replay: jest.fn().mockResolvedValue(replay),
+      summarize: jest.fn(),
+    };
+    const roomRepository = createRoomRepository({
+      ...room,
+      status: RoomStatus.PLAYING,
+      settings: { ...room.settings, allowSpectators: true },
+      players: [
+        {
+          ...room.players[0],
+          userId: 'other-user',
+        },
+      ],
+    });
+    const controller = new GameHistoryController(
+      getGameHistoryUseCase,
+      roomRepository,
+    );
+
+    await expect(
+      controller.replayByRoomId('room-1', {}, currentUser),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        rounds: [
+          expect.objectContaining({
+            viewerStartingHand: [],
+            entries: [expect.objectContaining({ actionData: {} })],
+            events: [expect.objectContaining({ actionData: {} })],
+          }),
+        ],
+      }),
+    );
+  });
+
   it('returns replay groups from the use-case', async () => {
     const replay = {
       roomId: 'room-1',

--- a/mei-tra-backend/src/controllers/game-history.controller.ts
+++ b/mei-tra-backend/src/controllers/game-history.controller.ts
@@ -20,7 +20,7 @@ import {
   GameHistoryReplayView,
   GameHistorySummary,
 } from '../types/game-history.types';
-import { Room, RoomPlayer } from '../types/room.types';
+import { Room, RoomPlayer, RoomStatus } from '../types/room.types';
 import { resolveSeatId } from '../types/identity.types';
 import { AuthenticatedUser } from '../types/user.types';
 import { IGetGameHistoryUseCase } from '../use-cases/interfaces/get-game-history.use-case.interface';
@@ -80,7 +80,10 @@ export class GameHistoryController {
       this.parseQuery(query),
       playerNames,
     );
-    return this.withViewerStartingHands(replay, resolveSeatId(participant));
+    return this.withViewerStartingHands(
+      replay,
+      participant ? resolveSeatId(participant) : null,
+    );
   }
 
   @Get(':roomId')
@@ -99,7 +102,10 @@ export class GameHistoryController {
       this.parseQuery(query),
     );
     return history.map((entry) =>
-      this.withSanitizedActionData(entry, resolveSeatId(participant)),
+      this.withSanitizedActionData(
+        entry,
+        participant ? resolveSeatId(participant) : null,
+      ),
     );
   }
 
@@ -107,7 +113,7 @@ export class GameHistoryController {
     roomId: string,
     userId: string,
   ): Promise<{
-    participant: RoomPlayer;
+    participant: RoomPlayer | null;
     playerNames: Record<string, string>;
     teamNames: Room['settings']['teamNames'];
   }> {
@@ -119,12 +125,19 @@ export class GameHistoryController {
     const participants = room.players.filter(
       (player) => !player.isCOM && player.userId === userId,
     );
-    if (participants.length !== 1) {
+    if (
+      participants.length !== 1 &&
+      !(
+        participants.length === 0 &&
+        room.status === RoomStatus.PLAYING &&
+        room.settings.allowSpectators
+      )
+    ) {
       throw new ForbiddenException('Cannot access another user game history');
     }
 
     return {
-      participant: participants[0],
+      participant: participants[0] ?? null,
       playerNames: Object.fromEntries(
         room.players.map((player) => [player.playerId, player.name]),
       ),
@@ -134,7 +147,7 @@ export class GameHistoryController {
 
   private withViewerStartingHands(
     replay: GameHistoryReplayView,
-    viewerPlayerId: string,
+    viewerPlayerId: string | null,
   ): GameHistoryReplayView {
     return {
       ...replay,
@@ -155,7 +168,7 @@ export class GameHistoryController {
 
   private resolveViewerStartingHand(
     events: GameHistoryReplayEvent[],
-    viewerPlayerId: string,
+    viewerPlayerId: string | null,
   ): string[] | null {
     return events.reduce<string[] | null>((latestHand, event) => {
       return (
@@ -167,7 +180,7 @@ export class GameHistoryController {
 
   private withSanitizedActionData<
     TEntry extends { actionData: Record<string, unknown> },
-  >(entry: TEntry, viewerPlayerId: string): TEntry {
+  >(entry: TEntry, viewerPlayerId: string | null): TEntry {
     return {
       ...entry,
       actionData: this.sanitizeActionData(entry.actionData, viewerPlayerId),
@@ -176,7 +189,7 @@ export class GameHistoryController {
 
   private sanitizeActionData(
     actionData: Record<string, unknown>,
-    viewerPlayerId: string,
+    viewerPlayerId: string | null,
   ): Record<string, unknown> {
     const safeActionData = { ...actionData };
     delete safeActionData.startingHandsBySeatId;
@@ -193,12 +206,13 @@ export class GameHistoryController {
 
   private extractViewerStartingHand(
     actionData: Record<string, unknown>,
-    viewerPlayerId: string,
+    viewerPlayerId: string | null,
   ): string[] | null {
     const handsByPlayerId =
       actionData.startingHandsBySeatId ?? actionData.startingHandsByPlayerId;
     if (
       !handsByPlayerId ||
+      !viewerPlayerId ||
       typeof handsByPlayerId !== 'object' ||
       Array.isArray(handsByPlayerId)
     ) {


### PR DESCRIPTION
## Summary

観戦許可された進行中ルームで、認証済み観戦者が対局ログとサマリーを閲覧できるようにしました。観戦者には開始時手札を返さず、既存の参加者向け表示は維持します。

## User-facing change

観戦者がプレイ中のルームで対局ログを開けるようになります。開始時手札は表示されません。

## User benefit

対局へ参加していなくても、公開された進行状況やプレイ履歴を安全に確認できます。

## Validation

- `npm test -- --runInBand src/controllers/game-history.controller.spec.ts`（9 tests passed）
- `npm run build`
- `npm run lint -- --no-fix`
- `git diff --check`