### PR TITLE
roomのhostId aliasを削除

### DIFF
--- a/mei-tra-backend/src/controllers/game-history.controller.spec.ts
+++ b/mei-tra-backend/src/controllers/game-history.controller.spec.ts
@@ -31,7 +31,7 @@ describe('GameHistoryController', () => {
   const room = {
     id: 'room-1',
     name: 'Room 1',
-    hostId: 'player-1',
+    hostSeatId: asSeatId('player-1'),
     status: RoomStatus.FINISHED,
     players: [
       {

--- a/mei-tra-backend/src/repositories/implementations/supabase-room.repository.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-room.repository.ts
@@ -93,8 +93,6 @@ export class SupabaseRoomRepository implements IRoomRepository {
       if (updates.name) updateData.name = updates.name;
       if (updates.hostSeatId) {
         updateData.host_seat_id = updates.hostSeatId;
-      } else if (updates.hostId) {
-        updateData.host_seat_id = updates.hostId;
       }
       if (updates.status) updateData.status = updates.status;
       if (updates.settings) updateData.settings = updates.settings;
@@ -309,7 +307,6 @@ export class SupabaseRoomRepository implements IRoomRepository {
       id: dbRoom.id,
       name: dbRoom.name,
       hostSeatId: asSeatId(hostSeatId),
-      hostId: hostSeatId,
       status: dbRoom.status as RoomStatus,
       players: canonicalPlayers,
       settings: dbRoom.settings,

--- a/mei-tra-backend/src/services/__tests__/disconnect-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/disconnect-gateway-effects.service.spec.ts
@@ -71,7 +71,7 @@ describe('DisconnectGatewayEffectsService', () => {
       id: 'room-1',
       name: 'Room 1',
       status: 'playing',
-      hostId: 'player-1',
+      hostSeatId: asSeatId('player-1'),
       maxPlayers: 4,
       players: [
         {
@@ -102,7 +102,7 @@ describe('DisconnectGatewayEffectsService', () => {
     };
     const updatedRoom = {
       ...initialRoom,
-      hostId: 'player-2',
+      hostSeatId: asSeatId('player-2'),
       players: initialRoom.players.map((player) => ({
         ...player,
         isHost: player.playerId === 'player-2',
@@ -182,7 +182,7 @@ describe('DisconnectGatewayEffectsService', () => {
       { socketId: '' },
     );
     expect(roomService.updateRoom).toHaveBeenCalledWith('room-1', {
-      hostId: 'player-2',
+      hostSeatId: asSeatId('player-2'),
     });
     expect(result?.events).toEqual(
       expect.arrayContaining([

--- a/mei-tra-backend/src/services/__tests__/gameplay-notification.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/gameplay-notification.service.spec.ts
@@ -51,7 +51,7 @@ const state = (overrides: Partial<GameState> = {}): GameState =>
 const room = (overrides: Partial<Room> = {}): Room => ({
   id: 'room-1',
   name: 'Room',
-  hostId: 'player-1',
+  hostSeatId: asSeatId('player-1'),
   status: RoomStatus.PLAYING,
   players: [
     {

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -365,7 +365,7 @@ describe('Reconnection Token Management', () => {
     const baseRoom: Room = {
       id: 'room-123',
       name: 'Test Room',
-      hostId: 'player-1',
+      hostSeatId: asSeatId('player-1'),
       status: RoomStatus.PLAYING,
       settings: {
         maxPlayers: 4,
@@ -549,7 +549,7 @@ describe('Reconnection Token Management', () => {
           if (persistedRoom?.id === roomId) {
             persistedRoom = cloneRoom({
               ...persistedRoom,
-              hostId: hostId ?? persistedRoom.hostId,
+              hostSeatId: asSeatId(hostId ?? persistedRoom.hostSeatId),
               players: roomPlayers.map((player) => ({
                 ...player,
                 socketId: '',
@@ -1059,7 +1059,7 @@ describe('Reconnection Token Management', () => {
         const roomState = bindRoomRepositoryToState({
           ...baseRoom,
           id: roomId,
-          hostId: host.playerId,
+          hostSeatId: asSeatId(host.playerId),
           status: RoomStatus.WAITING,
           players: [host, comSeat],
         });
@@ -1120,7 +1120,7 @@ describe('Reconnection Token Management', () => {
         const roomState = bindRoomRepositoryToState({
           ...baseRoom,
           id: roomId,
-          hostId: host.playerId,
+          hostSeatId: asSeatId(host.playerId),
           status: RoomStatus.WAITING,
           settings: { ...baseRoom.settings, maxPlayers: 2 },
           players: [host, timeoutSeat],
@@ -1154,7 +1154,7 @@ describe('Reconnection Token Management', () => {
         const roomState = bindRoomRepositoryToState({
           ...baseRoom,
           id: roomId,
-          hostId: host.playerId,
+          hostSeatId: asSeatId(host.playerId),
           status: RoomStatus.PLAYING,
           settings: { ...baseRoom.settings, maxPlayers: 3 },
           players: [host, timeoutSeat],
@@ -1215,7 +1215,7 @@ describe('Reconnection Token Management', () => {
         const roomState = bindRoomRepositoryToState({
           ...baseRoom,
           id: roomId,
-          hostId: seatId,
+          hostSeatId: asSeatId(seatId),
           status: RoomStatus.PLAYING,
           players: [timeoutCOM],
         });
@@ -1434,7 +1434,7 @@ describe('Reconnection Token Management', () => {
 
         const room: Room = {
           ...baseRoom,
-          hostId: comPlayer.playerId,
+          hostSeatId: asSeatId(comPlayer.playerId),
           status: RoomStatus.WAITING,
           players: [comPlayer],
         };
@@ -1458,11 +1458,11 @@ describe('Reconnection Token Management', () => {
         );
       });
 
-      it('should normalize duplicate host flags based on room.hostId', async () => {
+      it('should normalize duplicate host flags based on room.hostSeatId', async () => {
         const roomId = 'room-123';
         const room: Room = {
           ...baseRoom,
-          hostId: 'player-2',
+          hostSeatId: asSeatId('player-2'),
           players: [
             {
               socketId: 'socket-1',
@@ -2361,7 +2361,7 @@ describe('Reconnection Token Management', () => {
       const roomState = bindRoomRepositoryToState({
         ...baseRoom,
         id: roomId,
-        hostId: playerId,
+        hostSeatId: asSeatId(playerId),
         status: RoomStatus.PLAYING,
         players: [
           {

--- a/mei-tra-backend/src/services/__tests__/room-membership-lifecycle.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room-membership-lifecycle.spec.ts
@@ -14,7 +14,7 @@ describe('RoomService active membership lifecycle', () => {
   const room: Room = {
     id: 'room-1',
     name: 'Room 1',
-    hostId: 'user-1',
+    hostSeatId: asSeatId('user-1'),
     status: RoomStatus.WAITING,
     settings: {
       maxPlayers: 4,
@@ -115,7 +115,7 @@ describe('RoomService active membership lifecycle', () => {
   it('joins with the persisted room seat id and leaves claiming to the atomic writer', async () => {
     const roomWithResolvedSeat: Room = {
       ...room,
-      hostId: 'seat-1',
+      hostSeatId: asSeatId('seat-1'),
       players: [
         {
           socketId: 'socket-old',

--- a/mei-tra-backend/src/services/__tests__/room-update-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room-update-gateway-effects.service.spec.ts
@@ -51,7 +51,7 @@ describe('RoomUpdateGatewayEffectsService', () => {
     const room = {
       id: 'room-1',
       name: 'Room',
-      hostId: 'player-1',
+      hostSeatId: asSeatId('player-1'),
       status: RoomStatus.WAITING,
       players: [
         {
@@ -85,7 +85,7 @@ describe('RoomUpdateGatewayEffectsService', () => {
       expect.objectContaining({
         id: room.id,
         name: room.name,
-        hostSeatId: room.hostId,
+        hostSeatId: room.hostSeatId,
         status: room.status,
         createdAt: room.createdAt.toISOString(),
         updatedAt: room.updatedAt.toISOString(),

--- a/mei-tra-backend/src/services/__tests__/room.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room.service.spec.ts
@@ -25,7 +25,7 @@ const createRoomPlayer = (overrides: Partial<RoomPlayer> = {}): RoomPlayer => ({
 const createRoom = (): Room => ({
   id: 'room-1',
   name: 'Room',
-  hostId: 'player-1',
+  hostSeatId: asSeatId('player-1'),
   status: RoomStatus.WAITING,
   players: [createRoomPlayer()],
   settings: {

--- a/mei-tra-backend/src/services/com-session.service.ts
+++ b/mei-tra-backend/src/services/com-session.service.ts
@@ -103,7 +103,7 @@ export class ComSessionService {
     }
 
     if (rosterChanged) {
-      await gameState.persistRoster(room.players, room.hostId);
+      await gameState.persistRoster(room.players, room.hostSeatId);
     }
   }
 
@@ -129,7 +129,7 @@ export class ComSessionService {
 
     const maxPlayers = room.settings?.maxPlayers ?? 4;
     if (room.players.length >= maxPlayers) {
-      await gameState.persistRoster(room.players, room.hostId);
+      await gameState.persistRoster(room.players, room.hostSeatId);
       return;
     }
 
@@ -171,7 +171,7 @@ export class ComSessionService {
       );
     }
 
-    await gameState.persistRoster(room.players, room.hostId);
+    await gameState.persistRoster(room.players, room.hostSeatId);
   }
 
   async convertPlayerToCOM(
@@ -225,7 +225,7 @@ export class ComSessionService {
 
     await gameState.persistRoster(
       room.players,
-      room.hostId,
+      room.hostSeatId,
       membershipMutation,
     );
     return true;

--- a/mei-tra-backend/src/services/disconnect-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/disconnect-gateway-effects.service.ts
@@ -304,14 +304,14 @@ export class DisconnectGatewayEffectsService {
     let room = params.room;
     const events: GatewayEvent[] = [];
 
-    if (room?.hostId === player.playerId) {
+    if (room?.hostSeatId === player.playerId) {
       const nextHost = room.players.find(
         (candidate) =>
           candidate.playerId !== player.playerId && !candidate.isCOM,
       );
       if (nextHost) {
         await this.roomService.updateRoom(roomId, {
-          hostId: nextHost.playerId,
+          hostSeatId: asSeatId(nextHost.playerId),
         });
         room = await this.roomService.getRoom(roomId);
         if (room) {

--- a/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
@@ -231,7 +231,7 @@ export class JoinRoomGatewayEffectsService {
         })),
         blowState: toBlowStateContract(joinData.resumeGame.gameState.blowState),
         youSeatId: resumeSelfPlayerId ? asSeatId(resumeSelfPlayerId) : null,
-        hostSeatId: asSeatId(room.hostId),
+        hostSeatId: asSeatId(room.hostSeatId),
       };
 
       events.push({

--- a/mei-tra-backend/src/services/room-join.service.ts
+++ b/mei-tra-backend/src/services/room-join.service.ts
@@ -72,7 +72,7 @@ export class RoomJoinService {
           user.userId ?? existingPlayer.participantKey ?? user.seatId,
         userId: user.userId ?? existingPlayer.userId,
         isAuthenticated: user.isAuthenticated ?? existingPlayer.isAuthenticated,
-        isHost: room.hostId === existingPlayer.playerId,
+        isHost: room.hostSeatId === existingPlayer.playerId,
         isCOM: reclaimingCOMSeat ? false : existingPlayer.isCOM,
       };
       upsertRuntimeSeat(room, state, updatedPlayer, {
@@ -97,7 +97,7 @@ export class RoomJoinService {
       });
       await gameState.persistRoster(
         room.players,
-        room.hostId,
+        room.hostSeatId,
         this.buildMembershipClaim(user),
       );
       if (reclaimingVacantSeatId !== undefined) {
@@ -246,7 +246,7 @@ export class RoomJoinService {
       hasRequiredBroken: false,
       isReady:
         currentSeatRoomPlayer?.isReady ?? seatRoomSnapshot?.isReady ?? false,
-      isHost: room.hostId === assignedSeatId,
+      isHost: room.hostSeatId === assignedSeatId,
       isCOM: false,
       joinedAt: seatRoomSnapshot?.joinedAt
         ? new Date(seatRoomSnapshot.joinedAt)
@@ -285,7 +285,7 @@ export class RoomJoinService {
     });
     await gameState.persistRoster(
       room.players,
-      room.hostId,
+      room.hostSeatId,
       this.buildMembershipClaim(user),
     );
     const persistedState = gameState.getState();

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -47,14 +47,11 @@ export class RoomService implements IRoomService, OnModuleDestroy {
   private readonly roomJoinService: RoomJoinService;
 
   private normalizeRoomHostFlags(room: Room): Room {
-    const hostSeatId = room.hostSeatId ?? asSeatId(room.hostId);
     return {
       ...room,
-      hostSeatId,
-      hostId: hostSeatId,
       players: room.players.map((player) => ({
         ...player,
-        isHost: player.playerId === hostSeatId,
+        isHost: player.playerId === room.hostSeatId,
       })),
     };
   }
@@ -201,7 +198,6 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       id: randomUUID(),
       name,
       hostSeatId,
-      hostId: hostSeatId,
       status: RoomStatus.WAITING,
       players: [],
       settings: {
@@ -498,19 +494,19 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     }
 
     // If host left, assign new host
-    if (room.hostId === playerId) {
+    if (room.hostSeatId === playerId) {
       const newHost = room.players.find((p) => !p.isCOM);
       if (newHost) {
-        room.hostId = newHost.playerId;
+        room.hostSeatId = asSeatId(newHost.playerId);
       }
     }
 
     room.players.forEach((player) => {
-      player.isHost = player.playerId === room.hostId;
+      player.isHost = player.playerId === room.hostSeatId;
     });
     await gameState.persistRoster(
       room.players,
-      room.hostId,
+      room.hostSeatId,
       membershipMutation,
     );
     return true;
@@ -734,7 +730,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
 
       Object.assign(roomPlayer, updates);
       if (updates.isHost === true) {
-        room.hostId = playerId;
+        room.hostSeatId = asSeatId(playerId);
       }
 
       const statePlayerIndex = state.players.findIndex(
@@ -748,9 +744,9 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     }
 
     room.players.forEach((player) => {
-      player.isHost = player.playerId === room.hostId;
+      player.isHost = player.playerId === room.hostSeatId;
     });
-    await gameState.persistRoster(room.players, room.hostId);
+    await gameState.persistRoster(room.players, room.hostSeatId);
     return true;
   }
 

--- a/mei-tra-backend/src/services/seat-restoration.service.ts
+++ b/mei-tra-backend/src/services/seat-restoration.service.ts
@@ -91,7 +91,7 @@ export class SeatRestorationService {
       delete vacantSeats[roomId];
     }
 
-    await gameState.persistRoster(room.players, room.hostId);
+    await gameState.persistRoster(room.players, room.hostSeatId);
     const persistedState = gameState.getState();
     const advancedBlowTurn =
       this.advanceBlowTurnPastActedPlayer(persistedState);

--- a/mei-tra-backend/src/types/room-adapters.ts
+++ b/mei-tra-backend/src/types/room-adapters.ts
@@ -45,7 +45,7 @@ export function toRoomContract(
   return {
     id: room.id,
     name: room.name,
-    hostSeatId: room.hostSeatId ?? resolveSeatId({ playerId: room.hostId }),
+    hostSeatId: room.hostSeatId,
     status: room.status,
     players: room.players.map((roomPlayer) =>
       toRoomPlayerContract(

--- a/mei-tra-backend/src/types/room.types.ts
+++ b/mei-tra-backend/src/types/room.types.ts
@@ -23,9 +23,7 @@ export interface RoomPlayer extends SessionUser, PlayerGameplayState {
 export interface Room {
   id: string;
   name: string;
-  hostSeatId?: SeatId;
-  /** @deprecated Use hostSeatId. */
-  hostId: string;
+  hostSeatId: SeatId;
   status: RoomStatus;
   players: RoomPlayer[];
   settings: RoomSettings;

--- a/mei-tra-backend/src/use-cases/__tests__/blow-phase-transition.helper.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/blow-phase-transition.helper.spec.ts
@@ -68,7 +68,7 @@ describe('transitionToPlayPhase', () => {
     const room = {
       id: 'room-1',
       name: 'Room 1',
-      hostId: 'player-1',
+      hostSeatId: asSeatId('player-1'),
       status: RoomStatus.PLAYING,
       players: [
         {

--- a/mei-tra-backend/src/use-cases/__tests__/create-room-with-chat.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/create-room-with-chat.spec.ts
@@ -1,3 +1,4 @@
+import { asSeatId } from '../../types/identity.types';
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
 import { CreateRoomUseCase } from '../create-room.use-case';
@@ -31,7 +32,7 @@ describe('CreateRoomUseCase', () => {
   const createdRoom: Room = {
     id: roomId,
     name: 'Test Game Room',
-    hostId: userId,
+    hostSeatId: asSeatId(userId),
     status: RoomStatus.WAITING,
     settings: {
       maxPlayers: 4,

--- a/mei-tra-backend/src/use-cases/__tests__/game-event-instrumentation.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game-event-instrumentation.spec.ts
@@ -12,7 +12,7 @@ describe('Game event instrumentation', () => {
     const roomService = {
       getRoom: jest.fn().mockResolvedValue({
         id: 'room-1',
-        hostId: 'host-1',
+        hostSeatId: asSeatId('host-1'),
         settings: { pointsToWin: 7 },
         players: [
           {

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -158,7 +158,7 @@ describe('Game Use Cases', () => {
   const baseRoom: Room = {
     id: 'room-1',
     name: 'Room',
-    hostId: 'player-1',
+    hostSeatId: asSeatId('player-1'),
     status: RoomStatus.WAITING,
     players: basePlayers,
     settings: {
@@ -181,7 +181,7 @@ describe('Game Use Cases', () => {
 
       const room: Room = {
         ...baseRoom,
-        hostId: 'user-1',
+        hostSeatId: asSeatId('user-1'),
         players: [
           {
             ...basePlayers[0],
@@ -261,7 +261,7 @@ describe('Game Use Cases', () => {
       };
       const room: Room = {
         ...baseRoom,
-        hostId: 'seat-1',
+        hostSeatId: asSeatId('seat-1'),
         players: [joinedPlayer, basePlayers[1]],
       };
       roomService.joinRoom.mockResolvedValue(true);
@@ -515,7 +515,7 @@ describe('Game Use Cases', () => {
       const waitingRoom: Room = {
         ...baseRoom,
         status: RoomStatus.WAITING,
-        hostId: 'player-2',
+        hostSeatId: asSeatId('player-2'),
         players: [
           {
             socketId: 'com-0',
@@ -1056,7 +1056,7 @@ describe('Game Use Cases', () => {
       ]);
       expect(persistRosterMock).toHaveBeenCalledWith(
         expect.any(Array),
-        room.hostId,
+        room.hostSeatId,
       );
       expect(persistRosterMock.mock.invocationCallOrder[0]).toBeLessThan(
         startGameMock.mock.invocationCallOrder[0],
@@ -1144,7 +1144,7 @@ describe('Game Use Cases', () => {
       roomService.updateRoomStatus.mockResolvedValue(false);
 
       const result = await useCase.execute({
-        playerId: room.hostId,
+        playerId: room.hostSeatId,
         roomId: room.id,
       });
 

--- a/mei-tra-backend/src/use-cases/__tests__/moderate-player.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/moderate-player.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { asSeatId } from '../../types/identity.types';
 import { ModeratePlayerUseCase } from '../moderate-player.use-case';
 import { IRoomService } from '../../services/interfaces/room-service.interface';
 import { ILeaveRoomUseCase } from '../interfaces/leave-room.use-case.interface';
@@ -6,7 +7,7 @@ import { RoomStatus } from '../../types/room.types';
 describe('ModeratePlayerUseCase', () => {
   const createRoom = () => ({
     id: 'room-1',
-    hostId: 'host',
+    hostSeatId: asSeatId('host'),
     status: RoomStatus.PLAYING,
     players: [
       {

--- a/mei-tra-backend/src/use-cases/__tests__/shuffle-teams.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/shuffle-teams.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { asSeatId } from '../../types/identity.types';
 import { ShuffleTeamsUseCase } from '../shuffle-teams.use-case';
 import { IRoomService } from '../../services/interfaces/room-service.interface';
 import { IFillWithComUseCase } from '../interfaces/fill-with-com.use-case.interface';
@@ -7,7 +8,7 @@ describe('ShuffleTeamsUseCase', () => {
   it('fills empty seats and atomically persists shuffled seats and teams', async () => {
     const room = {
       id: 'room-1',
-      hostId: 'host',
+      hostSeatId: asSeatId('host'),
       status: RoomStatus.WAITING,
       players: [
         { playerId: 'host', team: 0 },
@@ -63,7 +64,7 @@ describe('ShuffleTeamsUseCase', () => {
   it('returns failure when empty seats cannot be filled', async () => {
     const room = {
       id: 'room-1',
-      hostId: 'host',
+      hostSeatId: asSeatId('host'),
       status: RoomStatus.WAITING,
       players: [{ playerId: 'host', team: 0 }],
       updatedAt: new Date(),
@@ -91,7 +92,7 @@ describe('ShuffleTeamsUseCase', () => {
   it('rejects shuffling after the game has started', async () => {
     const room = {
       id: 'room-1',
-      hostId: 'host',
+      hostSeatId: asSeatId('host'),
       status: RoomStatus.PLAYING,
       players: [
         { playerId: 'host', team: 0 },
@@ -126,7 +127,7 @@ describe('ShuffleTeamsUseCase', () => {
   it('returns failure when the atomic roster update fails', async () => {
     const room = {
       id: 'room-1',
-      hostId: 'host',
+      hostSeatId: asSeatId('host'),
       status: RoomStatus.WAITING,
       players: [
         { playerId: 'host', team: 0 },

--- a/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
@@ -113,7 +113,7 @@ describe('UpdateAuthUseCase', () => {
     const updatedRoom: Room = {
       id: 'room-1',
       name: 'Room',
-      hostId: 'player-1',
+      hostSeatId: asSeatId('player-1'),
       status: RoomStatus.WAITING,
       players: [
         {
@@ -208,7 +208,7 @@ describe('UpdateAuthUseCase', () => {
     expect(roomUpdatedEvent).toBeDefined();
     expect(roomUpdatedEvent?.payload).toMatchObject({
       id: updatedRoom.id,
-      hostSeatId: updatedRoom.hostId,
+      hostSeatId: updatedRoom.hostSeatId,
       name: updatedRoom.name,
       status: updatedRoom.status,
     });

--- a/mei-tra-backend/src/use-cases/__tests__/update-team-names.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/update-team-names.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { asSeatId } from '../../types/identity.types';
 import { UpdateTeamNamesUseCase } from '../update-team-names.use-case';
 import { IRoomService } from '../../services/interfaces/room-service.interface';
 import { RoomStatus } from '../../types/room.types';
@@ -5,7 +6,7 @@ import { RoomStatus } from '../../types/room.types';
 describe('UpdateTeamNamesUseCase', () => {
   const waitingRoom = {
     id: 'room-1',
-    hostId: 'host',
+    hostSeatId: asSeatId('host'),
     status: RoomStatus.WAITING,
     settings: {
       maxPlayers: 4,

--- a/mei-tra-backend/src/use-cases/__tests__/watch-room.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/watch-room.use-case.spec.ts
@@ -28,7 +28,7 @@ describe('WatchRoomUseCase', () => {
   const room = (overrides: Partial<Room> = {}): Room => ({
     id: 'room-1',
     name: 'Room 1',
-    hostId: 'p1',
+    hostSeatId: asSeatId('p1'),
     status: RoomStatus.PLAYING,
     players: [
       player('p1', 0, ['A♠', 'K♠']),

--- a/mei-tra-backend/src/use-cases/change-player-team.use-case.ts
+++ b/mei-tra-backend/src/use-cases/change-player-team.use-case.ts
@@ -34,7 +34,7 @@ export class ChangePlayerTeamUseCase implements IChangePlayerTeamUseCase {
       }
 
       // Verify that the requesting player is the host
-      if (room.hostId !== playerId) {
+      if (room.hostSeatId !== playerId) {
         return { success: false, error: 'Only the host can change teams' };
       }
 

--- a/mei-tra-backend/src/use-cases/fill-with-com.use-case.ts
+++ b/mei-tra-backend/src/use-cases/fill-with-com.use-case.ts
@@ -36,7 +36,7 @@ export class FillWithComUseCase implements IFillWithComUseCase {
       }
 
       // Verify that the requesting player is the host
-      if (room.hostId !== playerId) {
+      if (room.hostSeatId !== playerId) {
         return {
           success: false,
           error: 'Only the host can add COM players',

--- a/mei-tra-backend/src/use-cases/join-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/join-room.use-case.ts
@@ -84,7 +84,7 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
       };
       const data: JoinRoomSuccess = {
         room,
-        isHost: room.hostId === joinedPlayer.playerId,
+        isHost: room.hostSeatId === joinedPlayer.playerId,
         roomStatus: room.status,
         roomsList: await this.roomService.listRooms(),
         resumeGame: await this.buildResumePayloadIfNeeded(room.id, room),

--- a/mei-tra-backend/src/use-cases/moderate-player.use-case.ts
+++ b/mei-tra-backend/src/use-cases/moderate-player.use-case.ts
@@ -51,7 +51,7 @@ export class ModeratePlayerUseCase {
       return { success: false, error: 'Room not found' };
     }
 
-    if (room.hostId !== request.requesterPlayerId) {
+    if (room.hostSeatId !== request.requesterPlayerId) {
       return { success: false, error: 'Only the host can moderate players' };
     }
 

--- a/mei-tra-backend/src/use-cases/reconnection.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reconnection.use-case.ts
@@ -203,7 +203,7 @@ export class ReconnectionUseCase {
           selfSeatId: asSeatId(reconnectedPlayer.playerId),
           selfName: reconnectedPlayer.name,
           selfTeam: reconnectedPlayer.team,
-          isHost: reconnectedRoom.hostId === reconnectedPlayer.playerId,
+          isHost: reconnectedRoom.hostSeatId === reconnectedPlayer.playerId,
         };
       }
 
@@ -414,7 +414,7 @@ export class ReconnectionUseCase {
             : null,
         fields: (state.playState?.fields ?? []).map(toCompletedFieldContract),
         roomId,
-        hostSeatId: asSeatId(room.hostId),
+        hostSeatId: asSeatId(room.hostSeatId),
         pointsToWin: state.pointsToWin,
         teamNames: room.settings.teamNames,
       },

--- a/mei-tra-backend/src/use-cases/shuffle-teams.use-case.ts
+++ b/mei-tra-backend/src/use-cases/shuffle-teams.use-case.ts
@@ -28,7 +28,7 @@ export class ShuffleTeamsUseCase {
       };
     }
 
-    if (room.hostId !== request.playerId) {
+    if (room.hostSeatId !== request.playerId) {
       return { success: false, error: 'Only the host can shuffle teams' };
     }
 

--- a/mei-tra-backend/src/use-cases/start-game.use-case.ts
+++ b/mei-tra-backend/src/use-cases/start-game.use-case.ts
@@ -54,7 +54,7 @@ export class StartGameUseCase implements IStartGameUseCase {
       }
 
       // Authorization check: verify the requesting player is the host
-      if (room.hostId !== playerId) {
+      if (room.hostSeatId !== playerId) {
         return {
           success: false,
           errorMessage: 'Only the host can start the game',
@@ -94,7 +94,7 @@ export class StartGameUseCase implements IStartGameUseCase {
       this.syncStatePlayersFromRoom(roomGameState, roomWithFilledSeats);
       await roomGameState.persistRoster(
         roomWithFilledSeats.players,
-        roomWithFilledSeats.hostId,
+        roomWithFilledSeats.hostSeatId,
       );
 
       const statusUpdated = await this.roomService.updateRoomStatus(

--- a/mei-tra-backend/src/use-cases/update-team-names.use-case.ts
+++ b/mei-tra-backend/src/use-cases/update-team-names.use-case.ts
@@ -41,7 +41,7 @@ export class UpdateTeamNamesUseCase {
       };
     }
 
-    if (room.hostId !== request.playerId) {
+    if (room.hostSeatId !== request.playerId) {
       return { success: false, error: 'Only the host can change team names' };
     }
 

--- a/mei-tra-backend/src/use-cases/watch-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/watch-room.use-case.ts
@@ -104,7 +104,7 @@ export class WatchRoomUseCase implements IWatchRoomUseCase {
         : null,
       fields: (state.playState?.fields ?? []).map(toCompletedFieldContract),
       roomId: room.id,
-      hostSeatId: asSeatId(room.hostId),
+      hostSeatId: asSeatId(room.hostSeatId),
       pointsToWin: room.settings.pointsToWin,
       teamNames: room.settings.teamNames,
     };


### PR DESCRIPTION
## Summary
- `Room.hostId` を削除し、`hostSeatId` を必須のcanonical `SeatId`へ変更
- host判定・host移譲・roster保存・transport変換を `hostSeatId` に統一
- Supabase repositoryのlegacy fallback/dual updateを削除
- Room fixtureをbranded seat IDへ更新

## Why
host identityが文字列aliasと席UUIDへ二重化されていたため、host判定と更新経路を席UUIDの正本へ集約します。

## Validation
- `cd mei-tra-backend && npm test -- --runInBand` (63 suites / 397 tests)
- `cd mei-tra-backend && npm run lint`
- `cd mei-tra-backend && npm run build`
- `git diff --check`

## User-facing change
なし。部屋ホストの内部参照を席UUIDへ統一します。

## User benefit
ホスト移譲や再接続時のID取り違えを防ぎます。
