### PR TITLE
吹き状態のplayerId aliasを削除

### DIFF
--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -1703,8 +1703,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         client,
         actorId,
       );
-      const winningPlayerId =
-        state.blowState.currentHighestDeclaration?.playerId;
+      const winningPlayerId = state.blowState.currentHighestDeclaration?.seatId;
 
       if (
         state.gamePhase !== 'play' ||

--- a/mei-tra-backend/src/services/__tests__/com-strategy-inherited-declaration.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy-inherited-declaration.spec.ts
@@ -1,3 +1,4 @@
+import { asSeatId } from '../../types/identity.types';
 import { ComStrategyService } from '../com-strategy.service';
 import { IBlowService } from '../interfaces/blow-service.interface';
 import { ICardService } from '../interfaces/card-service.interface';
@@ -43,7 +44,7 @@ const comPlayer = (over: Partial<DomainPlayer> = {}): DomainPlayer =>
   }) as DomainPlayer;
 
 const declaration = (playerId: string): BlowDeclaration => ({
-  playerId,
+  seatId: asSeatId(playerId),
   trumpType: 'herz',
   numberOfPairs: 8,
   timestamp: 1,

--- a/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
@@ -138,7 +138,7 @@ describe('ComStrategyService', () => {
       players: [com, enemy, player('partner-0', 0), player('enemy-2', 1)],
       blowState: {
         currentHighestDeclaration: {
-          playerId: enemy.playerId,
+          seatId: asSeatId(enemy.playerId),
           trumpType: 'tra',
           numberOfPairs: 7,
           timestamp: Date.now(),
@@ -171,7 +171,7 @@ describe('ComStrategyService', () => {
       players: [com, player('e1', 1), partner, player('e2', 1)],
       blowState: {
         currentHighestDeclaration: {
-          playerId: partner.playerId,
+          seatId: asSeatId(partner.playerId),
           trumpType: 'club',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -194,7 +194,7 @@ describe('ComStrategyService', () => {
       players: [com, player('e1', 1), partner, player('e2', 1)],
       blowState: {
         currentHighestDeclaration: {
-          playerId: partner.playerId,
+          seatId: asSeatId(partner.playerId),
           trumpType: 'club',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -221,7 +221,7 @@ describe('ComStrategyService', () => {
       blowState: {
         currentTrump: 'herz',
         currentHighestDeclaration: {
-          playerId: com.playerId,
+          seatId: asSeatId(com.playerId),
           trumpType: 'herz',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -284,7 +284,7 @@ describe('ComStrategyService', () => {
     const partner = player('partner-0', 0);
     const gameState = leadState(com, 'herz', {
       currentHighestDeclaration: {
-        playerId: partner.playerId,
+        seatId: asSeatId(partner.playerId),
         trumpType: 'herz',
         numberOfPairs: 6,
         timestamp: Date.now(),
@@ -307,7 +307,7 @@ describe('ComStrategyService', () => {
       'herz',
       {
         currentHighestDeclaration: {
-          playerId: partner.playerId,
+          seatId: asSeatId(partner.playerId),
           trumpType: 'herz',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -335,7 +335,7 @@ describe('ComStrategyService', () => {
       'herz',
       {
         currentHighestDeclaration: {
-          playerId: partner.playerId,
+          seatId: asSeatId(partner.playerId),
           trumpType: 'herz',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -360,7 +360,7 @@ describe('ComStrategyService', () => {
       'herz',
       {
         currentHighestDeclaration: {
-          playerId: partner.playerId,
+          seatId: asSeatId(partner.playerId),
           trumpType: 'herz',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -388,7 +388,7 @@ describe('ComStrategyService', () => {
       'herz',
       {
         currentHighestDeclaration: {
-          playerId: partner.playerId,
+          seatId: asSeatId(partner.playerId),
           trumpType: 'herz',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -416,7 +416,7 @@ describe('ComStrategyService', () => {
       'herz',
       {
         currentHighestDeclaration: {
-          playerId: partner.playerId,
+          seatId: asSeatId(partner.playerId),
           trumpType: 'herz',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -441,7 +441,7 @@ describe('ComStrategyService', () => {
     const enemy = player('enemy-1', 1);
     const gameState = leadState(com, 'herz', {
       currentHighestDeclaration: {
-        playerId: enemy.playerId,
+        seatId: asSeatId(enemy.playerId),
         trumpType: 'herz',
         numberOfPairs: 6,
         timestamp: Date.now(),
@@ -461,7 +461,7 @@ describe('ComStrategyService', () => {
     const enemy = player('enemy-1', 1);
     const gameState = leadState(com, 'herz', {
       currentHighestDeclaration: {
-        playerId: enemy.playerId,
+        seatId: asSeatId(enemy.playerId),
         trumpType: 'herz',
         numberOfPairs: 6,
         timestamp: Date.now(),

--- a/mei-tra-backend/src/services/__tests__/disconnect-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/disconnect-gateway-effects.service.spec.ts
@@ -417,7 +417,7 @@ describe('DisconnectGatewayEffectsService', () => {
     const blowState = {
       currentTrump: null,
       currentHighestDeclaration: {
-        playerId: 'com-timeout',
+        seatId: asSeatId('com-timeout'),
         trumpType: 'herz',
         numberOfPairs: 7,
         timestamp: 1,

--- a/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
@@ -275,14 +275,14 @@ describe('JoinRoomGatewayEffectsService', () => {
             blowState: {
               currentTrump: null,
               currentHighestDeclaration: {
-                playerId: 'player-1',
+                seatId: asSeatId('player-1'),
                 trumpType: 'daiya',
                 numberOfPairs: 6,
                 timestamp: 1,
               },
               declarations: [
                 {
-                  playerId: 'player-1',
+                  seatId: asSeatId('player-1'),
                   trumpType: 'daiya',
                   numberOfPairs: 6,
                   timestamp: 1,
@@ -291,7 +291,7 @@ describe('JoinRoomGatewayEffectsService', () => {
               actionHistory: [
                 {
                   type: 'declare',
-                  playerId: 'player-1',
+                  seatId: asSeatId('player-1'),
                   trumpType: 'daiya',
                   numberOfPairs: 6,
                   timestamp: 1,

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -787,7 +787,7 @@ describe('Reconnection Token Management', () => {
           openDeclarerSeatId: asSeatId(playerId),
         };
         gameState.getState().pendingBrokenHandReveal = {
-          playerId,
+          seatId: asSeatId(playerId),
           handSnapshot: ['JOKER', '9♣'],
           startedAt: 100,
         };
@@ -816,7 +816,7 @@ describe('Reconnection Token Management', () => {
         expect(gameState.getState().playState?.openDeclarerSeatId).toBe(
           comPlayerId,
         );
-        expect(gameState.getState().pendingBrokenHandReveal?.playerId).toBe(
+        expect(gameState.getState().pendingBrokenHandReveal?.seatId).toBe(
           comPlayerId,
         );
         expect(gameState.getState().playState?.neguri[comPlayerId]).toBe('9♣');
@@ -863,14 +863,14 @@ describe('Reconnection Token Management', () => {
         gameState.getState().blowState = {
           currentTrump: null,
           currentHighestDeclaration: {
-            playerId,
+            seatId: asSeatId(playerId),
             trumpType: 'tra',
             numberOfPairs: 6,
             timestamp: 1,
           },
           declarations: [
             {
-              playerId,
+              seatId: asSeatId(playerId),
               trumpType: 'tra',
               numberOfPairs: 6,
               timestamp: 1,
@@ -879,14 +879,14 @@ describe('Reconnection Token Management', () => {
           actionHistory: [
             {
               type: 'declare',
-              playerId,
+              seatId: asSeatId(playerId),
               trumpType: 'tra',
               numberOfPairs: 6,
               timestamp: 1,
             },
             {
               type: 'pass',
-              playerId,
+              seatId: asSeatId(playerId),
               timestamp: 2,
             },
           ],
@@ -901,15 +901,15 @@ describe('Reconnection Token Management', () => {
         const comPlayerId = gameState.getState().players[0].playerId;
         expect(comPlayerId).toBe(playerId);
         expect(
-          gameState.getState().blowState.currentHighestDeclaration?.playerId,
+          gameState.getState().blowState.currentHighestDeclaration?.seatId,
         ).toBe(comPlayerId);
-        expect(gameState.getState().blowState.declarations[0]?.playerId).toBe(
+        expect(gameState.getState().blowState.declarations[0]?.seatId).toBe(
           comPlayerId,
         );
         expect(
           gameState
             .getState()
-            .blowState.actionHistory.map((action) => action.playerId),
+            .blowState.actionHistory.map((action) => action.seatId),
         ).toEqual([comPlayerId, comPlayerId]);
         expect(gameState.getState().blowState.lastPasserSeatId).toBe(
           comPlayerId,
@@ -1783,7 +1783,7 @@ describe('Reconnection Token Management', () => {
           openDeclarerSeatId: asSeatId(targetCom.playerId),
         };
         gameState.getState().pendingBrokenHandReveal = {
-          playerId: targetCom.playerId,
+          seatId: asSeatId(targetCom.playerId),
           handSnapshot: ['H2', 'D3'],
           startedAt: 100,
         };
@@ -1838,7 +1838,7 @@ describe('Reconnection Token Management', () => {
         expect(gameState.getState().playState?.openDeclarerSeatId).toBe(
           targetCom.playerId,
         );
-        expect(gameState.getState().pendingBrokenHandReveal?.playerId).toBe(
+        expect(gameState.getState().pendingBrokenHandReveal?.seatId).toBe(
           targetCom.playerId,
         );
         expect(gameState.getState().playState?.neguri[targetCom.playerId]).toBe(
@@ -1896,14 +1896,14 @@ describe('Reconnection Token Management', () => {
         gameState.getState().blowState = {
           currentTrump: null,
           currentHighestDeclaration: {
-            playerId: targetCom.playerId,
+            seatId: asSeatId(targetCom.playerId),
             trumpType: 'club',
             numberOfPairs: 6,
             timestamp: 1,
           },
           declarations: [
             {
-              playerId: targetCom.playerId,
+              seatId: asSeatId(targetCom.playerId),
               trumpType: 'club',
               numberOfPairs: 6,
               timestamp: 1,
@@ -1912,14 +1912,14 @@ describe('Reconnection Token Management', () => {
           actionHistory: [
             {
               type: 'declare',
-              playerId: targetCom.playerId,
+              seatId: asSeatId(targetCom.playerId),
               trumpType: 'club',
               numberOfPairs: 6,
               timestamp: 1,
             },
             {
               type: 'pass',
-              playerId: targetCom.playerId,
+              seatId: asSeatId(targetCom.playerId),
               timestamp: 2,
             },
           ],
@@ -1960,15 +1960,15 @@ describe('Reconnection Token Management', () => {
 
         expect(result).toBe(true);
         expect(
-          gameState.getState().blowState.currentHighestDeclaration?.playerId,
+          gameState.getState().blowState.currentHighestDeclaration?.seatId,
         ).toBe(targetCom.playerId);
-        expect(gameState.getState().blowState.declarations[0]?.playerId).toBe(
+        expect(gameState.getState().blowState.declarations[0]?.seatId).toBe(
           targetCom.playerId,
         );
         expect(
           gameState
             .getState()
-            .blowState.actionHistory.map((action) => action.playerId),
+            .blowState.actionHistory.map((action) => action.seatId),
         ).toEqual([targetCom.playerId, targetCom.playerId]);
         expect(gameState.getState().blowState.lastPasserSeatId).toBe(
           targetCom.playerId,
@@ -2054,14 +2054,14 @@ describe('Reconnection Token Management', () => {
         gameState.getState().blowState = {
           currentTrump: null,
           currentHighestDeclaration: {
-            playerId: replacingComId,
+            seatId: asSeatId(replacingComId),
             trumpType: 'daiya',
             numberOfPairs: 7,
             timestamp: 1,
           },
           declarations: [
             {
-              playerId: replacingComId,
+              seatId: asSeatId(replacingComId),
               trumpType: 'daiya',
               numberOfPairs: 7,
               timestamp: 1,
@@ -2070,7 +2070,7 @@ describe('Reconnection Token Management', () => {
           actionHistory: [
             {
               type: 'declare',
-              playerId: replacingComId,
+              seatId: asSeatId(replacingComId),
               trumpType: 'daiya',
               numberOfPairs: 7,
               timestamp: 1,
@@ -2086,9 +2086,9 @@ describe('Reconnection Token Management', () => {
         expect(result).toBe(true);
         expect(gameState.getState().players[0]?.playerId).toBe(replacingComId);
         expect(
-          gameState.getState().blowState.currentHighestDeclaration?.playerId,
+          gameState.getState().blowState.currentHighestDeclaration?.seatId,
         ).toBe(replacingComId);
-        expect(gameState.getState().blowState.declarations[0]?.playerId).toBe(
+        expect(gameState.getState().blowState.declarations[0]?.seatId).toBe(
           replacingComId,
         );
         expect(gameState.getState().currentSeatId).toBe(nextPlayerId);
@@ -2179,14 +2179,14 @@ describe('Reconnection Token Management', () => {
         gameState.getState().blowState = {
           currentTrump: null,
           currentHighestDeclaration: {
-            playerId: seatId,
+            seatId: asSeatId(seatId),
             trumpType: 'club',
             numberOfPairs: 7,
             timestamp: 1,
           },
           declarations: [
             {
-              playerId: seatId,
+              seatId: asSeatId(seatId),
               trumpType: 'club',
               numberOfPairs: 7,
               timestamp: 1,
@@ -2195,7 +2195,7 @@ describe('Reconnection Token Management', () => {
           actionHistory: [
             {
               type: 'declare',
-              playerId: seatId,
+              seatId: asSeatId(seatId),
               trumpType: 'club',
               numberOfPairs: 7,
               timestamp: 1,
@@ -2249,12 +2249,12 @@ describe('Reconnection Token Management', () => {
         expect(result).toBe(true);
         expect(gameState.getState().players[0]?.playerId).toBe(seatId);
         expect(
-          gameState.getState().blowState.currentHighestDeclaration?.playerId,
+          gameState.getState().blowState.currentHighestDeclaration?.seatId,
         ).toBe(seatId);
-        expect(gameState.getState().blowState.declarations[0]?.playerId).toBe(
+        expect(gameState.getState().blowState.declarations[0]?.seatId).toBe(
           seatId,
         );
-        expect(gameState.getState().blowState.actionHistory[0]?.playerId).toBe(
+        expect(gameState.getState().blowState.actionHistory[0]?.seatId).toBe(
           seatId,
         );
         expect(gameState.getState().currentSeatId).toBe(nextPlayerId);
@@ -2267,7 +2267,7 @@ describe('Reconnection Token Management', () => {
         expect(
           gameStateRepository.update.mock.calls.some(
             ([, update]) =>
-              update.blowState?.currentHighestDeclaration?.playerId === seatId,
+              update.blowState?.currentHighestDeclaration?.seatId === seatId,
           ),
         ).toBe(true);
       });

--- a/mei-tra-backend/src/services/blow.service.ts
+++ b/mei-tra-backend/src/services/blow.service.ts
@@ -68,7 +68,6 @@ export class BlowService implements IBlowService {
   ): BlowDeclaration {
     return {
       seatId: asSeatId(playerId),
-      playerId,
       team,
       trumpType,
       numberOfPairs,

--- a/mei-tra-backend/src/services/com-strategy.service.ts
+++ b/mei-tra-backend/src/services/com-strategy.service.ts
@@ -90,7 +90,7 @@ export class ComStrategyService implements IComStrategyService {
 
     const currentHighest = state.blowState.currentHighestDeclaration;
     const currentHighestPlayer = currentHighest
-      ? this.findPlayer(state, currentHighest.playerId)
+      ? this.findPlayer(state, currentHighest.seatId)
       : null;
     // Never treat one's own bid as a partner's — an inherited declaration would
     // otherwise make the COM defer to itself and pass.
@@ -370,8 +370,8 @@ export class ComStrategyService implements IComStrategyService {
   ): string | null {
     if (
       declaration == null ||
-      declaration.playerId === comPlayer.playerId ||
-      this.findPlayer(state, declaration.playerId)?.team !== comPlayer.team
+      declaration.seatId === comPlayer.playerId ||
+      this.findPlayer(state, declaration.seatId)?.team !== comPlayer.team
     ) {
       return null;
     }
@@ -772,7 +772,7 @@ export class ComStrategyService implements IComStrategyService {
     if (!declaration) {
       return null;
     }
-    return this.findPlayer(state, declaration.playerId)?.team ?? null;
+    return this.findPlayer(state, declaration.seatId)?.team ?? null;
   }
 
   private countCompletedFieldsByTeam(state: GameState, team: Team): number {

--- a/mei-tra-backend/src/services/room-join.service.ts
+++ b/mei-tra-backend/src/services/room-join.service.ts
@@ -367,10 +367,10 @@ export class RoomJoinService {
     return (
       player.isPasser ||
       blowState.declarations.some(
-        (declaration) => declaration.playerId === player.playerId,
+        (declaration) => declaration.seatId === player.playerId,
       ) ||
       (blowState.actionHistory ?? []).some(
-        (action) => action.playerId === player.playerId,
+        (action) => action.seatId === player.playerId,
       )
     );
   }

--- a/mei-tra-backend/src/services/seat-restoration.service.ts
+++ b/mei-tra-backend/src/services/seat-restoration.service.ts
@@ -131,10 +131,10 @@ export class SeatRestorationService {
     return (
       player.isPasser ||
       blowState.declarations.some(
-        (declaration) => declaration.playerId === player.playerId,
+        (declaration) => declaration.seatId === player.playerId,
       ) ||
       (blowState.actionHistory ?? []).some(
-        (action) => action.playerId === player.playerId,
+        (action) => action.seatId === player.playerId,
       )
     );
   }

--- a/mei-tra-backend/src/types/game-contract-adapters.ts
+++ b/mei-tra-backend/src/types/game-contract-adapters.ts
@@ -19,7 +19,7 @@ export function toBlowDeclarationContract(
   declaration: BlowDeclaration,
 ): BlowDeclarationContract {
   return {
-    seatId: declaration.seatId ?? asSeatId(declaration.playerId),
+    seatId: declaration.seatId ?? asSeatId(declaration.seatId),
     team: declaration.team,
     trumpType: declaration.trumpType,
     numberOfPairs: declaration.numberOfPairs,
@@ -30,7 +30,7 @@ export function toBlowDeclarationContract(
 export function toBlowActionContract(action: BlowAction): BlowActionContract {
   return {
     type: action.type,
-    seatId: action.seatId ?? asSeatId(action.playerId),
+    seatId: action.seatId ?? asSeatId(action.seatId),
     trumpType: action.trumpType,
     numberOfPairs: action.numberOfPairs,
     timestamp: action.timestamp,

--- a/mei-tra-backend/src/types/game-state-identity.ts
+++ b/mei-tra-backend/src/types/game-state-identity.ts
@@ -29,17 +29,17 @@ export function normalizeGameStateIdentityAliases(state: GameState): GameState {
   const blowState = {
     ...state.blowState,
     declarations: state.blowState.declarations.map((declaration) => {
-      const seatId = declaration.seatId ?? asSeatId(declaration.playerId);
+      const seatId = declaration.seatId ?? asSeatId(declaration.seatId);
       return { ...declaration, seatId, playerId: seatId };
     }),
     actionHistory: state.blowState.actionHistory.map((action) => {
-      const seatId = action.seatId ?? asSeatId(action.playerId);
+      const seatId = action.seatId ?? asSeatId(action.seatId);
       return { ...action, seatId, playerId: seatId };
     }),
     currentHighestDeclaration: state.blowState.currentHighestDeclaration
       ? (() => {
           const declaration = state.blowState.currentHighestDeclaration;
-          const seatId = declaration.seatId ?? asSeatId(declaration.playerId);
+          const seatId = declaration.seatId ?? asSeatId(declaration.seatId);
           return { ...declaration, seatId, playerId: seatId };
         })()
       : null,
@@ -82,7 +82,7 @@ export function normalizeGameStateIdentityAliases(state: GameState): GameState {
     ? (() => {
         const seatId =
           state.pendingBrokenHandReveal.seatId ??
-          asSeatId(state.pendingBrokenHandReveal.playerId);
+          asSeatId(state.pendingBrokenHandReveal.seatId);
         return {
           ...state.pendingBrokenHandReveal,
           seatId,

--- a/mei-tra-backend/src/types/game-state-persistence.spec.ts
+++ b/mei-tra-backend/src/types/game-state-persistence.spec.ts
@@ -15,7 +15,6 @@ describe('game-state persistence identity', () => {
       currentTrump: 'herz',
       currentHighestDeclaration: {
         seatId: firstSeatId,
-        playerId: firstSeatId,
         trumpType: 'herz',
         numberOfPairs: 6,
         timestamp: 1,
@@ -23,7 +22,6 @@ describe('game-state persistence identity', () => {
       declarations: [
         {
           seatId: firstSeatId,
-          playerId: firstSeatId,
           trumpType: 'herz',
           numberOfPairs: 6,
           timestamp: 1,
@@ -33,7 +31,6 @@ describe('game-state persistence identity', () => {
         {
           type: 'pass',
           seatId: secondSeatId,
-          playerId: secondSeatId,
           timestamp: 2,
         },
       ],
@@ -75,7 +72,6 @@ describe('game-state persistence identity', () => {
     });
     const persistedReveal = toPersistedPendingBrokenHandReveal({
       seatId: firstSeatId,
-      playerId: firstSeatId,
       handSnapshot: ['H7'],
       startedAt: 3,
     });

--- a/mei-tra-backend/src/types/game-state-persistence.ts
+++ b/mei-tra-backend/src/types/game-state-persistence.ts
@@ -99,14 +99,14 @@ function toPersistedBlowDeclaration(
 ): PersistedBlowDeclaration {
   return {
     ...omitKeys(declaration, ['playerId', 'seatId']),
-    seatId: declaration.seatId ?? asSeatId(declaration.playerId),
+    seatId: declaration.seatId ?? asSeatId(declaration.seatId),
   } as PersistedBlowDeclaration;
 }
 
 function toPersistedBlowAction(action: BlowAction): PersistedBlowAction {
   return {
     ...omitKeys(action, ['playerId', 'seatId']),
-    seatId: action.seatId ?? asSeatId(action.playerId),
+    seatId: action.seatId ?? asSeatId(action.seatId),
   } as PersistedBlowAction;
 }
 
@@ -182,7 +182,7 @@ export function toPersistedPendingBrokenHandReveal(
 
   return {
     ...omitKeys(pendingReveal, ['playerId', 'seatId']),
-    seatId: pendingReveal.seatId ?? asSeatId(pendingReveal.playerId),
+    seatId: pendingReveal.seatId ?? asSeatId(pendingReveal.seatId),
   } as PersistedPendingBrokenHandReveal;
 }
 

--- a/mei-tra-backend/src/types/game.types.ts
+++ b/mei-tra-backend/src/types/game.types.ts
@@ -40,9 +40,7 @@ export interface TeamScores {
 export type TrumpType = 'tra' | 'herz' | 'daiya' | 'club' | 'zuppe';
 
 export interface BlowDeclaration {
-  seatId?: SeatId;
-  /** @deprecated Use seatId. */
-  playerId: string;
+  seatId: SeatId;
   team?: Team;
   trumpType: TrumpType;
   numberOfPairs: number;
@@ -51,9 +49,7 @@ export interface BlowDeclaration {
 
 export interface BlowAction {
   type: 'declare' | 'pass';
-  seatId?: SeatId;
-  /** @deprecated Use seatId. */
-  playerId: string;
+  seatId: SeatId;
   trumpType?: TrumpType;
   numberOfPairs?: number;
   timestamp: number;
@@ -99,9 +95,7 @@ export interface PlayState {
 }
 
 export interface PendingBrokenHandReveal {
-  seatId?: SeatId;
-  /** @deprecated Use seatId. */
-  playerId: string;
+  seatId: SeatId;
   handSnapshot: string[];
   startedAt: number;
 }

--- a/mei-tra-backend/src/use-cases/__tests__/blow-phase-transition.helper.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/blow-phase-transition.helper.spec.ts
@@ -9,7 +9,7 @@ import { asSeatId } from '../../types/identity.types';
 describe('transitionToPlayPhase', () => {
   it('reveals the Agari card using room player socket when session lookup is empty', async () => {
     const declaration = {
-      playerId: 'player-1',
+      seatId: asSeatId('player-1'),
       trumpType: 'club' as const,
       numberOfPairs: 6,
       timestamp: 1,
@@ -156,7 +156,7 @@ describe('transitionToPlayPhase', () => {
 
   it('does not request broken reveal after the Agari card is added', async () => {
     const declaration = {
-      playerId: 'player-1',
+      seatId: asSeatId('player-1'),
       trumpType: 'club' as const,
       numberOfPairs: 6,
       timestamp: 1,

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -1564,7 +1564,7 @@ describe('Game Use Cases', () => {
           actionHistory: [
             {
               type: 'pass' as const,
-              playerId: 'player-1',
+              seatId: asSeatId('player-1'),
               timestamp: 1,
             },
           ],
@@ -2292,7 +2292,7 @@ describe('Game Use Cases', () => {
         blowState: {
           currentTrump: 'herz' as const,
           currentHighestDeclaration: {
-            playerId: 'com-timeout-1',
+            seatId: asSeatId('com-timeout-1'),
             trumpType: 'herz' as const,
             numberOfPairs: 6,
             timestamp: Date.now(),
@@ -2562,7 +2562,7 @@ describe('Game Use Cases', () => {
       const roomService = createRoomServiceMock();
       const blowService = {
         findHighestDeclaration: jest.fn(() => ({
-          playerId: 'com-timeout-1',
+          seatId: asSeatId('com-timeout-1'),
           trumpType: 'herz',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -2596,7 +2596,7 @@ describe('Game Use Cases', () => {
         blowState: {
           declarations: [
             {
-              playerId: 'com-timeout-1',
+              seatId: asSeatId('com-timeout-1'),
               trumpType: 'herz' as const,
               numberOfPairs: 6,
               timestamp: Date.now(),
@@ -2740,8 +2740,7 @@ describe('Game Use Cases', () => {
         gamePhase: 'play' | 'blow';
         deck: string[];
         pendingBrokenHandReveal?: {
-          seatId?: ReturnType<typeof asSeatId>;
-          playerId: string;
+          seatId: ReturnType<typeof asSeatId>;
           handSnapshot: string[];
           startedAt: number;
         } | null;
@@ -2814,7 +2813,6 @@ describe('Game Use Cases', () => {
       expect(preparation.followUp).toBeDefined();
       expect(state.pendingBrokenHandReveal).toEqual({
         seatId: 'player-1',
-        playerId: 'player-1',
         handSnapshot: ['C1'],
         startedAt: expect.any(Number),
       });
@@ -2907,7 +2905,7 @@ describe('Game Use Cases', () => {
         blowState: {
           declarations: [
             {
-              playerId: 'player-1',
+              seatId: asSeatId('player-1'),
               trumpType: 'club' as const,
               numberOfPairs: 6,
               timestamp: 1,
@@ -2993,8 +2991,7 @@ describe('Game Use Cases', () => {
         gamePhase: 'play' | 'blow';
         deck: string[];
         pendingBrokenHandReveal?: {
-          seatId?: ReturnType<typeof asSeatId>;
-          playerId: string;
+          seatId: ReturnType<typeof asSeatId>;
           handSnapshot: string[];
           startedAt: number;
         } | null;
@@ -3036,7 +3033,7 @@ describe('Game Use Cases', () => {
           currentTrump: 'club',
           declarations: [
             {
-              playerId: 'player-1',
+              seatId: asSeatId('player-1'),
               trumpType: 'club',
               numberOfPairs: 6,
               timestamp: 1,
@@ -3045,19 +3042,19 @@ describe('Game Use Cases', () => {
           actionHistory: [
             {
               type: 'declare',
-              playerId: 'player-1',
+              seatId: asSeatId('player-1'),
               trumpType: 'club',
               numberOfPairs: 6,
               timestamp: 1,
             },
             {
               type: 'pass',
-              playerId: 'player-2',
+              seatId: asSeatId('player-2'),
               timestamp: 2,
             },
           ],
           currentHighestDeclaration: {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             trumpType: 'club',
             numberOfPairs: 6,
             timestamp: 1,
@@ -3070,7 +3067,7 @@ describe('Game Use Cases', () => {
         gamePhase: 'blow',
         deck: [],
         pendingBrokenHandReveal: {
-          playerId: 'player-3',
+          seatId: asSeatId('player-3'),
           handSnapshot: ['H1'],
           startedAt: 1,
         },
@@ -3145,7 +3142,7 @@ describe('Game Use Cases', () => {
         blowState: Pick<BlowState, 'declarations'>;
         gamePhase: GamePhase;
         pendingBrokenHandReveal?: {
-          playerId: string;
+          seatId: ReturnType<typeof asSeatId>;
           handSnapshot: string[];
           startedAt: number;
         } | null;
@@ -3163,7 +3160,7 @@ describe('Game Use Cases', () => {
         blowState: { declarations: [] },
         gamePhase: 'blow',
         pendingBrokenHandReveal: {
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           handSnapshot: ['old-card'],
           startedAt: Date.now() - BROKEN_HAND_REVEAL_PENDING_TTL_MS - 1,
         },
@@ -3186,7 +3183,6 @@ describe('Game Use Cases', () => {
       expect(preparation.success).toBe(true);
       expect(state.pendingBrokenHandReveal).toEqual({
         seatId: 'player-1',
-        playerId: 'player-1',
         handSnapshot: ['C1'],
         startedAt: expect.any(Number),
       });
@@ -3212,7 +3208,7 @@ describe('Game Use Cases', () => {
         gamePhase: 'play' | 'blow';
         deck: string[];
         pendingBrokenHandReveal?: {
-          playerId: string;
+          seatId: ReturnType<typeof asSeatId>;
           handSnapshot: string[];
           startedAt: number;
         } | null;
@@ -3240,7 +3236,7 @@ describe('Game Use Cases', () => {
         gamePhase: 'play',
         deck: [],
         pendingBrokenHandReveal: {
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           handSnapshot: ['old-card'],
           startedAt: 1,
         },
@@ -3282,7 +3278,7 @@ describe('Game Use Cases', () => {
         gamePhase: 'play' | 'blow';
         deck: string[];
         pendingBrokenHandReveal?: {
-          playerId: string;
+          seatId: ReturnType<typeof asSeatId>;
           handSnapshot: string[];
           startedAt: number;
         } | null;

--- a/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
@@ -384,7 +384,7 @@ describe('ReconnectionUseCase', () => {
           actionHistory: [],
           currentTrump: null,
           currentHighestDeclaration: {
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             trumpType: 'zuppe',
             numberOfPairs: 7,
             timestamp: 1,

--- a/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
+++ b/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
@@ -40,7 +40,7 @@ export async function transitionToPlayPhase({
     state.blowState.declarations,
   );
   const winningPlayer = state.players.find(
-    (p) => p.playerId === highestDeclaration.playerId,
+    (p) => p.playerId === highestDeclaration.seatId,
   );
 
   if (!winningPlayer) {

--- a/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
+++ b/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
@@ -167,7 +167,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
 
     if (
       state.playState?.negriCard == null &&
-      state.blowState.currentHighestDeclaration?.playerId === comPlayer.playerId
+      state.blowState.currentHighestDeclaration?.seatId === comPlayer.playerId
     ) {
       const negriCard = this.comStrategyService.chooseNegriCard(
         state,

--- a/mei-tra-backend/src/use-cases/complete-field.use-case.ts
+++ b/mei-tra-backend/src/use-cases/complete-field.use-case.ts
@@ -153,8 +153,8 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
       await this.gameEventLogService?.log({
         roomId,
         actionType: 'round_completed',
-        actorSeatId: state.blowState.currentHighestDeclaration?.playerId
-          ? asSeatId(state.blowState.currentHighestDeclaration.playerId)
+        actorSeatId: state.blowState.currentHighestDeclaration?.seatId
+          ? asSeatId(state.blowState.currentHighestDeclaration.seatId)
           : null,
         state,
         actionData: {
@@ -305,14 +305,14 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
     }
 
     const player = state.players.find(
-      (p) => p.playerId === highestDeclaration.playerId,
+      (p) => p.playerId === highestDeclaration.seatId,
     );
     if (player) {
       return player.team;
     }
 
     if (state.teamAssignments) {
-      const team = state.teamAssignments[highestDeclaration.playerId];
+      const team = state.teamAssignments[highestDeclaration.seatId];
       if (typeof team === 'number') {
         return team;
       }

--- a/mei-tra-backend/src/use-cases/declare-blow.use-case.ts
+++ b/mei-tra-backend/src/use-cases/declare-blow.use-case.ts
@@ -109,7 +109,6 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
       state.blowState.actionHistory.push({
         type: 'declare',
         seatId: asSeatId(player.playerId),
-        playerId: player.playerId,
         trumpType: declaration.trumpType,
         numberOfPairs: declaration.numberOfPairs,
         timestamp: newDeclaration.timestamp,

--- a/mei-tra-backend/src/use-cases/helpers/blow-action.helper.ts
+++ b/mei-tra-backend/src/use-cases/helpers/blow-action.helper.ts
@@ -6,10 +6,10 @@ export function hasPlayerDeclaredInBlow(
 ): boolean {
   return (
     blowState.declarations.some(
-      (declaration) => declaration.playerId === playerId,
+      (declaration) => declaration.seatId === playerId,
     ) ||
     (blowState.actionHistory ?? []).some(
-      (action) => action.playerId === playerId && action.type === 'declare',
+      (action) => action.seatId === playerId && action.type === 'declare',
     )
   );
 }
@@ -21,7 +21,7 @@ export function hasPlayerPassedInBlow(
   return (
     player.isPasser ||
     (blowState.actionHistory ?? []).some(
-      (action) => action.playerId === player.playerId && action.type === 'pass',
+      (action) => action.seatId === player.playerId && action.type === 'pass',
     )
   );
 }

--- a/mei-tra-backend/src/use-cases/pass-blow.use-case.ts
+++ b/mei-tra-backend/src/use-cases/pass-blow.use-case.ts
@@ -101,7 +101,6 @@ export class PassBlowUseCase implements IPassBlowUseCase {
       state.blowState.actionHistory.push({
         type: 'pass',
         seatId: asSeatId(player.playerId),
-        playerId: player.playerId,
         timestamp: Date.now(),
       });
       state.blowState.lastPasserSeatId = asSeatId(player.playerId);

--- a/mei-tra-backend/src/use-cases/reconnection.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reconnection.use-case.ts
@@ -408,8 +408,7 @@ export class ReconnectionUseCase {
         revealedAgari:
           state.gamePhase === 'play' &&
           !state.playState?.negriCard &&
-          state.blowState.currentHighestDeclaration?.playerId ===
-            player.playerId
+          state.blowState.currentHighestDeclaration?.seatId === player.playerId
             ? (state.agari ?? null)
             : null,
         fields: (state.playState?.fields ?? []).map(toCompletedFieldContract),

--- a/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
@@ -52,7 +52,7 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
       }
 
       const hasDeclared = state.blowState.declarations.some(
-        (declaration) => declaration.playerId === playerId,
+        (declaration) => declaration.seatId === playerId,
       );
       if (player.isPasser || hasDeclared) {
         return { success: false, error: 'Cannot reveal broken hand now' };
@@ -70,7 +70,6 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
       const handSnapshot = [...player.hand];
       state.pendingBrokenHandReveal = {
         seatId: asSeatId(playerId),
-        playerId,
         handSnapshot,
         startedAt: Date.now(),
       };
@@ -111,7 +110,7 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
       }
 
       const pendingReveal = state.pendingBrokenHandReveal;
-      if (!pendingReveal || pendingReveal.playerId !== playerId) {
+      if (!pendingReveal || pendingReveal.seatId !== playerId) {
         return { success: false, error: 'Broken hand reveal is not pending' };
       }
 

--- a/mei-tra-backend/src/use-cases/select-negri.use-case.ts
+++ b/mei-tra-backend/src/use-cases/select-negri.use-case.ts
@@ -77,7 +77,7 @@ export class SelectNegriUseCase implements ISelectNegriUseCase {
       }
 
       const winnerIndex = state.players.findIndex(
-        (p) => p.playerId === winner.playerId,
+        (p) => p.playerId === winner.seatId,
       );
       if (winnerIndex === -1) {
         return {
@@ -86,7 +86,7 @@ export class SelectNegriUseCase implements ISelectNegriUseCase {
         };
       }
 
-      setCurrentSeat(state, winner.playerId);
+      setCurrentSeat(state, winner.seatId);
       const room = await this.roomService.getRoom(roomId);
 
       const events: GatewayEvent[] = [


### PR DESCRIPTION
## Summary
- BlowDeclaration / BlowAction / PendingBrokenHandReveal の `playerId` aliasを削除
- 吹き勝者・action history・broken hand pendingを必須 `seatId` へ統一
- 永続化・transport変換・再接続・COM戦略をcanonical seat参照へ更新
- 型を迂回するmockも新shapeへ更新

## Why
吹き状態内に同じ席を示す `seatId` と `playerId` が重複し、再接続やCOM置換時の参照ずれを生む余地がありました。

## Validation
- `cd mei-tra-backend && npm test -- --runInBand` (63 suites / 397 tests)
- `cd mei-tra-backend && npm run lint`
- `cd mei-tra-backend && npm run build`
- `git diff --check`

## User-facing change
なし。吹きフェーズとbroken handの内部参照を席UUIDへ統一します。

## User benefit
吹き勝者・ネグリ・再接続処理の参照ずれを防ぎます。
