### PR TITLE
現在手番のaliasを削除

### DIFF
--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
@@ -84,8 +84,6 @@ describe('SupabaseGameStateRepository', () => {
         },
       ],
       currentSeatId: firstSeatId,
-      currentPlayerId: firstSeatId,
-      currentPlayerIndex: 0,
       gamePhase: 'waiting',
       deck: [],
       teamScores: {
@@ -298,8 +296,6 @@ describe('SupabaseGameStateRepository', () => {
     const state = await repository.findByRoomId(gameStateRow.room_id);
 
     expect(state?.currentSeatId).toBe(secondSeatId);
-    expect(state?.currentPlayerId).toBeUndefined();
-    expect(state?.currentPlayerIndex).toBeUndefined();
   });
 
   it('restores canonical seat references', async () => {

--- a/mei-tra-backend/src/services/__tests__/com-session.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-session.service.spec.ts
@@ -23,7 +23,7 @@ const createGameStateStub = () => {
       },
     ],
     teamAssignments: { [HUMAN_ID]: 0 } as Record<string, number>,
-    currentPlayerId: HUMAN_ID as string | null,
+    currentSeatId: asSeatId(HUMAN_ID),
     playState: {
       currentField: {
         cards: ['A♠'],
@@ -100,7 +100,7 @@ describe('ComSessionService.convertPlayerToCOM', () => {
     expect(state.playState!.currentField!.playedBy).toEqual([comId]);
     expect(state.playState!.currentField!.dealerSeatId).toBe(comId);
     expect(state.teamAssignments[comId]).toBe(0);
-    expect(state.currentPlayerId).toBe(comId);
+    expect(state.currentSeatId).toBe(comId);
     expect(Object.keys(vacantSeats['room-1'])).toEqual([HUMAN_ID]);
     expect(vacantSeats['room-1'][asSeatId(HUMAN_ID)].roomPlayer.playerId).toBe(
       HUMAN_ID,

--- a/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
@@ -66,7 +66,7 @@ describe('ComStrategyService', () => {
     };
 
     return {
-      currentPlayerIndex: 0,
+      currentSeatId: asSeatId(players[0].playerId),
       gamePhase: 'blow' as GamePhase,
       deck: [],
       teamScores: {

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -258,7 +258,7 @@ describe('Reconnection Token Management', () => {
         const roomId = 'room-empty';
         const persistedState: GameState = {
           players: [],
-          currentPlayerIndex: -1,
+          currentSeatId: null,
           gamePhase: null,
           deck: [],
           blowState: {

--- a/mei-tra-backend/src/services/game-state-manager.service.ts
+++ b/mei-tra-backend/src/services/game-state-manager.service.ts
@@ -37,8 +37,6 @@ export class GameStateManager {
 
     if (roomId) {
       const persistencePatch: Partial<GameState> = { ...newState };
-      delete persistencePatch.currentPlayerId;
-      delete persistencePatch.currentPlayerIndex;
       if (Object.prototype.hasOwnProperty.call(newState, 'currentSeatId')) {
         persistencePatch.currentSeatId = nextState.currentSeatId;
       }

--- a/mei-tra-backend/src/types/game-state-identity.spec.ts
+++ b/mei-tra-backend/src/types/game-state-identity.spec.ts
@@ -17,8 +17,6 @@ describe('normalizeGameStateIdentityAliases', () => {
         },
       ],
       currentSeatId: asSeatId('seat-1'),
-      currentPlayerId: 'legacy-current',
-      currentPlayerIndex: 0,
       gamePhase: 'play',
       deck: [],
       teamScores: {
@@ -63,8 +61,6 @@ describe('normalizeGameStateIdentityAliases', () => {
       expect.objectContaining({ seatId: 'seat-1', playerId: 'seat-1' }),
     );
     expect(normalized.currentSeatId).toBe('seat-1');
-    expect(normalized.currentPlayerId).toBeUndefined();
-    expect(normalized.currentPlayerIndex).toBeUndefined();
     expect(normalized.blowState.lastPasserSeatId).toBe('seat-1');
     expect(normalized.playState?.currentField?.playedBy).toEqual(['seat-1']);
     expect(normalized.playState?.currentField?.playedBySeatIds).toEqual([
@@ -102,8 +98,6 @@ describe('normalizeGameStateIdentityAliases', () => {
         },
       ],
       currentSeatId: asSeatId('seat-1'),
-      currentPlayerId: 'seat-1',
-      currentPlayerIndex: 0,
       gamePhase: 'play',
       deck: [],
       teamScores: {

--- a/mei-tra-backend/src/types/game-state-identity.ts
+++ b/mei-tra-backend/src/types/game-state-identity.ts
@@ -104,7 +104,5 @@ export function normalizeGameStateIdentityAliases(state: GameState): GameState {
     ),
   };
 
-  delete normalizedState.currentPlayerId;
-  delete normalizedState.currentPlayerIndex;
   return normalizedState;
 }

--- a/mei-tra-backend/src/types/game.types.ts
+++ b/mei-tra-backend/src/types/game.types.ts
@@ -144,10 +144,6 @@ export interface GameState {
   identitySchemaVersion?: 1 | 2;
   players: DomainPlayer[];
   currentSeatId?: SeatId | null;
-  /** @deprecated Use currentSeatId. */
-  currentPlayerId?: string | null;
-  /** @deprecated Derive the index from currentSeatId and players. */
-  currentPlayerIndex?: number;
   gamePhase: GamePhase;
   deck: string[];
   teamScores: Record<Team, { play: number; total: number }>;

--- a/mei-tra-backend/src/use-cases/__tests__/blow-phase-transition.helper.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/blow-phase-transition.helper.spec.ts
@@ -4,6 +4,7 @@ import { GameState } from '../../types/game.types';
 import { Room, RoomStatus } from '../../types/room.types';
 import { IBlowService } from '../../services/interfaces/blow-service.interface';
 import { ICardService } from '../../services/interfaces/card-service.interface';
+import { asSeatId } from '../../types/identity.types';
 
 describe('transitionToPlayPhase', () => {
   it('reveals the Agari card using room player socket when session lookup is empty', async () => {
@@ -30,7 +31,7 @@ describe('transitionToPlayPhase', () => {
           isPasser: false,
         },
       ],
-      currentPlayerIndex: 0,
+      currentSeatId: asSeatId('player-1'),
       gamePhase: 'blow',
       deck: [],
       agari: 'H-A',
@@ -171,7 +172,7 @@ describe('transitionToPlayPhase', () => {
           hasRequiredBroken: false,
         },
       ],
-      currentPlayerIndex: 0,
+      currentSeatId: asSeatId('player-1'),
       gamePhase: 'blow',
       deck: [],
       agari: 'J♦',

--- a/mei-tra-backend/src/use-cases/__tests__/watch-room.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/watch-room.use-case.spec.ts
@@ -71,7 +71,7 @@ describe('WatchRoomUseCase', () => {
       hasRequiredBroken: false,
     })),
     deck: [],
-    currentPlayerIndex: 0,
+    currentSeatId: asSeatId(roomValue.players[0].playerId),
     gamePhase: 'play',
     blowState: blowState(),
     playState: {


### PR DESCRIPTION
## Summary
- `GameState.currentPlayerId` と `currentPlayerIndex` を削除
- 現在手番の正本を `currentSeatId` に限定
- state正規化・永続化patchから旧alias除去処理を削除

## Why
手番をID・index・SeatIdの3形式で持つと、席順変更後にindexだけ古くなるためです。

## Validation
- `cd mei-tra-backend && npm test -- --runInBand` (63 suites / 397 tests)
- `cd mei-tra-backend && npm run lint`
- `cd mei-tra-backend && npm run build`

## User-facing change
なし。現在手番の内部表現をSeatIdへ統一します。

## User benefit
シャッフル、再接続、ラウンド遷移後の手番ずれを防ぎやすくします。
