### PR TITLE
場の席参照aliasを削除

### DIFF
--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
@@ -340,7 +340,7 @@ describe('SupabaseGameStateRepository', () => {
                 cards: ['S1'],
                 playedBySeatIds: [firstSeatId],
                 baseCard: 'S1',
-                dealerSeatId: secondSeatId,
+                dealerSeatId: asSeatId(secondSeatId),
                 isComplete: false,
               },
               negriCard: '5♣',
@@ -349,9 +349,9 @@ describe('SupabaseGameStateRepository', () => {
               fields: [
                 {
                   cards: ['S1'],
-                  winnerSeatId: firstSeatId,
+                  winnerSeatId: asSeatId(firstSeatId),
                   winnerTeam: 1,
-                  dealerSeatId: secondSeatId,
+                  dealerSeatId: asSeatId(secondSeatId),
                 },
               ],
               lastWinnerSeatId: firstSeatId,

--- a/mei-tra-backend/src/services/__tests__/com-autoplay-recovery.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-autoplay-recovery.service.spec.ts
@@ -1,3 +1,4 @@
+import { asSeatId } from '../../types/identity.types';
 import { Logger } from '@nestjs/common';
 import { IRoomService } from '../interfaces/room-service.interface';
 import { IComAutoPlayUseCase } from '../../use-cases/interfaces/com-autoplay-use-case.interface';
@@ -105,7 +106,7 @@ describe('ComAutoPlayRecoveryService', () => {
       cards: ['A♠', 'K♠', 'Q♠', 'J♠'],
       playedBy: ['p1', 'p2', 'p3', 'com-1'],
       baseCard: 'A♠',
-      dealerId: 'p1',
+      dealerSeatId: asSeatId('p1'),
       isComplete: true,
     };
     const state = {

--- a/mei-tra-backend/src/services/__tests__/com-session.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-session.service.spec.ts
@@ -29,7 +29,7 @@ const createGameStateStub = () => {
         cards: ['A♠'],
         playedBy: [HUMAN_ID],
         baseCard: 'A♠',
-        dealerId: HUMAN_ID,
+        dealerSeatId: asSeatId(HUMAN_ID),
         isComplete: false,
       },
       fields: [],
@@ -98,7 +98,7 @@ describe('ComSessionService.convertPlayerToCOM', () => {
     expect(comId).toBe(HUMAN_ID);
 
     expect(state.playState!.currentField!.playedBy).toEqual([comId]);
-    expect(state.playState!.currentField!.dealerId).toBe(comId);
+    expect(state.playState!.currentField!.dealerSeatId).toBe(comId);
     expect(state.teamAssignments[comId]).toBe(0);
     expect(state.currentPlayerId).toBe(comId);
     expect(Object.keys(vacantSeats['room-1'])).toEqual([HUMAN_ID]);

--- a/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
@@ -1,3 +1,4 @@
+import { asSeatId } from '../../types/identity.types';
 import { ConfigService } from '@nestjs/config';
 import { BlowService } from '../blow.service';
 import { CardService } from '../card.service';
@@ -236,7 +237,7 @@ describe('ComStrategyService', () => {
       cards: ['A♠', 'K♠'],
       playedBy: ['partner-0', 'enemy-1'],
       baseCard: 'A♠',
-      dealerId: 'partner-0',
+      dealerSeatId: asSeatId('partner-0'),
       isComplete: false,
     };
     const com = player('com-0', 0, ['5♠', 'JOKER', 'K♥'], { isCOM: true });
@@ -250,7 +251,7 @@ describe('ComStrategyService', () => {
       cards: ['K♠'],
       playedBy: ['enemy-1'],
       baseCard: 'K♠',
-      dealerId: 'enemy-1',
+      dealerSeatId: asSeatId('enemy-1'),
       isComplete: false,
     };
     const com = player('com-0', 0, ['A♠', '5♠', 'JOKER'], { isCOM: true });
@@ -264,7 +265,7 @@ describe('ComStrategyService', () => {
       cards: ['K♠'],
       playedBy: ['enemy-1'],
       baseCard: 'K♠',
-      dealerId: 'enemy-1',
+      dealerSeatId: asSeatId('enemy-1'),
       isComplete: false,
     };
     const com = player('com-0', 0, ['5♣', '6♦', 'Q♥'], { isCOM: true });
@@ -550,9 +551,9 @@ describe('ComStrategyService', () => {
   ): CompletedField {
     return {
       cards,
-      winnerId: 'winner',
+      winnerSeatId: asSeatId('winner'),
       winnerTeam,
-      dealerId: 'leader',
+      dealerSeatId: asSeatId('leader'),
     };
   }
 });

--- a/mei-tra-backend/src/services/__tests__/game-event-log.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/game-event-log.service.spec.ts
@@ -249,7 +249,7 @@ describe('GameEventLogService', () => {
         actionType: 'field_completed' as const,
         actorSeatId: 'player-2',
         actionData: {
-          winnerSeatId: 'player-2',
+          winnerSeatId: asSeatId('player-2'),
           winnerTeam: 1,
           context: { roundNumber: 1 },
           playerNames: {
@@ -366,7 +366,7 @@ describe('GameEventLogService', () => {
               gamePhase: 'waiting',
               summary: 'Field completed by Player Two for Team 2',
               details: {
-                winnerSeatId: 'player-2',
+                winnerSeatId: asSeatId('player-2'),
                 winnerTeam: 1,
                 cards: [],
               },
@@ -394,7 +394,7 @@ describe('GameEventLogService', () => {
                 teamScores: undefined,
               },
               actionData: {
-                winnerSeatId: 'player-2',
+                winnerSeatId: asSeatId('player-2'),
                 winnerTeam: 1,
                 context: { roundNumber: 1 },
                 playerNames: {
@@ -470,7 +470,7 @@ describe('GameEventLogService', () => {
           actionType: 'field_completed' as const,
           actorSeatId: 'player-3',
           actionData: {
-            winnerSeatId: 'player-3',
+            winnerSeatId: asSeatId('player-3'),
             winnerTeam: 0,
             playerNames: { 'player-3': 'COM 3' },
           },

--- a/mei-tra-backend/src/services/__tests__/game-state-phase.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/game-state-phase.spec.ts
@@ -160,7 +160,7 @@ describe('GameStateService phase transitions', () => {
       cards: ['S1', 'S2', 'S3', 'S4'],
       playedBy: ['player-1', 'player-2', 'player-3', 'player-4'],
       baseCard: 'S1',
-      dealerId: 'player-1',
+      dealerSeatId: asSeatId('player-1'),
       isComplete: true,
     };
     state.playState = {
@@ -176,7 +176,10 @@ describe('GameStateService phase transitions', () => {
     const completedField = service.completeField(currentField, 'player-1');
 
     expect(completedField).toEqual(
-      expect.objectContaining({ winnerId: 'player-1', winnerTeam: 0 }),
+      expect.objectContaining({
+        winnerSeatId: asSeatId('player-1'),
+        winnerTeam: 0,
+      }),
     );
     expect(state.playState.fields).toHaveLength(1);
     expect(repository.update).not.toHaveBeenCalled();

--- a/mei-tra-backend/src/services/__tests__/gameplay-notification.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/gameplay-notification.service.spec.ts
@@ -1,3 +1,4 @@
+import { asSeatId } from '../../types/identity.types';
 import { GameplayNotificationService } from '../gameplay-notification.service';
 import type { PushNotificationService } from '../../push/push-notification.service';
 import type { IUserProfileRepository } from '../../repositories/interfaces/user-profile.repository.interface';
@@ -31,7 +32,7 @@ const state = (overrides: Partial<GameState> = {}): GameState =>
         cards: [],
         playedBy: [],
         baseCard: '',
-        dealerId: 'player-1',
+        dealerSeatId: asSeatId('player-1'),
         isComplete: false,
       },
       negriCard: null,

--- a/mei-tra-backend/src/services/__tests__/play.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/play.service.spec.ts
@@ -1,3 +1,4 @@
+import { asSeatId } from '../../types/identity.types';
 import { CardService } from '../card.service';
 import { PlayService } from '../play.service';
 import { DomainPlayer, Field } from '../../types/game.types';
@@ -26,7 +27,7 @@ describe('PlayService', () => {
       cards: ['5♣', 'A♣', 'K♣', '6♣'],
       playedBy: ['player-1', 'player-2', 'player-3', 'player-4'],
       baseCard: '5♣',
-      dealerId: 'player-1',
+      dealerSeatId: asSeatId('player-1'),
       isComplete: true,
     };
 
@@ -47,7 +48,7 @@ describe('PlayService', () => {
       cards: ['5♣', 'A♣', '6♣', 'K♣'],
       playedBy: ['player-1', 'com-1', 'player-2', 'com-2'],
       baseCard: '5♣',
-      dealerId: 'player-1',
+      dealerSeatId: asSeatId('player-1'),
       isComplete: true,
     };
 
@@ -68,7 +69,7 @@ describe('PlayService', () => {
       cards: ['5♣', 'A♣', '6♣', 'K♣'],
       playedBy: ['player-1', 'player-3', 'player-2', 'player-4'],
       baseCard: '5♣',
-      dealerId: 'player-1',
+      dealerSeatId: asSeatId('player-1'),
       isComplete: true,
     };
 
@@ -89,7 +90,7 @@ describe('PlayService', () => {
       cards: ['5♣', 'A♣', '6♣', 'K♣'],
       playedBy: [],
       baseCard: '5♣',
-      dealerId: 'player-1',
+      dealerSeatId: asSeatId('player-1'),
       isComplete: true,
     };
 
@@ -103,7 +104,7 @@ describe('PlayService', () => {
       cards: ['K♠'],
       playedBy: ['player-2'],
       baseCard: 'K♠',
-      dealerId: 'player-2',
+      dealerSeatId: asSeatId('player-2'),
       isComplete: false,
     };
 
@@ -117,7 +118,7 @@ describe('PlayService', () => {
       cards: [],
       playedBy: [],
       baseCard: '',
-      dealerId: 'player-1',
+      dealerSeatId: asSeatId('player-1'),
       isComplete: false,
     };
 

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -769,7 +769,7 @@ describe('Reconnection Token Management', () => {
             cards: ['JOKER'],
             playedBy: [playerId],
             baseCard: 'JOKER',
-            dealerId: playerId,
+            dealerSeatId: asSeatId(playerId),
             isComplete: false,
           },
           negriCard: null,
@@ -777,9 +777,9 @@ describe('Reconnection Token Management', () => {
           fields: [
             {
               cards: ['7♣', '8♣', '9♣', '10♣'],
-              winnerId: playerId,
+              winnerSeatId: asSeatId(playerId),
               winnerTeam: 0,
-              dealerId: playerId,
+              dealerSeatId: asSeatId(playerId),
             },
           ],
           lastWinnerSeatId: asSeatId(playerId),
@@ -798,16 +798,16 @@ describe('Reconnection Token Management', () => {
         expect(result).toBe(true);
         const comPlayerId = gameState.getState().players[0].playerId;
         expect(comPlayerId).toBe(playerId);
-        expect(gameState.getState().playState?.currentField?.dealerId).toBe(
+        expect(gameState.getState().playState?.currentField?.dealerSeatId).toBe(
           comPlayerId,
         );
         expect(gameState.getState().playState?.currentField?.playedBy).toEqual([
           comPlayerId,
         ]);
-        expect(gameState.getState().playState?.fields[0]?.winnerId).toBe(
+        expect(gameState.getState().playState?.fields[0]?.winnerSeatId).toBe(
           comPlayerId,
         );
-        expect(gameState.getState().playState?.fields[0]?.dealerId).toBe(
+        expect(gameState.getState().playState?.fields[0]?.dealerSeatId).toBe(
           comPlayerId,
         );
         expect(gameState.getState().playState?.lastWinnerSeatId).toBe(
@@ -1765,7 +1765,7 @@ describe('Reconnection Token Management', () => {
             cards: ['9♥'],
             playedBy: [targetCom.playerId],
             baseCard: '9♥',
-            dealerId: targetCom.playerId,
+            dealerSeatId: asSeatId(targetCom.playerId),
             isComplete: false,
           },
           negriCard: null,
@@ -1773,9 +1773,9 @@ describe('Reconnection Token Management', () => {
           fields: [
             {
               cards: ['7♣', '8♣', '9♣', '10♣'],
-              winnerId: targetCom.playerId,
+              winnerSeatId: asSeatId(targetCom.playerId),
               winnerTeam: 0,
-              dealerId: targetCom.playerId,
+              dealerSeatId: asSeatId(targetCom.playerId),
             },
           ],
           lastWinnerSeatId: asSeatId(targetCom.playerId),
@@ -1820,16 +1820,16 @@ describe('Reconnection Token Management', () => {
         const result = await roomService.joinRoom(roomId, user);
 
         expect(result).toBe(true);
-        expect(gameState.getState().playState?.currentField?.dealerId).toBe(
+        expect(gameState.getState().playState?.currentField?.dealerSeatId).toBe(
           targetCom.playerId,
         );
         expect(gameState.getState().playState?.currentField?.playedBy).toEqual([
           targetCom.playerId,
         ]);
-        expect(gameState.getState().playState?.fields[0]?.winnerId).toBe(
+        expect(gameState.getState().playState?.fields[0]?.winnerSeatId).toBe(
           targetCom.playerId,
         );
-        expect(gameState.getState().playState?.fields[0]?.dealerId).toBe(
+        expect(gameState.getState().playState?.fields[0]?.dealerSeatId).toBe(
           targetCom.playerId,
         );
         expect(gameState.getState().playState?.lastWinnerSeatId).toBe(

--- a/mei-tra-backend/src/services/__tests__/room-update-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room-update-gateway-effects.service.spec.ts
@@ -25,7 +25,7 @@ describe('RoomUpdateGatewayEffectsService', () => {
               cards: ['J♠'],
               playedBy: ['com-player-1'],
               baseCard: 'J♠',
-              dealerId: 'com-player-1',
+              dealerSeatId: asSeatId('com-player-1'),
               isComplete: false,
             },
           },
@@ -112,7 +112,7 @@ describe('RoomUpdateGatewayEffectsService', () => {
       cards: ['J♠'],
       playedBySeatIds: ['com-player-1'],
       baseCard: 'J♠',
-      dealerSeatId: 'com-player-1',
+      dealerSeatId: asSeatId('com-player-1'),
       declaredSuit: undefined,
       isComplete: false,
     });
@@ -123,7 +123,7 @@ describe('RoomUpdateGatewayEffectsService', () => {
       cards: ['J♠'],
       playedBy: ['com-player-1'],
       baseCard: 'J♠',
-      dealerId: 'com-player-1',
+      dealerSeatId: asSeatId('com-player-1'),
       isComplete: false,
     };
     const roomService = {
@@ -178,7 +178,7 @@ describe('RoomUpdateGatewayEffectsService', () => {
         playedBySeatIds: ['com-player-1'],
         baseCard: 'J♠',
         baseSuit: undefined,
-        dealerSeatId: 'com-player-1',
+        dealerSeatId: asSeatId('com-player-1'),
         declaredSuit: undefined,
         isComplete: false,
       },

--- a/mei-tra-backend/src/services/__tests__/rule-services.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/rule-services.spec.ts
@@ -1,3 +1,4 @@
+import { asSeatId } from '../../types/identity.types';
 import { CardService } from '../card.service';
 import { BlowService } from '../blow.service';
 import { PlayService } from '../play.service';
@@ -54,7 +55,7 @@ describe('Rule service characterization', () => {
       cards: ['10♠', 'A♠', 'J♣', 'K♠'],
       playedBy: ['p1', 'p2', 'p3', 'p4'],
       baseCard: '10♠',
-      dealerId: 'p1',
+      dealerSeatId: asSeatId('p1'),
       isComplete: false,
     };
 

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -537,7 +537,7 @@ export class GameStateService implements IGameStateService {
     return currentPlayer?.playerId === playerId;
   }
 
-  completeField(field: Field, winnerId: string): CompletedField | null {
+  completeField(field: Field, winnerSeatId: string): CompletedField | null {
     const state = this.getState();
     if (!state.playState) {
       return null;
@@ -549,18 +549,16 @@ export class GameStateService implements IGameStateService {
     }
 
     field.isComplete = true;
-    const winner = state.players.find((p) => p.playerId === winnerId);
+    const winner = state.players.find((p) => p.playerId === winnerSeatId);
     if (!winner) {
       return null;
     }
 
     const completedField: CompletedField = {
       cards: [...field.cards],
-      winnerSeatId: asSeatId(winnerId),
-      winnerId: winnerId,
+      winnerSeatId: asSeatId(winnerSeatId),
       winnerTeam: winner.team,
-      dealerSeatId: asSeatId(field.dealerSeatId ?? field.dealerId),
-      dealerId: field.dealerId,
+      dealerSeatId: field.dealerSeatId,
     };
 
     state.playState.fields.push(completedField);
@@ -630,7 +628,6 @@ export class GameStateService implements IGameStateService {
         playedBySeatIds: [],
         baseCard: '',
         dealerSeatId: asSeatId(state.players[0].playerId),
-        dealerId: state.players[0].playerId,
         isComplete: false,
       },
       negriCard: null,

--- a/mei-tra-backend/src/services/gameplay-notification.service.ts
+++ b/mei-tra-backend/src/services/gameplay-notification.service.ts
@@ -238,7 +238,7 @@ export class GameplayNotificationService implements OnModuleDestroy {
       state.blowState.actionHistory?.length ?? 0,
       state.playState?.fields?.length ?? 0,
       state.playState?.currentField?.cards?.length ?? 0,
-      state.playState?.currentField?.dealerId ?? '',
+      state.playState?.currentField?.dealerSeatId ?? '',
     ].join(':');
   }
 

--- a/mei-tra-backend/src/services/play.service.ts
+++ b/mei-tra-backend/src/services/play.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { asSeatId } from '../types/identity.types';
 import { DomainPlayer, Field, TrumpType } from '../types/game.types';
 import { CardService } from './card.service';
 import { IPlayService } from './interfaces/play-service.interface';
@@ -35,12 +36,14 @@ export class PlayService implements IPlayService {
     let highestStrength = -1;
 
     // ディーラーのインデックスを取得
-    let dealerIndex = players.findIndex((p) => p.playerId === field.dealerId);
+    let dealerIndex = players.findIndex(
+      (p) => p.playerId === field.dealerSeatId,
+    );
 
     // ディーラーが見つからない場合、最初の有効なプレイヤーをディーラーとする
     if (dealerIndex === -1) {
       dealerIndex = 0;
-      field.dealerId = players[0].playerId;
+      field.dealerSeatId = asSeatId(players[0].playerId);
     }
 
     const playersById = new Map(

--- a/mei-tra-backend/src/types/game-contract-adapters.ts
+++ b/mei-tra-backend/src/types/game-contract-adapters.ts
@@ -69,7 +69,7 @@ export function toFieldContract(field: Field): FieldContract {
     playedBySeatIds: (field.playedBySeatIds ?? field.playedBy).map(asSeatId),
     baseCard: field.baseCard,
     baseSuit: field.baseSuit,
-    dealerSeatId: field.dealerSeatId ?? asSeatId(field.dealerId),
+    dealerSeatId: field.dealerSeatId,
     declaredSuit: field.declaredSuit,
     isComplete: field.isComplete,
   };
@@ -80,8 +80,8 @@ export function toCompletedFieldContract(
 ): CompletedFieldContract {
   return {
     cards: [...field.cards],
-    winnerSeatId: field.winnerSeatId ?? asSeatId(field.winnerId),
+    winnerSeatId: field.winnerSeatId,
     winnerTeam: field.winnerTeam,
-    dealerSeatId: field.dealerSeatId ?? asSeatId(field.dealerId),
+    dealerSeatId: field.dealerSeatId,
   };
 }

--- a/mei-tra-backend/src/types/game-state-identity.spec.ts
+++ b/mei-tra-backend/src/types/game-state-identity.spec.ts
@@ -42,7 +42,6 @@ describe('normalizeGameStateIdentityAliases', () => {
           playedBy: ['legacy-player'],
           baseCard: '',
           dealerSeatId: asSeatId('seat-1'),
-          dealerId: 'legacy-dealer',
           isComplete: false,
         },
         negriCard: '5♣',
@@ -74,7 +73,7 @@ describe('normalizeGameStateIdentityAliases', () => {
     expect(normalized.playState?.currentField?.playedBy).not.toBe(
       normalized.playState?.currentField?.playedBySeatIds,
     );
-    expect(normalized.playState?.currentField?.dealerId).toBe('seat-1');
+    expect(normalized.playState?.currentField?.dealerSeatId).toBe('seat-1');
     expect(normalized.playState?.negriSeatId).toBe('seat-1');
     expect(normalized.playState?.lastWinnerSeatId).toBe('seat-1');
     expect(normalized.playState?.openDeclarerSeatId).toBe('seat-1');
@@ -133,7 +132,6 @@ describe('normalizeGameStateIdentityAliases', () => {
           playedBy: ['seat-1', 'seat-1', 'seat-2', 'seat-2'],
           baseCard: '5♣',
           dealerSeatId: asSeatId('seat-1'),
-          dealerId: 'seat-1',
           isComplete: false,
         },
         negriCard: null,

--- a/mei-tra-backend/src/types/game-state-identity.ts
+++ b/mei-tra-backend/src/types/game-state-identity.ts
@@ -60,26 +60,18 @@ export function normalizeGameStateIdentityAliases(state: GameState): GameState {
           ? (() => {
               const field = state.playState.currentField;
               const playedBySeatIds = normalizePlayedBySeatIds(field);
-              const dealerSeatId =
-                field.dealerSeatId ?? asSeatId(field.dealerId);
+              const dealerSeatId = field.dealerSeatId;
               return {
                 ...field,
                 playedBy: [...playedBySeatIds],
                 playedBySeatIds: [...playedBySeatIds],
                 dealerSeatId,
-                dealerId: dealerSeatId,
               };
             })()
           : null,
         fields: state.playState.fields.map((field) => {
-          const winnerSeatId = field.winnerSeatId ?? asSeatId(field.winnerId);
-          const dealerSeatId = field.dealerSeatId ?? asSeatId(field.dealerId);
           return {
             ...field,
-            winnerSeatId,
-            winnerId: winnerSeatId,
-            dealerSeatId,
-            dealerId: dealerSeatId,
           };
         }),
         lastWinnerSeatId: state.playState.lastWinnerSeatId ?? null,

--- a/mei-tra-backend/src/types/game-state-persistence.spec.ts
+++ b/mei-tra-backend/src/types/game-state-persistence.spec.ts
@@ -55,8 +55,7 @@ describe('game-state persistence identity', () => {
         playedBy: [firstSeatId],
         playedBySeatIds: [firstSeatId],
         baseCard: 'H7',
-        dealerSeatId: secondSeatId,
-        dealerId: secondSeatId,
+        dealerSeatId: asSeatId(secondSeatId),
         isComplete: false,
       },
       negriCard: 'S9',
@@ -65,11 +64,9 @@ describe('game-state persistence identity', () => {
       fields: [
         {
           cards: ['H7'],
-          winnerSeatId: firstSeatId,
-          winnerId: firstSeatId,
+          winnerSeatId: asSeatId(firstSeatId),
           winnerTeam: 0,
-          dealerSeatId: secondSeatId,
-          dealerId: secondSeatId,
+          dealerSeatId: asSeatId(secondSeatId),
         },
       ],
       lastWinnerSeatId: firstSeatId,
@@ -91,8 +88,6 @@ describe('game-state persistence identity', () => {
     expect(persistedReveal?.seatId).toBe(firstSeatId);
     expect(serialized).not.toContain('playerId');
     expect(serialized).not.toContain('playedBy"');
-    expect(serialized).not.toContain('dealerId');
-    expect(serialized).not.toContain('winnerId');
   });
 
   it('finds canonical nested seat references outside the room roster', () => {
@@ -102,7 +97,7 @@ describe('game-state persistence identity', () => {
           playerStates: { [firstSeatId]: { hand: [] } },
           playState: {
             currentField: {
-              dealerSeatId: secondSeatId,
+              dealerSeatId: asSeatId(secondSeatId),
               playedBySeatIds: [firstSeatId, 'unknown-seat'],
             },
           },

--- a/mei-tra-backend/src/types/game-state-persistence.ts
+++ b/mei-tra-backend/src/types/game-state-persistence.ts
@@ -53,21 +53,12 @@ export type PersistedBlowState = Omit<
   lastPasserSeatId: SeatId | null;
 };
 
-export type PersistedField = Omit<
-  Field,
-  'playedBy' | 'playedBySeatIds' | 'dealerId' | 'dealerSeatId'
-> & {
+export type PersistedField = Omit<Field, 'playedBy' | 'playedBySeatIds'> & {
   playedBySeatIds: SeatId[];
   dealerSeatId: SeatId;
 };
 
-export type PersistedCompletedField = Omit<
-  CompletedField,
-  'winnerId' | 'winnerSeatId' | 'dealerId' | 'dealerSeatId'
-> & {
-  winnerSeatId: SeatId;
-  dealerSeatId: SeatId;
-};
+export type PersistedCompletedField = CompletedField;
 
 export type PersistedPlayState = Omit<
   PlayState,
@@ -141,31 +132,17 @@ export function toPersistedBlowState(blowState: BlowState): PersistedBlowState {
 
 function toPersistedField(field: Field): PersistedField {
   return {
-    ...omitKeys(field, [
-      'playedBy',
-      'playedBySeatIds',
-      'dealerId',
-      'dealerSeatId',
-    ]),
+    ...omitKeys(field, ['playedBy', 'playedBySeatIds']),
     playedBySeatIds:
       field.playedBySeatIds ?? field.playedBy.map((seatId) => asSeatId(seatId)),
-    dealerSeatId: field.dealerSeatId ?? asSeatId(field.dealerId),
+    dealerSeatId: field.dealerSeatId,
   } as PersistedField;
 }
 
 function toPersistedCompletedField(
   field: CompletedField,
 ): PersistedCompletedField {
-  return {
-    ...omitKeys(field, [
-      'winnerId',
-      'winnerSeatId',
-      'dealerId',
-      'dealerSeatId',
-    ]),
-    winnerSeatId: field.winnerSeatId ?? asSeatId(field.winnerId),
-    dealerSeatId: field.dealerSeatId ?? asSeatId(field.dealerId),
-  } as PersistedCompletedField;
+  return { ...field };
 }
 
 export function toPersistedPlayState(

--- a/mei-tra-backend/src/types/game.types.ts
+++ b/mei-tra-backend/src/types/game.types.ts
@@ -75,22 +75,16 @@ export interface Field {
   playedBySeatIds?: SeatId[];
   baseCard: string;
   baseSuit?: string;
-  dealerSeatId?: SeatId;
-  /** @deprecated Use dealerSeatId. */
-  dealerId: string;
+  dealerSeatId: SeatId;
   declaredSuit?: string;
   isComplete: boolean;
 }
 
 export interface CompletedField {
   cards: string[];
-  winnerSeatId?: SeatId;
-  /** @deprecated Use winnerSeatId. */
-  winnerId: string;
+  winnerSeatId: SeatId;
   winnerTeam: Team;
-  dealerSeatId?: SeatId;
-  /** @deprecated Use dealerSeatId. */
-  dealerId: string;
+  dealerSeatId: SeatId;
 }
 
 export interface PlayState {

--- a/mei-tra-backend/src/use-cases/__tests__/game-event-instrumentation.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game-event-instrumentation.spec.ts
@@ -95,7 +95,7 @@ describe('Game event instrumentation', () => {
           cards: [],
           playedBy: [],
           baseCard: '',
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
           isComplete: false,
         },
       },

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -97,11 +97,11 @@ describe('Game Use Cases', () => {
 
   const createPlayRulesService = () => new PlayService(new CardService());
 
-  const createPlayServiceMock = (winnerId: string) => {
+  const createPlayServiceMock = (winnerSeatId: string) => {
     const determineFieldWinnerMock = jest.fn<
       ReturnType<IPlayService['determineFieldWinner']>,
       Parameters<IPlayService['determineFieldWinner']>
-    >((_, players) => players.find((p) => p.playerId === winnerId) || null);
+    >((_, players) => players.find((p) => p.playerId === winnerSeatId) || null);
 
     const mock: Partial<jest.Mocked<IPlayService>> = {
       determineFieldWinner: determineFieldWinnerMock,
@@ -1651,7 +1651,7 @@ describe('Game Use Cases', () => {
         cards: [],
         playedBy: [],
         baseCard: '',
-        dealerId: 'player-1',
+        dealerSeatId: asSeatId('player-1'),
         isComplete: false,
       };
 
@@ -1745,7 +1745,7 @@ describe('Game Use Cases', () => {
         playedBy: sharedPlayedBy,
         playedBySeatIds: sharedPlayedBy,
         baseCard: '',
-        dealerId: 'player-1',
+        dealerSeatId: asSeatId('player-1'),
         isComplete: false,
       };
       const state = {
@@ -1795,7 +1795,7 @@ describe('Game Use Cases', () => {
         cards: ['C1', 'C2', 'C3'],
         playedBy: ['player-1', 'player-2', 'player-3'],
         baseCard: 'C1',
-        dealerId: 'player-1',
+        dealerSeatId: asSeatId('player-1'),
         isComplete: false,
       };
 
@@ -1879,7 +1879,7 @@ describe('Game Use Cases', () => {
             cards: [],
             playedBy: [],
             baseCard: '',
-            dealerId: 'player-1',
+            dealerSeatId: asSeatId('player-1'),
             isComplete: false,
           } as Field,
         },
@@ -1945,7 +1945,7 @@ describe('Game Use Cases', () => {
         cards: ['K♠'],
         playedBy: ['player-2'],
         baseCard: 'K♠',
-        dealerId: 'player-2',
+        dealerSeatId: asSeatId('player-2'),
         isComplete: false,
       };
       const state = {
@@ -1993,7 +1993,7 @@ describe('Game Use Cases', () => {
         cards: ['K♠'],
         playedBy: ['player-2'],
         baseCard: 'K♠',
-        dealerId: 'player-2',
+        dealerSeatId: asSeatId('player-2'),
         isComplete: false,
       };
       const state = {
@@ -2049,7 +2049,7 @@ describe('Game Use Cases', () => {
         cards: [],
         playedBy: [],
         baseCard: '',
-        dealerId: 'player-1',
+        dealerSeatId: asSeatId('player-1'),
         isComplete: false,
       };
       const state = {
@@ -2171,7 +2171,7 @@ describe('Game Use Cases', () => {
             playedBy: ['com-0'],
             baseCard: 'JOKER',
             baseSuit: undefined,
-            dealerId: 'com-0',
+            dealerSeatId: asSeatId('com-0'),
             isComplete: false,
           },
         },
@@ -2306,7 +2306,7 @@ describe('Game Use Cases', () => {
             cards: [],
             playedBy: [],
             baseCard: '',
-            dealerId: 'com-timeout-1',
+            dealerSeatId: asSeatId('com-timeout-1'),
             isComplete: false,
           },
           negriCard: null,
@@ -2676,7 +2676,7 @@ describe('Game Use Cases', () => {
             playedBy: ['player-1'],
             baseCard: 'JOKER',
             baseSuit: undefined,
-            dealerId: 'player-1',
+            dealerSeatId: asSeatId('player-1'),
             isComplete: false,
           },
         },
@@ -3394,7 +3394,7 @@ describe('Game Use Cases', () => {
           cards: [],
           playedBy: [],
           baseCard: '',
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
           isComplete: false,
         } as Field,
       },
@@ -3439,9 +3439,9 @@ describe('Game Use Cases', () => {
       state.playState.fields = [{ winnerTeam: 0 } as unknown as CompletedField];
       const completeFieldMock = jest.fn(() => ({
         cards: ['A', 'B', 'C', 'D'],
-        winnerId: 'player-1',
+        winnerSeatId: asSeatId('player-1'),
         winnerTeam: 0,
-        dealerId: 'player-1',
+        dealerSeatId: asSeatId('player-1'),
       }));
       const saveStateMock = jest.fn();
       let roundNumberValue = state.roundNumber;
@@ -3467,7 +3467,7 @@ describe('Game Use Cases', () => {
           cards: ['A', 'C', 'E', 'F'],
           playedBy: ['player-1', 'player-2', 'player-3', 'player-4'],
           baseCard: 'A',
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
           isComplete: false,
         },
       });
@@ -3507,7 +3507,7 @@ describe('Game Use Cases', () => {
           cards: ['A', 'B', 'C', 'D'],
           playedBy: ['player-1', 'player-2', 'player-3'],
           baseCard: 'A',
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
           isComplete: true,
         },
       });
@@ -3533,7 +3533,7 @@ describe('Game Use Cases', () => {
         cards: ['A', 'B', 'C', 'D'],
         playedBy: ['player-1', 'player-2', 'player-3', 'player-4'],
         baseCard: 'A',
-        dealerId: 'player-1',
+        dealerSeatId: asSeatId('player-1'),
         isComplete: true,
       };
 
@@ -3551,7 +3551,7 @@ describe('Game Use Cases', () => {
           cards: ['A', 'B', 'C', 'D'],
           playedBy: ['player-1', 'player-3', 'player-2', 'player-4'],
           baseCard: 'A',
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
           isComplete: true,
         },
       });
@@ -3588,7 +3588,7 @@ describe('Game Use Cases', () => {
         cards: ['5♣', 'A♣', '6♣', 'K♣'],
         playedBy: ['player-1', 'player-3', 'player-2', 'player-4'],
         baseCard: '5♣',
-        dealerId: 'player-1',
+        dealerSeatId: asSeatId('player-1'),
         isComplete: true,
       };
       state.playState.currentField = {
@@ -3599,22 +3599,24 @@ describe('Game Use Cases', () => {
 
       const roomGameState = {
         getState: jest.fn(() => state),
-        completeField: jest.fn((completedField: Field, winnerId: string) => {
-          const winner = state.players.find(
-            (player) => player.playerId === winnerId,
-          );
-          if (!winner) {
-            return null;
-          }
-          const persistedField = {
-            cards: [...completedField.cards],
-            winnerId,
-            winnerTeam: winner.team,
-            dealerId: completedField.dealerId,
-          };
-          state.playState.fields.push(persistedField);
-          return persistedField;
-        }),
+        completeField: jest.fn(
+          (completedField: Field, winnerSeatId: string) => {
+            const winner = state.players.find(
+              (player) => player.playerId === winnerSeatId,
+            );
+            if (!winner) {
+              return null;
+            }
+            const persistedField = {
+              cards: [...completedField.cards],
+              winnerSeatId: asSeatId(winnerSeatId),
+              winnerTeam: winner.team,
+              dealerSeatId: asSeatId(completedField.dealerSeatId),
+            };
+            state.playState.fields.push(persistedField);
+            return persistedField;
+          },
+        ),
         saveState: jest.fn(),
         resetRoundState: jest.fn(async () => {}),
         transitionPhase: jest.fn(async () => {}),
@@ -3641,10 +3643,10 @@ describe('Game Use Cases', () => {
       ).toEqual(
         expect.objectContaining({
           field: expect.objectContaining({
-            winnerSeatId: 'player-3',
+            winnerSeatId: asSeatId('player-3'),
             winnerTeam: 0,
           }),
-          winnerSeatId: 'player-3',
+          winnerSeatId: asSeatId('player-3'),
           nextSeatId: 'player-3',
         }),
       );
@@ -3671,9 +3673,9 @@ describe('Game Use Cases', () => {
         getState: jest.fn(() => state),
         completeField: jest.fn(() => ({
           cards: ['A', 'C', 'E', 'F'],
-          winnerId: 'player-1',
+          winnerSeatId: asSeatId('player-1'),
           winnerTeam: 0,
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
         })),
         saveState: jest.fn(),
         resetRoundState: jest.fn(async () => {}),
@@ -3689,7 +3691,7 @@ describe('Game Use Cases', () => {
           cards: ['A', 'C', 'E', 'F'],
           playedBy: ['player-1', 'player-2', 'player-3', 'player-4'],
           baseCard: 'A',
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
           isComplete: true,
         },
       });
@@ -3719,9 +3721,9 @@ describe('Game Use Cases', () => {
         getState: jest.fn(() => state),
         completeField: jest.fn(() => ({
           cards: ['A', 'B', 'C', 'D'],
-          winnerId: 'player-1',
+          winnerSeatId: asSeatId('player-1'),
           winnerTeam: 0,
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
         })),
         saveState: jest.fn(),
       } as unknown as GameStateService;
@@ -3734,7 +3736,7 @@ describe('Game Use Cases', () => {
           cards: ['A', 'B', 'C', 'D'],
           playedBy: ['player-1', 'player-2', 'player-3', 'player-4'],
           baseCard: 'A',
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
           isComplete: false,
         },
       });
@@ -3774,9 +3776,9 @@ describe('Game Use Cases', () => {
         getState: jest.fn(() => state),
         completeField: jest.fn(() => ({
           cards: ['A', 'B', 'C', 'D'],
-          winnerId: 'player-2',
+          winnerSeatId: asSeatId('player-2'),
           winnerTeam: 1,
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
         })),
         saveState: jest.fn(),
         resetRoundState: jest.fn(async () => {}),
@@ -3794,7 +3796,7 @@ describe('Game Use Cases', () => {
           cards: ['A', 'B', 'C', 'D'],
           playedBy: ['player-1', 'player-2', 'player-3', 'player-4'],
           baseCard: 'A',
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
           isComplete: false,
         },
       });
@@ -3831,9 +3833,9 @@ describe('Game Use Cases', () => {
         getState: jest.fn(() => state),
         completeField: jest.fn(() => ({
           cards: ['A', 'B', 'C', 'D'],
-          winnerId: 'player-2',
+          winnerSeatId: asSeatId('player-2'),
           winnerTeam: 1,
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
         })),
         saveState: jest.fn(),
         resetRoundState: jest.fn(async () => {}),
@@ -3851,7 +3853,7 @@ describe('Game Use Cases', () => {
           cards: ['A', 'B', 'C', 'D'],
           playedBy: ['player-1', 'player-2', 'player-3', 'player-4'],
           baseCard: 'A',
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
           isComplete: false,
         },
       });
@@ -3887,9 +3889,9 @@ describe('Game Use Cases', () => {
         getState: jest.fn(() => state),
         completeField: jest.fn(() => ({
           cards: ['A', 'B', 'C', 'D'],
-          winnerId: 'player-1',
+          winnerSeatId: asSeatId('player-1'),
           winnerTeam: 0,
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
         })),
         saveState: jest.fn(),
         resetRoundState: jest.fn(async () => {}),
@@ -3907,7 +3909,7 @@ describe('Game Use Cases', () => {
           cards: ['A', 'B', 'C', 'D'],
           playedBy: ['player-1', 'player-2', 'player-3', 'player-4'],
           baseCard: 'A',
-          dealerId: 'player-1',
+          dealerSeatId: asSeatId('player-1'),
           isComplete: false,
         },
       });

--- a/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
+++ b/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
@@ -225,7 +225,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       updatedField &&
       updatedField.baseCard === 'JOKER' &&
       !updatedField.baseSuit &&
-      updatedField.dealerId === comPlayer.playerId
+      updatedField.dealerSeatId === comPlayer.playerId
     ) {
       updatedField.baseSuit = this.comStrategyService.chooseBaseSuit(
         updatedState,

--- a/mei-tra-backend/src/use-cases/complete-field.use-case.ts
+++ b/mei-tra-backend/src/use-cases/complete-field.use-case.ts
@@ -101,7 +101,6 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
           playedBySeatIds: [],
           baseCard: '',
           dealerSeatId: asSeatId(winner.playerId),
-          dealerId: winner.playerId,
           isComplete: false,
         };
       }
@@ -276,7 +275,7 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
       const isSameField =
         this.isSameSequence(currentField.cards, field.cards) &&
         this.isSameSequence(currentField.playedBy, field.playedBy) &&
-        currentField.dealerId === field.dealerId &&
+        currentField.dealerSeatId === field.dealerSeatId &&
         currentField.baseCard === field.baseCard &&
         currentField.baseSuit === field.baseSuit;
 
@@ -386,7 +385,6 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
         playedBySeatIds: [],
         baseCard: '',
         dealerSeatId: asSeatId(nextBlowPlayer.playerId),
-        dealerId: nextBlowPlayer.playerId,
         isComplete: false,
       },
       negriCard: null,

--- a/mei-tra-backend/src/use-cases/select-base-suit.use-case.ts
+++ b/mei-tra-backend/src/use-cases/select-base-suit.use-case.ts
@@ -37,7 +37,7 @@ export class SelectBaseSuitUseCase implements ISelectBaseSuitUseCase {
         return { success: false, error: 'Player not found in game state' };
       }
 
-      if (state.playState.currentField.dealerId !== player.playerId) {
+      if (state.playState.currentField.dealerSeatId !== player.playerId) {
         return {
           success: false,
           error: "It's not your turn to select base suit",

--- a/mei-tra-backend/src/use-cases/select-negri.use-case.ts
+++ b/mei-tra-backend/src/use-cases/select-negri.use-case.ts
@@ -53,7 +53,6 @@ export class SelectNegriUseCase implements ISelectNegriUseCase {
           playedBySeatIds: [],
           baseCard: '',
           dealerSeatId: asSeatId(player.playerId),
-          dealerId: player.playerId,
           isComplete: false,
         },
         negriCard: card,


### PR DESCRIPTION
## Summary
- `Field.dealerId` を削除し `dealerSeatId` に統一
- `CompletedField.winnerId` / `dealerId` を削除し SeatId 型へ統一
- ゲーム進行、永続化、再接続、通知、テストの参照をcanonical名へ更新

## Why
場の配り手・勝者を旧文字列IDとSeatIdで二重保持しており、更新漏れが発生し得たためです。

## Validation
- `cd mei-tra-backend && npm test -- --runInBand` (63 suites / 397 tests)
- `cd mei-tra-backend && npm run lint`
- `cd mei-tra-backend && npm run build`

## User-facing change
なし。場の席参照を内部的に単一化します。

## User benefit
再接続やCOM置換後も、出したカードと勝者の席対応がずれにくくなります。
