### PR TITLE
sessionのplayerId aliasを削除

### DIFF
--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -631,7 +631,6 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     const syncResult = this.gameState.upsertSessionUser({
       socketId: client.id,
-      playerId: userId,
       name: displayName,
       userId,
       isAuthenticated: true,

--- a/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
@@ -161,7 +161,7 @@ describe('JoinRoomGatewayEffectsService', () => {
       roomId: 'room-1',
       normalizedUser: {
         socketId: 'socket-1',
-        playerId: 'player-1',
+        seatId: asSeatId('player-1'),
         name: 'Host',
       },
       joinData: {
@@ -242,7 +242,7 @@ describe('JoinRoomGatewayEffectsService', () => {
       roomId: 'room-1',
       normalizedUser: {
         socketId: 'socket-1',
-        playerId: 'player-1',
+        seatId: asSeatId('player-1'),
         name: 'Host',
       },
       joinData: {
@@ -411,7 +411,7 @@ describe('JoinRoomGatewayEffectsService', () => {
       roomId: 'room-1',
       normalizedUser: {
         socketId: 'socket-1',
-        playerId: 'stale-player',
+        seatId: asSeatId('stale-player'),
         userId: 'user-1',
         name: 'User 1',
         isAuthenticated: true,
@@ -501,7 +501,7 @@ describe('JoinRoomGatewayEffectsService', () => {
       roomId: 'room-1',
       normalizedUser: {
         socketId: 'socket-1',
-        playerId: 'stale-player',
+        seatId: asSeatId('stale-player'),
         userId: 'user-1',
         name: 'User 1',
         isAuthenticated: true,

--- a/mei-tra-backend/src/services/__tests__/player-connection-manager.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/player-connection-manager.service.spec.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { PlayerConnectionManager } from '../player-connection-manager.service';
+import { asSeatId } from '../../types/identity.types';
 
 describe('PlayerConnectionManager', () => {
   it('disconnects only the requested player when other sockets are empty', () => {
@@ -8,20 +9,20 @@ describe('PlayerConnectionManager', () => {
     } as unknown as Logger);
     manager.upsertSessionUser({
       socketId: '',
-      playerId: 'host',
+      seatId: asSeatId('host'),
       name: 'Host',
       userId: 'host-user',
       isAuthenticated: true,
     });
     manager.upsertSessionUser({
       socketId: '',
-      playerId: 'com-1',
+      seatId: asSeatId('com-1'),
       name: 'COM',
       isAuthenticated: false,
     });
     manager.upsertSessionUser({
       socketId: 'target-socket',
-      playerId: 'target',
+      seatId: asSeatId('target'),
       name: 'Target',
       userId: 'target-user',
       isAuthenticated: true,
@@ -36,7 +37,7 @@ describe('PlayerConnectionManager', () => {
     });
     expect(manager.findSessionUserByPlayerId('host')).toEqual(
       expect.objectContaining({
-        playerId: 'host',
+        seatId: asSeatId('host'),
         name: 'Host',
         userId: 'host-user',
       }),
@@ -50,20 +51,20 @@ describe('PlayerConnectionManager', () => {
     } as unknown as Logger);
     manager.upsertSessionUser({
       socketId: 'old-socket',
-      playerId: 'user-1',
+      seatId: asSeatId('user-1'),
       name: 'Player',
       userId: 'user-1',
       isAuthenticated: true,
     });
     manager.upsertSessionUser({
       socketId: 'room-socket',
-      playerId: 'seat-1',
+      seatId: asSeatId('seat-1'),
       name: 'Player',
     });
 
     manager.upsertSessionUser({
       socketId: 'new-socket',
-      playerId: 'seat-1',
+      seatId: asSeatId('seat-1'),
       name: 'Player',
       userId: 'user-1',
       isAuthenticated: true,
@@ -72,13 +73,13 @@ describe('PlayerConnectionManager', () => {
     expect(manager.getSessionUsers()).toEqual([
       {
         socketId: 'new-socket',
-        playerId: 'seat-1',
+        seatId: asSeatId('seat-1'),
         name: 'Player',
         userId: 'user-1',
         isAuthenticated: true,
       },
     ]);
-    expect(manager.findSessionUserByUserId('user-1')?.playerId).toBe('seat-1');
+    expect(manager.findSessionUserByUserId('user-1')?.seatId).toBe('seat-1');
   });
 
   it('removes a stale user mapping when one socket changes identity', () => {
@@ -87,7 +88,7 @@ describe('PlayerConnectionManager', () => {
     } as unknown as Logger);
     manager.upsertSessionUser({
       socketId: 'shared-socket',
-      playerId: 'seat-1',
+      seatId: asSeatId('seat-1'),
       name: 'Player 1',
       userId: 'user-1',
       isAuthenticated: true,
@@ -95,7 +96,7 @@ describe('PlayerConnectionManager', () => {
 
     manager.upsertSessionUser({
       socketId: 'shared-socket',
-      playerId: 'seat-2',
+      seatId: asSeatId('seat-2'),
       name: 'Player 2',
       userId: 'user-2',
       isAuthenticated: true,

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -1066,7 +1066,7 @@ describe('Reconnection Token Management', () => {
 
         const joined = await roomService.joinRoom(roomId, {
           socketId: 'socket-new',
-          playerId: 'user-new',
+          seatId: asSeatId('user-new'),
           userId: 'user-new',
           isAuthenticated: true,
           name: 'New Player',
@@ -1128,7 +1128,7 @@ describe('Reconnection Token Management', () => {
 
         const joined = await roomService.joinRoom(roomId, {
           socketId: 'socket-new',
-          playerId: 'user-new',
+          seatId: asSeatId('user-new'),
           userId: 'user-new',
           isAuthenticated: true,
           name: 'New Player',
@@ -1175,7 +1175,7 @@ describe('Reconnection Token Management', () => {
 
         const joined = await roomService.joinRoom(roomId, {
           socketId: 'socket-new',
-          playerId: 'user-new',
+          seatId: asSeatId('user-new'),
           userId: 'user-new',
           isAuthenticated: true,
           name: 'New Player',
@@ -1247,7 +1247,7 @@ describe('Reconnection Token Management', () => {
 
         const joined = await roomService.joinRoom(roomId, {
           socketId: 'socket-owner',
-          playerId: 'stale-player-id',
+          seatId: asSeatId('stale-player-id'),
           userId: 'user-owner',
           isAuthenticated: true,
           name: 'Owner',
@@ -1384,7 +1384,7 @@ describe('Reconnection Token Management', () => {
 
         const result = await roomService.joinRoom(roomId, {
           socketId: 'socket-new',
-          playerId: 'stale-player',
+          seatId: asSeatId('stale-player'),
           userId: 'user-1',
           isAuthenticated: true,
           name: 'Test Player',
@@ -2277,7 +2277,7 @@ describe('Reconnection Token Management', () => {
         const originalPlayerId = 'player-1';
         const newUser = {
           socketId: 'socket-2',
-          playerId: 'player-2', // Different playerId
+          seatId: asSeatId('player-2'),
           name: 'New Player',
         };
 

--- a/mei-tra-backend/src/services/__tests__/room-membership-lifecycle.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room-membership-lifecycle.spec.ts
@@ -8,6 +8,7 @@ import { IComPlayerService } from '../interfaces/com-player-service.interface';
 import { ActiveRoomMembershipConflictError } from '../../types/room-membership.types';
 import { Room, RoomStatus } from '../../types/room.types';
 import { GameStateService } from '../game-state.service';
+import { asSeatId } from '../../types/identity.types';
 
 describe('RoomService active membership lifecycle', () => {
   const room: Room = {
@@ -101,7 +102,7 @@ describe('RoomService active membership lifecycle', () => {
     await expect(
       service.joinRoom('room-1', {
         socketId: 'socket-1',
-        playerId: 'user-1',
+        seatId: asSeatId('user-1'),
         userId: 'user-1',
         name: 'Player 1',
       }),
@@ -137,7 +138,7 @@ describe('RoomService active membership lifecycle', () => {
     await expect(
       service.joinRoom('room-1', {
         socketId: 'socket-new',
-        playerId: 'user-1',
+        seatId: asSeatId('user-1'),
         userId: 'user-1',
         name: 'Player 1',
       }),
@@ -146,7 +147,7 @@ describe('RoomService active membership lifecycle', () => {
     expect(membershipService.claim).not.toHaveBeenCalled();
     const joinRequest: unknown = roomJoinService.joinRoom.mock.calls[0]?.[0];
     expect(joinRequest).toMatchObject({
-      user: { playerId: 'seat-1' },
+      user: { seatId: 'seat-1' },
     });
     expect(membershipService.get).toHaveBeenCalledWith('user-1');
   });
@@ -175,7 +176,7 @@ describe('RoomService active membership lifecycle', () => {
     await expect(
       service.joinRoom('room-1', {
         socketId: 'socket-new',
-        playerId: 'user-1',
+        seatId: asSeatId('user-1'),
         userId: 'user-1',
         name: 'Player 1',
       }),
@@ -191,7 +192,7 @@ describe('RoomService active membership lifecycle', () => {
     await expect(
       service.joinRoom('room-1', {
         socketId: 'socket-1',
-        playerId: 'user-1',
+        seatId: asSeatId('user-1'),
         userId: 'user-1',
         name: 'Player 1',
       }),
@@ -206,7 +207,7 @@ describe('RoomService active membership lifecycle', () => {
 
     await service.joinRoom('room-1', {
       socketId: 'socket-2',
-      playerId: 'user-1',
+      seatId: asSeatId('user-1'),
       userId: 'user-1',
       name: 'Player 1',
     });

--- a/mei-tra-backend/src/services/__tests__/room.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room.service.spec.ts
@@ -157,7 +157,7 @@ describe('RoomService join rollback', () => {
     await expect(
       service.joinRoom('room-1', {
         socketId: 'socket-2',
-        playerId: 'user-2',
+        seatId: asSeatId('user-2'),
         userId: 'user-2',
         name: 'Player 2',
         isAuthenticated: true,

--- a/mei-tra-backend/src/services/com-session.service.ts
+++ b/mei-tra-backend/src/services/com-session.service.ts
@@ -28,7 +28,6 @@ export class ComSessionService {
       session: {
         socketId: `com-${idStr}`,
         seatId,
-        playerId: seatId,
         name: 'COM',
       },
       participantKey: `com-${idStr}-${seatId}`,
@@ -152,7 +151,6 @@ export class ComSessionService {
         session: {
           socketId: `com-${startingPlayerCount + i}`,
           seatId,
-          playerId: seatId,
           name: comPlayer.name,
         },
         participantKey: comPlayer.playerId,

--- a/mei-tra-backend/src/services/disconnect-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/disconnect-gateway-effects.service.ts
@@ -275,8 +275,7 @@ export class DisconnectGatewayEffectsService {
     if (disconnectedSessionUser) {
       return (
         players.find(
-          (candidate) =>
-            candidate.playerId === disconnectedSessionUser.playerId,
+          (candidate) => candidate.seatId === disconnectedSessionUser.seatId,
         ) ?? null
       );
     }

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -341,7 +341,7 @@ export class GameStateService implements IGameStateService {
     if (sessionUser) {
       return (
         this.state.players.find(
-          (player) => player.playerId === sessionUser.playerId,
+          (player) => player.seatId === sessionUser.seatId,
         ) || null
       );
     }
@@ -363,7 +363,7 @@ export class GameStateService implements IGameStateService {
 
     return (
       this.state.players.find(
-        (player) => player.playerId === sessionUser.playerId,
+        (player) => player.seatId === sessionUser.seatId,
       ) ?? null
     );
   }

--- a/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
@@ -79,17 +79,20 @@ export class JoinRoomGatewayEffectsService {
     const events: GatewayEvent[] = [];
     let room = joinData.room;
     const selfRoomPlayer = this.resolveSelfRoomPlayer(room, normalizedUser);
-    const selfPlayerId = selfRoomPlayer?.playerId ?? normalizedUser.playerId;
+    if (!selfRoomPlayer) {
+      throw new Error(
+        `Joined seat could not be resolved: room=${roomId} user=${normalizedUser.userId ?? 'unknown'}`,
+      );
+    }
+    const selfPlayerId = selfRoomPlayer.playerId;
 
-    if (currentRoomId && currentRoomId !== roomId) {
+    if (currentRoomId && currentRoomId !== roomId && previousRoomNotification) {
       events.push({
         scope: 'room',
         roomId: currentRoomId,
         event: 'player-left',
         payload: {
-          seatId: asSeatId(
-            previousRoomNotification?.playerId ?? normalizedUser.playerId,
-          ),
+          seatId: asSeatId(previousRoomNotification.playerId),
           roomId: currentRoomId,
         },
       });
@@ -294,7 +297,7 @@ export class JoinRoomGatewayEffectsService {
     }
 
     return room.players.find(
-      (player) => player.playerId === normalizedUser.playerId,
+      (player) => player.playerId === normalizedUser.seatId,
     );
   }
 
@@ -310,11 +313,13 @@ export class JoinRoomGatewayEffectsService {
       return selfRoomPlayer.playerId;
     }
 
-    if (gamePlayerIds.has(normalizedUser.playerId)) {
-      return normalizedUser.playerId;
+    if (normalizedUser.seatId && gamePlayerIds.has(normalizedUser.seatId)) {
+      return normalizedUser.seatId;
     }
 
-    return normalizedUser.playerId;
+    throw new Error(
+      `Resume seat could not be resolved: room=${room.id} user=${normalizedUser.userId ?? 'unknown'}`,
+    );
   }
 
   async buildRoomEntryEvents({

--- a/mei-tra-backend/src/services/player-connection-manager.service.ts
+++ b/mei-tra-backend/src/services/player-connection-manager.service.ts
@@ -20,18 +20,12 @@ export class PlayerConnectionManager {
     userId?: string,
     isAuthenticated?: boolean,
   ): boolean {
-    const playerId = userId || this.generateReconnectToken();
     this.users.push({
       socketId,
-      playerId,
       name,
       userId,
       isAuthenticated: isAuthenticated || false,
     });
-
-    if (userId) {
-      this.playerIds.set(userId, playerId);
-    }
 
     return true;
   }
@@ -45,7 +39,7 @@ export class PlayerConnectionManager {
   }
 
   findSessionUserByPlayerId(playerId: string): SessionUser | null {
-    return this.users.find((user) => user.playerId === playerId) || null;
+    return this.users.find((user) => user.seatId === playerId) || null;
   }
 
   upsertSessionUser(sessionUser: SessionUser): {
@@ -55,12 +49,15 @@ export class PlayerConnectionManager {
   } {
     const matchingUsers = this.users.filter(
       (user) =>
-        user.playerId === sessionUser.playerId ||
+        (sessionUser.seatId != null && user.seatId === sessionUser.seatId) ||
         (sessionUser.userId != null && user.userId === sessionUser.userId) ||
         (sessionUser.socketId !== '' && user.socketId === sessionUser.socketId),
     );
     const existingUser =
-      matchingUsers.find((user) => user.playerId === sessionUser.playerId) ??
+      matchingUsers.find(
+        (user) =>
+          sessionUser.seatId != null && user.seatId === sessionUser.seatId,
+      ) ??
       matchingUsers.find(
         (user) =>
           sessionUser.userId != null && user.userId === sessionUser.userId,
@@ -69,8 +66,8 @@ export class PlayerConnectionManager {
 
     if (!existingUser) {
       this.users.push(sessionUser);
-      if (sessionUser.userId) {
-        this.playerIds.set(sessionUser.userId, sessionUser.playerId);
+      if (sessionUser.userId && sessionUser.seatId) {
+        this.playerIds.set(sessionUser.userId, sessionUser.seatId);
       }
       return {
         user: sessionUser,
@@ -82,12 +79,11 @@ export class PlayerConnectionManager {
     const nextUserId = sessionUser.userId ?? existingUser.userId;
     const nextIsAuthenticated =
       sessionUser.isAuthenticated ?? existingUser.isAuthenticated;
-    const previousPlayerId = existingUser.playerId;
+    const previousSeatId = existingUser.seatId;
     const previousUserId = existingUser.userId;
     const changed =
       existingUser.socketId !== sessionUser.socketId ||
       existingUser.seatId !== sessionUser.seatId ||
-      existingUser.playerId !== sessionUser.playerId ||
       existingUser.name !== sessionUser.name ||
       existingUser.userId !== nextUserId ||
       existingUser.isAuthenticated !== nextIsAuthenticated;
@@ -95,7 +91,6 @@ export class PlayerConnectionManager {
     if (changed) {
       existingUser.socketId = sessionUser.socketId;
       existingUser.seatId = sessionUser.seatId;
-      existingUser.playerId = sessionUser.playerId;
       existingUser.name = sessionUser.name;
       existingUser.userId = nextUserId;
       existingUser.isAuthenticated = nextIsAuthenticated;
@@ -104,13 +99,13 @@ export class PlayerConnectionManager {
     if (
       previousUserId &&
       previousUserId !== sessionUser.userId &&
-      this.playerIds.get(previousUserId) === previousPlayerId
+      this.playerIds.get(previousUserId) === previousSeatId
     ) {
       this.playerIds.delete(previousUserId);
     }
 
-    if (sessionUser.userId) {
-      this.playerIds.set(sessionUser.userId, sessionUser.playerId);
+    if (sessionUser.userId && sessionUser.seatId) {
+      this.playerIds.set(sessionUser.userId, sessionUser.seatId);
     }
 
     for (const duplicateUser of matchingUsers) {
@@ -120,7 +115,7 @@ export class PlayerConnectionManager {
       if (
         duplicateUser.userId &&
         duplicateUser.userId !== sessionUser.userId &&
-        this.playerIds.get(duplicateUser.userId) === duplicateUser.playerId
+        this.playerIds.get(duplicateUser.userId) === duplicateUser.seatId
       ) {
         this.playerIds.delete(duplicateUser.userId);
       }
@@ -170,7 +165,7 @@ export class PlayerConnectionManager {
     }
 
     return (
-      players.find((player) => player.playerId === sessionUser.playerId) || null
+      players.find((player) => player.seatId === sessionUser.seatId) || null
     );
   }
 
@@ -217,7 +212,6 @@ export class PlayerConnectionManager {
     const { user } = this.upsertSessionUser({
       socketId,
       seatId: asSeatId(playerId),
-      playerId,
       name,
       userId: resolvedUserId,
       isAuthenticated:
@@ -273,9 +267,5 @@ export class PlayerConnectionManager {
       clearTimeout(timeout);
     }
     this.disconnectedPlayers.clear();
-  }
-
-  private generateReconnectToken(): string {
-    return Math.random().toString(36).substring(2, 15);
   }
 }

--- a/mei-tra-backend/src/services/room-join.service.ts
+++ b/mei-tra-backend/src/services/room-join.service.ts
@@ -56,7 +56,7 @@ export class RoomJoinService {
         }
         return user.userId
           ? seatData.roomPlayer.userId === user.userId
-          : seatData.roomPlayer.playerId === user.playerId;
+          : seatData.roomPlayer.seatId === user.seatId;
       })?.[0];
       const reclaimingCOMSeat = Boolean(
         existingPlayer.isCOM &&
@@ -69,7 +69,7 @@ export class RoomJoinService {
         seatId: resolveSeatId(existingPlayer),
         playerId: resolveSeatId(existingPlayer),
         participantKey:
-          user.userId ?? existingPlayer.participantKey ?? user.playerId,
+          user.userId ?? existingPlayer.participantKey ?? user.seatId,
         userId: user.userId ?? existingPlayer.userId,
         isAuthenticated: user.isAuthenticated ?? existingPlayer.isAuthenticated,
         isHost: room.hostId === existingPlayer.playerId,
@@ -125,7 +125,8 @@ export class RoomJoinService {
     let restoredSeatData: RestoredSeatData | null = null;
 
     const matchingVacantEntry = vacantEntries.find(
-      ([, seatData]) => seatData.roomPlayer.playerId === user.playerId,
+      ([, seatData]) =>
+        user.seatId != null && seatData.roomPlayer.seatId === user.seatId,
     );
 
     if (matchingVacantEntry) {
@@ -138,7 +139,7 @@ export class RoomJoinService {
 
       team = seatRoomPlayer ? seatRoomPlayer.team : team;
       restoredSeatData = seatData;
-      gameState.clearDisconnectTimeout(user.playerId);
+      gameState.clearDisconnectTimeout(vacantSeatId);
       delete roomVacant[asSeatId(vacantSeatId)];
       if (Object.keys(roomVacant).length === 0) {
         delete vacantSeats[roomId];
@@ -237,7 +238,7 @@ export class RoomJoinService {
       socketId: user.socketId,
       seatId: assignedSeatId,
       playerId: assignedSeatId,
-      participantKey: user.userId ?? user.playerId,
+      participantKey: user.userId ?? user.seatId ?? assignedSeatId,
       team: currentSeatRoomPlayer?.team ?? team,
       hand: [],
       isPasser: false,
@@ -329,7 +330,7 @@ export class RoomJoinService {
       }
     }
 
-    return players.find((player) => player.playerId === user.playerId);
+    return players.find((player) => player.seatId === user.seatId);
   }
 
   private isReplaceableCOMSeat(player: RoomPlayer): boolean {

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -188,7 +188,6 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     const canonicalHostUser: SessionUser = {
       ...hostUser,
       seatId: hostSeatId,
-      playerId: hostSeatId,
     };
     const reservation = await this.roomMembershipService.reserve(
       hostUserId,
@@ -612,7 +611,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     );
     if (roomMatches.length === 1) {
       const seatId = asSeatId(roomMatches[0].playerId);
-      return { ...user, seatId, playerId: seatId };
+      return { ...user, seatId };
     }
     if (roomMatches.length > 1) {
       throw new Error(
@@ -628,7 +627,6 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       return {
         ...user,
         seatId,
-        playerId: seatId,
       };
     }
     if (vacantMatches.length > 1) {
@@ -640,7 +638,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     const membership = await this.roomMembershipService.get(user.userId);
     if (membership?.roomId === roomId) {
       const seatId = membership.seatId;
-      return { ...user, seatId, playerId: seatId };
+      return { ...user, seatId };
     }
 
     return user;

--- a/mei-tra-backend/src/types/player-adapters.ts
+++ b/mei-tra-backend/src/types/player-adapters.ts
@@ -183,8 +183,7 @@ export function toRoomPlayer(params: {
     socketId: params.session.socketId,
     seatId,
     playerId: seatId,
-    participantKey:
-      params.participantKey ?? params.session.userId ?? params.session.playerId,
+    participantKey: params.participantKey ?? params.session.userId ?? seatId,
     name: params.gameplay.name,
     userId: params.session.userId,
     isAuthenticated: params.session.isAuthenticated,

--- a/mei-tra-backend/src/types/room.types.ts
+++ b/mei-tra-backend/src/types/room.types.ts
@@ -11,6 +11,8 @@ export enum RoomStatus {
 }
 
 export interface RoomPlayer extends SessionUser, PlayerGameplayState {
+  /** @deprecated Use seatId. */
+  playerId: string;
   participantKey?: string;
   isReady: boolean;
   isHost: boolean;

--- a/mei-tra-backend/src/types/session.types.ts
+++ b/mei-tra-backend/src/types/session.types.ts
@@ -3,8 +3,6 @@ import type { SeatId } from './identity.types';
 export interface SessionUser {
   socketId: string;
   seatId?: SeatId;
-  /** @deprecated Use seatId after joining a room. */
-  playerId: string;
   name: string;
   userId?: string;
   isAuthenticated?: boolean;

--- a/mei-tra-backend/src/use-cases/__tests__/create-room-with-chat.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/create-room-with-chat.spec.ts
@@ -102,7 +102,6 @@ describe('CreateRoomUseCase', () => {
     expect(roomService.createNewRoom).toHaveBeenCalledWith(
       'Test Game Room',
       expect.objectContaining({
-        playerId: userId,
         userId,
         socketId: 'socket-1',
       }),
@@ -112,7 +111,6 @@ describe('CreateRoomUseCase', () => {
     expect(roomService.joinRoom).toHaveBeenCalledWith(
       roomId,
       expect.objectContaining({
-        playerId: userId,
         userId,
         name: 'Test Player',
       }),

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -244,7 +244,6 @@ describe('Game Use Cases', () => {
         expect.objectContaining({
           name: 'Display Name',
           socketId: 'socket-1',
-          playerId: 'user-1',
           userId: 'user-1',
           isAuthenticated: true,
         }),
@@ -282,7 +281,7 @@ describe('Game Use Cases', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(result.normalizedUser?.playerId).toBe('seat-1');
+      expect(result.normalizedUser?.seatId).toBe('seat-1');
       expect(result.data?.isHost).toBe(true);
     });
 
@@ -395,7 +394,6 @@ describe('Game Use Cases', () => {
       expect(createRoomMock).toHaveBeenCalledWith(
         'Room',
         expect.objectContaining({
-          playerId: 'player-1',
           userId: 'player-1',
           socketId: 'socket-1',
         }),
@@ -4169,7 +4167,6 @@ describe('Game Use Cases', () => {
       expect(gameState.upsertSessionUser).toHaveBeenCalledWith(
         expect.objectContaining({
           socketId: 'socket-1',
-          playerId: 'user-1',
           name: 'User Display',
           userId: 'user-1',
           isAuthenticated: true,

--- a/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
@@ -222,7 +222,7 @@ describe('ReconnectionUseCase', () => {
     expect(gameState.upsertSessionUser).toHaveBeenCalledWith(
       expect.objectContaining({
         socketId: 'socket-1',
-        playerId: 'seat-1',
+        seatId: 'seat-1',
         userId: 'user-1',
       }),
     );

--- a/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
@@ -6,6 +6,7 @@ import { AuthenticatedUser } from '../../types/user.types';
 import { Room, RoomStatus } from '../../types/room.types';
 import { GameStateService } from '../../services/game-state.service';
 import { PlayerConnectionState, SessionUser } from '../../types/session.types';
+import { asSeatId } from '../../types/identity.types';
 
 describe('UpdateAuthUseCase', () => {
   const createAuthServiceMock = () =>
@@ -48,7 +49,7 @@ describe('UpdateAuthUseCase', () => {
     const users: SessionUser[] = [
       {
         socketId: 'socket-1',
-        playerId: 'player-1',
+        seatId: asSeatId('player-1'),
         name: 'Old Name',
         userId: 'user-1',
         isAuthenticated: true,
@@ -164,7 +165,7 @@ describe('UpdateAuthUseCase', () => {
     expect(gameState.upsertSessionUser).toHaveBeenCalledWith(
       expect.objectContaining({
         socketId: 'socket-1',
-        playerId: 'player-1',
+        seatId: 'player-1',
         name: 'User Display',
         userId: 'user-1',
         isAuthenticated: true,

--- a/mei-tra-backend/src/use-cases/create-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/create-room.use-case.ts
@@ -64,7 +64,6 @@ export class CreateRoomUseCase implements ICreateRoomUseCase {
 
       const hostUser: SessionUser = {
         socketId,
-        playerId: authenticatedUser.id,
         name: playerName,
         userId: authenticatedUser.id,
         isAuthenticated: true,

--- a/mei-tra-backend/src/use-cases/join-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/join-room.use-case.ts
@@ -44,7 +44,7 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
       );
       if (!joinSucceeded) {
         this.logger.warn(
-          `Join room failed for player ${normalizedUser.playerId} in room ${targetRoomId}`,
+          `Join room failed for user ${normalizedUser.userId} in room ${targetRoomId}`,
         );
         return {
           success: false,
@@ -69,7 +69,7 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
       const joinedPlayer = this.resolveJoinedRoomPlayer(room, normalizedUser);
       if (!joinedPlayer) {
         this.logger.error(
-          `Joined player could not be resolved for user ${normalizedUser.userId ?? normalizedUser.playerId} in room ${targetRoomId}`,
+          `Joined player could not be resolved for user ${normalizedUser.userId} in room ${targetRoomId}`,
         );
         return {
           success: false,
@@ -80,7 +80,7 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
       }
       const resolvedUser: SessionUser = {
         ...normalizedUser,
-        playerId: joinedPlayer.playerId,
+        seatId: asSeatId(joinedPlayer.playerId),
       };
       const data: JoinRoomSuccess = {
         room,
@@ -127,7 +127,6 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
 
     return {
       socketId: request.socketId,
-      playerId: authenticatedUser.id,
       name: displayName,
       userId: authenticatedUser.id,
       isAuthenticated: true,
@@ -151,9 +150,8 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
     }
 
     return (
-      room.players.find(
-        (player) => player.playerId === normalizedUser.playerId,
-      ) ?? null
+      room.players.find((player) => player.seatId === normalizedUser.seatId) ??
+      null
     );
   }
 
@@ -172,7 +170,10 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
 
     return {
       roomId: currentRoomId,
-      playerId: currentRoomPlayer?.playerId ?? normalizedUser.playerId,
+      playerId:
+        currentRoomPlayer?.playerId ??
+        normalizedUser.seatId ??
+        normalizedUser.userId!,
     };
   }
 

--- a/mei-tra-backend/src/use-cases/reconnection.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reconnection.use-case.ts
@@ -430,7 +430,7 @@ export class ReconnectionUseCase {
 
     this.gameState.upsertSessionUser({
       socketId,
-      playerId,
+      seatId: asSeatId(playerId),
       name: displayName,
       userId: authenticatedUser.id,
       isAuthenticated: true,
@@ -492,9 +492,8 @@ export class ReconnectionUseCase {
 
     if (sessionUser) {
       const sessionMatchedPlayer =
-        roomPlayers.find(
-          (player) => player.playerId === sessionUser.playerId,
-        ) ?? null;
+        roomPlayers.find((player) => player.seatId === sessionUser.seatId) ??
+        null;
       if (sessionMatchedPlayer) {
         return sessionMatchedPlayer;
       }

--- a/mei-tra-backend/src/use-cases/update-auth.use-case.ts
+++ b/mei-tra-backend/src/use-cases/update-auth.use-case.ts
@@ -9,6 +9,7 @@ import { IGameStateService } from '../services/interfaces/game-state-service.int
 import { IRoomService } from '../services/interfaces/room-service.interface';
 import { GatewayEvent } from './interfaces/gateway-event.interface';
 import { AuthenticatedUser } from '../types/user.types';
+import { asSeatId } from '../types/identity.types';
 import {
   buildPlayerSyncEvents,
   buildRoomUpdatedEvent,
@@ -97,7 +98,7 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
 
     const syncResult = this.gameState.upsertSessionUser({
       socketId,
-      playerId: playerId ?? authenticatedUser.id,
+      seatId: playerId ? asSeatId(playerId) : undefined,
       name: displayName,
       userId: authenticatedUser.id,
       isAuthenticated: true,


### PR DESCRIPTION
## Summary
- `SessionUser.playerId` を削除し、接続セッションを `seatId` / `userId` / `socketId` で識別
- 入室前の認証ユーザーIDと入室後の席IDを同じフィールドへ格納する処理を廃止
- 接続・再接続・入室処理と関連テストをcanonical seat identityへ更新
- 次段の削除を分離するため、RoomPlayerのlegacy `playerId` は明示的にRoomPlayerへ移動

## Why
`SessionUser.playerId` は入室前にはuserId、入室後にはseatIdとして意味が変わり、identityの取り違えを起こしやすい状態でした。セッション上の各IDの役割を分離します。

## Validation
- `cd mei-tra-backend && npm test -- --runInBand` (63 suites / 397 tests)
- `cd mei-tra-backend && npm run lint`
- `cd mei-tra-backend && npm run build`
- `git diff --check`

## User-facing change
なし。内部の接続セッションidentityを整理します。

## User benefit
再接続・入退室時のユーザーIDと席IDの取り違えを防ぎます。
