### PR TITLE
バックエンドのplayerId aliasを削除

### DIFF
--- a/mei-tra-backend/src/__tests__/game.gateway.com-recovery.spec.ts
+++ b/mei-tra-backend/src/__tests__/game.gateway.com-recovery.spec.ts
@@ -1,5 +1,6 @@
 import { Socket } from 'socket.io';
 import { GameGateway } from '../game.gateway';
+import { asSeatId } from '../types/identity.types';
 
 const createGateway = (): GameGateway => {
   const GatewayConstructor = GameGateway as unknown as new (
@@ -349,7 +350,7 @@ describe('GameGateway COM recovery integration', () => {
       getRoom: jest.fn().mockResolvedValue({
         players: [
           {
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             userId: 'user-1',
             isCOM: false,
           },

--- a/mei-tra-backend/src/controllers/game-history.controller.spec.ts
+++ b/mei-tra-backend/src/controllers/game-history.controller.spec.ts
@@ -36,7 +36,7 @@ describe('GameHistoryController', () => {
     players: [
       {
         socketId: 'socket-1',
-        playerId: 'player-1',
+        seatId: asSeatId('player-1'),
         userId: 'user-1',
         isAuthenticated: true,
         name: 'Player 1',
@@ -489,7 +489,7 @@ describe('GameHistoryController', () => {
         room.players[0],
         {
           ...room.players[0],
-          playerId: 'player-duplicate',
+          seatId: asSeatId('player-duplicate'),
           socketId: 'socket-duplicate',
           isHost: false,
         },

--- a/mei-tra-backend/src/game.gateway.ts
+++ b/mei-tra-backend/src/game.gateway.ts
@@ -194,7 +194,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       );
     }
 
-    return roomPlayers[0].playerId;
+    return roomPlayers[0].seatId;
   }
 
   private async rejectInactiveMutatingAction(
@@ -334,7 +334,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const roomGameState = await this.roomService.getRoomGameState(roomId);
     const room = await this.roomService.getRoom(roomId);
     const targetPlayer = room?.players.find(
-      (player) => player.playerId === playerId,
+      (player) => player.seatId === playerId,
     );
     const targetSocketId =
       roomGameState.getPlayerConnectionState(playerId)?.socketId;
@@ -593,7 +593,6 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
             room: result.room,
             selfPlayer: {
               seatId: result.selfSeatId,
-              playerId: result.selfSeatId,
               name: result.selfName,
               team: result.selfTeam,
             },
@@ -790,8 +789,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
           clientId: client.id,
           room: updatedRoom,
           selfPlayer: {
-            seatId: asSeatId(hostPlayer.playerId),
-            playerId: hostPlayer.playerId,
+            seatId: asSeatId(hostPlayer.seatId),
             name: hostPlayer.name,
             team: hostPlayer.team,
           },

--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.spec.ts
@@ -72,8 +72,7 @@ describe('SupabaseGameStateRepository', () => {
       version: 4,
       players: [
         {
-          seatId: firstSeatId,
-          playerId: firstSeatId,
+          seatId: asSeatId(firstSeatId),
           name: 'Current name',
           hand: ['S1'],
           team: 1,
@@ -109,8 +108,7 @@ describe('SupabaseGameStateRepository', () => {
   function createRoomPlayer(): RoomPlayer {
     return {
       socketId: 'transient-socket',
-      seatId: firstSeatId,
-      playerId: firstSeatId,
+      seatId: asSeatId(firstSeatId),
       participantKey: roomPlayerRow.user_id,
       userId: roomPlayerRow.user_id,
       isAuthenticated: true,
@@ -144,8 +142,7 @@ describe('SupabaseGameStateRepository', () => {
     expect(state?.version).toBe(4);
     expect(state?.players).toEqual([
       expect.objectContaining({
-        playerId: firstSeatId,
-        seatId: firstSeatId,
+        seatId: asSeatId(firstSeatId),
         name: 'Current name',
         team: 1,
         hand: ['S1'],
@@ -185,7 +182,7 @@ describe('SupabaseGameStateRepository', () => {
 
     const state = await repository.findByRoomId(gameStateRow.room_id);
 
-    expect(state?.players.map((player) => player.playerId)).toEqual([
+    expect(state?.players.map((player) => player.seatId)).toEqual([
       firstSeatId,
       secondSeatId,
     ]);

--- a/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-game-state.repository.ts
@@ -458,7 +458,6 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
 
         return toRuntimePlayer({
           seatId: asSeatId(seatId),
-          playerId: seatId,
           name: roomPlayer?.name,
           team: roomPlayer?.team as 0 | 1 | undefined,
           isCOM: roomPlayer?.isCOM,
@@ -472,7 +471,7 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
     const canonicalCurrentPlayerId = dbGameState.current_seat_id;
     if (
       canonicalCurrentPlayerId &&
-      !players.some((player) => player.playerId === canonicalCurrentPlayerId)
+      !players.some((player) => player.seatId === canonicalCurrentPlayerId)
     ) {
       throw new Error(
         `Current seat ${canonicalCurrentPlayerId} is outside room ${dbGameState.room_id}`,
@@ -511,7 +510,7 @@ export class SupabaseGameStateRepository implements IGameStateRepository {
       roundNumber: dbGameState.round_number,
       pointsToWin: dbGameState.points_to_win,
       teamAssignments: Object.fromEntries(
-        players.map((player) => [player.playerId, player.team]),
+        players.map((player) => [player.seatId, player.team]),
       ),
     });
   }

--- a/mei-tra-backend/src/repositories/implementations/supabase-room.repository.spec.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-room.repository.spec.ts
@@ -127,10 +127,10 @@ describe('SupabaseRoomRepository', () => {
     });
     expect(rooms).toHaveLength(2);
     expect(rooms[0].id).toBe('room-2');
-    expect(rooms[0].players.map((player) => player.playerId)).toEqual([
+    expect(rooms[0].players.map((player) => player.seatId)).toEqual([
       'room-2-player-3',
     ]);
-    expect(rooms[1].players.map((player) => player.playerId)).toEqual([
+    expect(rooms[1].players.map((player) => player.seatId)).toEqual([
       'room-1-player-1',
       'room-1-player-2',
     ]);

--- a/mei-tra-backend/src/repositories/implementations/supabase-room.repository.ts
+++ b/mei-tra-backend/src/repositories/implementations/supabase-room.repository.ts
@@ -295,13 +295,13 @@ export class SupabaseRoomRepository implements IRoomRepository {
   }
 
   private mapDatabaseToRoom(dbRoom: RoomRow, players: RoomPlayer[]): Room {
-    const hostSeatId = dbRoom.host_seat_id ?? players[0]?.playerId;
+    const hostSeatId = dbRoom.host_seat_id ?? players[0]?.seatId;
     if (!hostSeatId) {
       throw new Error(`Room ${dbRoom.id} has no canonical host seat`);
     }
     const canonicalPlayers = players.map((player) => ({
       ...player,
-      isHost: player.playerId === hostSeatId,
+      isHost: player.seatId === hostSeatId,
     }));
     return {
       id: dbRoom.id,
@@ -364,8 +364,7 @@ export class SupabaseRoomRepository implements IRoomRepository {
     const seatId = asSeatId(dbPlayer.id);
     return {
       socketId: '',
-      seatId,
-      playerId: seatId,
+      seatId: asSeatId(seatId),
       participantKey: dbPlayer.user_id ?? dbPlayer.id,
       userId: dbPlayer.user_id ?? undefined,
       isAuthenticated: Boolean(dbPlayer.user_id),

--- a/mei-tra-backend/src/services/__tests__/com-session.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-session.service.spec.ts
@@ -13,7 +13,7 @@ const createGameStateStub = () => {
   const makeState = () => ({
     players: [
       {
-        playerId: HUMAN_ID,
+        seatId: asSeatId(HUMAN_ID),
         name: 'Human',
         team: 0 as const,
         hand: ['A♠'],
@@ -60,7 +60,7 @@ const createRoom = (): Room =>
     hostId: HUMAN_ID,
     players: [
       {
-        playerId: HUMAN_ID,
+        seatId: asSeatId(HUMAN_ID),
         name: 'Human',
         team: 0,
         hand: ['A♠'],
@@ -94,7 +94,7 @@ describe('ComSessionService.convertPlayerToCOM', () => {
     expect(converted).toBe(true);
 
     const state = gameState.getState();
-    const comId = state.players[0].playerId;
+    const comId = state.players[0].seatId;
     expect(comId).toBe(HUMAN_ID);
 
     expect(state.playState!.currentField!.playedBy).toEqual([comId]);
@@ -102,7 +102,7 @@ describe('ComSessionService.convertPlayerToCOM', () => {
     expect(state.teamAssignments[comId]).toBe(0);
     expect(state.currentSeatId).toBe(comId);
     expect(Object.keys(vacantSeats['room-1'])).toEqual([HUMAN_ID]);
-    expect(vacantSeats['room-1'][asSeatId(HUMAN_ID)].roomPlayer.playerId).toBe(
+    expect(vacantSeats['room-1'][asSeatId(HUMAN_ID)].roomPlayer.seatId).toBe(
       HUMAN_ID,
     );
   });
@@ -134,7 +134,7 @@ describe('ComSessionService.convertPlayerToCOM', () => {
     expect(converted).toBe(true);
     expect(room.players[0]).toEqual(
       expect.objectContaining({
-        playerId: HUMAN_ID,
+        seatId: asSeatId(HUMAN_ID),
         userId: 'user-1',
         participantKey: 'user-1',
         isAuthenticated: true,

--- a/mei-tra-backend/src/services/__tests__/com-strategy-inherited-declaration.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy-inherited-declaration.spec.ts
@@ -21,7 +21,7 @@ import {
  */
 const comPlayer = (over: Partial<DomainPlayer> = {}): DomainPlayer =>
   ({
-    playerId: 'com-timeout-0-123',
+    seatId: asSeatId('com-timeout-0-123'),
     name: 'COM',
     hand: [
       'A♠',
@@ -88,7 +88,7 @@ describe('ComStrategyService.chooseBlowAction — inherited declaration', () => 
     const service = buildService();
 
     const action = service.chooseBlowAction(
-      stateWith([declaration(com.playerId)], [com]),
+      stateWith([declaration(com.seatId)], [com]),
       com,
     );
 
@@ -101,7 +101,7 @@ describe('ComStrategyService.chooseBlowAction — inherited declaration', () => 
     const service = buildService();
 
     const action = service.chooseBlowAction(
-      stateWith([declaration(com.playerId)], [com]),
+      stateWith([declaration(com.seatId)], [com]),
       com,
     );
 
@@ -113,7 +113,7 @@ describe('ComStrategyService.chooseBlowAction — inherited declaration', () => 
     const service = buildService();
 
     const action = service.chooseBlowAction(
-      stateWith([declaration(com.playerId)], [com]),
+      stateWith([declaration(com.seatId)], [com]),
       com,
     );
 
@@ -125,18 +125,18 @@ describe('ComStrategyService.chooseBlowAction — inherited declaration', () => 
     // for the COM itself, which made it "defer to its partner" and pass.
     const com = comPlayer();
     const service = buildService();
-    const state = stateWith([declaration(com.playerId)], [com]);
+    const state = stateWith([declaration(com.seatId)], [com]);
 
     expect(service.chooseBlowAction(state, com).type).not.toBe('pass');
   });
 
   it('still acts normally when it has not declared', () => {
     const com = comPlayer();
-    const partner = comPlayer({ playerId: 'com-1', team: 0 });
+    const partner = comPlayer({ seatId: asSeatId('com-1'), team: 0 });
     const service = buildService();
 
     const action = service.chooseBlowAction(
-      stateWith([declaration(partner.playerId)], [com, partner]),
+      stateWith([declaration(partner.seatId)], [com, partner]),
       com,
     );
 

--- a/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/com-strategy.service.spec.ts
@@ -36,7 +36,7 @@ describe('ComStrategyService', () => {
     hand: string[] = [],
     overrides: Partial<DomainPlayer> = {},
   ): DomainPlayer => ({
-    playerId,
+    seatId: asSeatId(playerId),
     name: playerId,
     team,
     hand,
@@ -66,7 +66,7 @@ describe('ComStrategyService', () => {
     };
 
     return {
-      currentSeatId: asSeatId(players[0].playerId),
+      currentSeatId: asSeatId(players[0].seatId),
       gamePhase: 'blow' as GamePhase,
       deck: [],
       teamScores: {
@@ -78,7 +78,7 @@ describe('ComStrategyService', () => {
       roundNumber: 1,
       pointsToWin: 5,
       teamAssignments: Object.fromEntries(
-        players.map((statePlayer) => [statePlayer.playerId, statePlayer.team]),
+        players.map((statePlayer) => [statePlayer.seatId, statePlayer.team]),
       ),
       ...overrides,
       players,
@@ -138,7 +138,7 @@ describe('ComStrategyService', () => {
       players: [com, enemy, player('partner-0', 0), player('enemy-2', 1)],
       blowState: {
         currentHighestDeclaration: {
-          seatId: asSeatId(enemy.playerId),
+          seatId: asSeatId(enemy.seatId),
           trumpType: 'tra',
           numberOfPairs: 7,
           timestamp: Date.now(),
@@ -171,7 +171,7 @@ describe('ComStrategyService', () => {
       players: [com, player('e1', 1), partner, player('e2', 1)],
       blowState: {
         currentHighestDeclaration: {
-          seatId: asSeatId(partner.playerId),
+          seatId: asSeatId(partner.seatId),
           trumpType: 'club',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -194,7 +194,7 @@ describe('ComStrategyService', () => {
       players: [com, player('e1', 1), partner, player('e2', 1)],
       blowState: {
         currentHighestDeclaration: {
-          seatId: asSeatId(partner.playerId),
+          seatId: asSeatId(partner.seatId),
           trumpType: 'club',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -221,7 +221,7 @@ describe('ComStrategyService', () => {
       blowState: {
         currentTrump: 'herz',
         currentHighestDeclaration: {
-          seatId: asSeatId(com.playerId),
+          seatId: asSeatId(com.seatId),
           trumpType: 'herz',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -284,7 +284,7 @@ describe('ComStrategyService', () => {
     const partner = player('partner-0', 0);
     const gameState = leadState(com, 'herz', {
       currentHighestDeclaration: {
-        seatId: asSeatId(partner.playerId),
+        seatId: asSeatId(partner.seatId),
         trumpType: 'herz',
         numberOfPairs: 6,
         timestamp: Date.now(),
@@ -307,7 +307,7 @@ describe('ComStrategyService', () => {
       'herz',
       {
         currentHighestDeclaration: {
-          seatId: asSeatId(partner.playerId),
+          seatId: asSeatId(partner.seatId),
           trumpType: 'herz',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -335,7 +335,7 @@ describe('ComStrategyService', () => {
       'herz',
       {
         currentHighestDeclaration: {
-          seatId: asSeatId(partner.playerId),
+          seatId: asSeatId(partner.seatId),
           trumpType: 'herz',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -360,7 +360,7 @@ describe('ComStrategyService', () => {
       'herz',
       {
         currentHighestDeclaration: {
-          seatId: asSeatId(partner.playerId),
+          seatId: asSeatId(partner.seatId),
           trumpType: 'herz',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -388,7 +388,7 @@ describe('ComStrategyService', () => {
       'herz',
       {
         currentHighestDeclaration: {
-          seatId: asSeatId(partner.playerId),
+          seatId: asSeatId(partner.seatId),
           trumpType: 'herz',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -416,7 +416,7 @@ describe('ComStrategyService', () => {
       'herz',
       {
         currentHighestDeclaration: {
-          seatId: asSeatId(partner.playerId),
+          seatId: asSeatId(partner.seatId),
           trumpType: 'herz',
           numberOfPairs: 6,
           timestamp: Date.now(),
@@ -441,7 +441,7 @@ describe('ComStrategyService', () => {
     const enemy = player('enemy-1', 1);
     const gameState = leadState(com, 'herz', {
       currentHighestDeclaration: {
-        seatId: asSeatId(enemy.playerId),
+        seatId: asSeatId(enemy.seatId),
         trumpType: 'herz',
         numberOfPairs: 6,
         timestamp: Date.now(),
@@ -461,7 +461,7 @@ describe('ComStrategyService', () => {
     const enemy = player('enemy-1', 1);
     const gameState = leadState(com, 'herz', {
       currentHighestDeclaration: {
-        seatId: asSeatId(enemy.playerId),
+        seatId: asSeatId(enemy.seatId),
         trumpType: 'herz',
         numberOfPairs: 6,
         timestamp: Date.now(),

--- a/mei-tra-backend/src/services/__tests__/disconnect-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/disconnect-gateway-effects.service.spec.ts
@@ -38,7 +38,7 @@ describe('DisconnectGatewayEffectsService', () => {
     const state = {
       players: [
         {
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Host',
           hand: [],
           team: 0,
@@ -53,7 +53,7 @@ describe('DisconnectGatewayEffectsService', () => {
       saveState: jest.fn().mockResolvedValue(undefined),
       findSessionUserBySocketId: jest.fn(() => ({
         socketId: 'socket-1',
-        playerId: 'player-1',
+        seatId: asSeatId('player-1'),
         name: 'Host',
         userId: 'user-1',
         isAuthenticated: true,
@@ -75,7 +75,7 @@ describe('DisconnectGatewayEffectsService', () => {
       maxPlayers: 4,
       players: [
         {
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Host',
           isCOM: false,
           socketId: 'socket-1',
@@ -85,7 +85,7 @@ describe('DisconnectGatewayEffectsService', () => {
           joinedAt: new Date(),
         },
         {
-          playerId: 'player-2',
+          seatId: asSeatId('player-2'),
           name: 'Other',
           isCOM: false,
           socketId: 'socket-2',
@@ -105,7 +105,7 @@ describe('DisconnectGatewayEffectsService', () => {
       hostSeatId: asSeatId('player-2'),
       players: initialRoom.players.map((player) => ({
         ...player,
-        isHost: player.playerId === 'player-2',
+        isHost: player.seatId === 'player-2',
       })),
     };
     const roomService = {
@@ -316,13 +316,13 @@ describe('DisconnectGatewayEffectsService', () => {
   it('ignores a stale socket disconnect after a newer socket reconnects', async () => {
     const roomGameState = {
       getState: jest.fn(() => ({
-        players: [{ playerId: 'player-1', name: 'Player 1', team: 0 }],
+        players: [{ seatId: asSeatId('player-1'), name: 'Player 1', team: 0 }],
         teamAssignments: {},
         gamePhase: 'play',
       })),
       findSessionUserBySocketId: jest.fn(() => ({
         socketId: 'socket-old',
-        playerId: 'player-1',
+        seatId: asSeatId('player-1'),
         userId: 'user-1',
         name: 'Player 1',
       })),

--- a/mei-tra-backend/src/services/__tests__/game-state-phase.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/game-state-phase.spec.ts
@@ -118,14 +118,14 @@ describe('GameStateService phase transitions', () => {
     const state = service.getState();
     state.players = [
       {
-        playerId: 'player-1',
+        seatId: asSeatId('player-1'),
         name: 'Player 1',
         team: 0,
         hand: [],
         isPasser: false,
       },
       {
-        playerId: 'player-2',
+        seatId: asSeatId('player-2'),
         name: 'Player 2',
         team: 1,
         hand: [],
@@ -149,7 +149,7 @@ describe('GameStateService phase transitions', () => {
     const state = service.getState();
     state.players = [
       {
-        playerId: 'player-1',
+        seatId: asSeatId('player-1'),
         name: 'Player 1',
         team: 0,
         hand: [],
@@ -196,28 +196,28 @@ describe('GameStateService phase transitions', () => {
     const state = service.getState();
     state.players = [
       {
-        playerId: 'host-player',
+        seatId: asSeatId('host-player'),
         name: 'Host',
         team: 0,
         hand: [],
         isPasser: false,
       },
       {
-        playerId: 'player-2',
+        seatId: asSeatId('player-2'),
         name: 'Player 2',
         team: 1,
         hand: [],
         isPasser: false,
       },
       {
-        playerId: 'player-3',
+        seatId: asSeatId('player-3'),
         name: 'Player 3',
         team: 0,
         hand: [],
         isPasser: false,
       },
       {
-        playerId: 'player-4',
+        seatId: asSeatId('player-4'),
         name: 'Player 4',
         team: 1,
         hand: [],

--- a/mei-tra-backend/src/services/__tests__/gameplay-notification.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/gameplay-notification.service.spec.ts
@@ -55,7 +55,7 @@ const room = (overrides: Partial<Room> = {}): Room => ({
   status: RoomStatus.PLAYING,
   players: [
     {
-      playerId: 'player-1',
+      seatId: asSeatId('player-1'),
       userId: 'user-1',
       socketId: 'socket-1',
       name: 'Player 1',
@@ -69,7 +69,7 @@ const room = (overrides: Partial<Room> = {}): Room => ({
       joinedAt: new Date('2026-07-23T00:00:00.000Z'),
     },
     {
-      playerId: 'player-2',
+      seatId: asSeatId('player-2'),
       userId: 'user-2',
       socketId: 'socket-2',
       name: 'Player 2',
@@ -83,7 +83,7 @@ const room = (overrides: Partial<Room> = {}): Room => ({
       joinedAt: new Date('2026-07-23T00:00:00.000Z'),
     },
     {
-      playerId: 'com-3',
+      seatId: asSeatId('com-3'),
       socketId: 'socket-3',
       name: 'COM 3',
       team: 0,

--- a/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/join-room-gateway-effects.service.spec.ts
@@ -59,7 +59,7 @@ describe('JoinRoomGatewayEffectsService', () => {
       players: [
         {
           socketId: 'socket-1',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Host',
           hand: [],
           team: 0 as const,
@@ -89,7 +89,7 @@ describe('JoinRoomGatewayEffectsService', () => {
         ...room.players,
         {
           socketId: 'com-1',
-          playerId: 'com-1',
+          seatId: asSeatId('com-1'),
           name: 'COM 1',
           hand: [],
           team: 1 as const,
@@ -106,7 +106,7 @@ describe('JoinRoomGatewayEffectsService', () => {
     roomService.getRoomGameState.mockResolvedValue({
       getState: jest.fn(() => ({
         players: updatedRoom.players.map((player) => ({
-          playerId: player.playerId,
+          seatId: player.seatId,
           name: player.name,
           hand: [],
           team: player.team,
@@ -118,15 +118,15 @@ describe('JoinRoomGatewayEffectsService', () => {
         (players: DomainPlayer[]): TransportPlayer[] =>
           players.map(
             (player): TransportPlayer => ({
-              socketId: player.playerId === 'player-1' ? 'socket-1' : '',
-              seatId: asSeatId(player.playerId),
+              socketId: player.seatId === 'player-1' ? 'socket-1' : '',
+              seatId: asSeatId(player.seatId),
               name: player.name,
               hand: [...player.hand],
               team: player.team,
               isPasser: player.isPasser,
               isCOM: player.isCOM,
               isHost: updatedRoom.players.find(
-                (roomPlayer) => roomPlayer.playerId === player.playerId,
+                (roomPlayer) => roomPlayer.seatId === player.seatId,
               )?.isHost,
             }),
           ),
@@ -197,7 +197,7 @@ describe('JoinRoomGatewayEffectsService', () => {
       players: [
         {
           socketId: 'socket-1',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Host',
           hand: ['A'],
           team: 0 as const,
@@ -226,8 +226,8 @@ describe('JoinRoomGatewayEffectsService', () => {
         (players: DomainPlayer[]): TransportPlayer[] =>
           players.map(
             (player): TransportPlayer => ({
-              socketId: player.playerId === 'player-1' ? 'socket-1' : '',
-              seatId: asSeatId(player.playerId),
+              socketId: player.seatId === 'player-1' ? 'socket-1' : '',
+              seatId: asSeatId(player.seatId),
               name: player.name,
               hand: [...player.hand],
               team: player.team,
@@ -255,14 +255,14 @@ describe('JoinRoomGatewayEffectsService', () => {
           gameState: {
             players: [
               {
-                playerId: 'player-1',
+                seatId: asSeatId('player-1'),
                 name: 'Host',
                 hand: ['A'],
                 team: 0 as const,
                 isPasser: false,
               },
               {
-                playerId: 'player-2',
+                seatId: asSeatId('player-2'),
                 name: 'Other',
                 hand: ['B'],
                 team: 1 as const,
@@ -328,7 +328,7 @@ describe('JoinRoomGatewayEffectsService', () => {
       payload: {
         declarations: [
           {
-            seatId: 'player-1',
+            seatId: asSeatId('player-1'),
             trumpType: 'daiya',
             numberOfPairs: 6,
             timestamp: 1,
@@ -337,14 +337,14 @@ describe('JoinRoomGatewayEffectsService', () => {
         actionHistory: [
           {
             type: 'declare',
-            seatId: 'player-1',
+            seatId: asSeatId('player-1'),
             trumpType: 'daiya',
             numberOfPairs: 6,
             timestamp: 1,
           },
         ],
         currentHighest: {
-          seatId: 'player-1',
+          seatId: asSeatId('player-1'),
           trumpType: 'daiya',
           numberOfPairs: 6,
           timestamp: 1,
@@ -369,7 +369,7 @@ describe('JoinRoomGatewayEffectsService', () => {
       players: [
         {
           socketId: 'socket-1',
-          playerId: 'actual-seat',
+          seatId: asSeatId('actual-seat'),
           userId: 'user-1',
           name: 'User 1',
           hand: [],
@@ -382,7 +382,7 @@ describe('JoinRoomGatewayEffectsService', () => {
         },
         {
           socketId: 'com-1',
-          playerId: 'com-1',
+          seatId: asSeatId('com-1'),
           name: 'COM 1',
           hand: [],
           team: 1 as const,
@@ -431,7 +431,7 @@ describe('JoinRoomGatewayEffectsService', () => {
     expect(selfJoinedEvent).toMatchObject({
       socketId: 'socket-1',
       payload: {
-        seatId: 'actual-seat',
+        seatId: asSeatId('actual-seat'),
         isSelf: true,
       },
     });
@@ -441,7 +441,7 @@ describe('JoinRoomGatewayEffectsService', () => {
     expect(roomPlayerJoinedEvent).toMatchObject({
       scope: 'room',
       roomId: 'room-1',
-      payload: { seatId: 'actual-seat' },
+      payload: { seatId: asSeatId('actual-seat') },
     });
   });
 
@@ -454,7 +454,7 @@ describe('JoinRoomGatewayEffectsService', () => {
       players: [
         {
           socketId: 'socket-1',
-          playerId: 'actual-seat',
+          seatId: asSeatId('actual-seat'),
           userId: 'user-1',
           name: 'User 1',
           hand: ['A'],
@@ -484,13 +484,13 @@ describe('JoinRoomGatewayEffectsService', () => {
         (players: DomainPlayer[]): TransportPlayer[] =>
           players.map(
             (player): TransportPlayer => ({
-              socketId: player.playerId === 'actual-seat' ? 'socket-1' : '',
-              seatId: asSeatId(player.playerId),
+              socketId: player.seatId === 'actual-seat' ? 'socket-1' : '',
+              seatId: asSeatId(player.seatId),
               name: player.name,
               hand: [...player.hand],
               team: player.team,
               isPasser: player.isPasser,
-              userId: player.playerId === 'actual-seat' ? 'user-1' : undefined,
+              userId: player.seatId === 'actual-seat' ? 'user-1' : undefined,
             }),
           ),
       ),
@@ -516,14 +516,14 @@ describe('JoinRoomGatewayEffectsService', () => {
           gameState: {
             players: [
               {
-                playerId: 'actual-seat',
+                seatId: asSeatId('actual-seat'),
                 name: 'User 1',
                 hand: ['A'],
                 team: 0 as const,
                 isPasser: false,
               },
               {
-                playerId: 'other-seat',
+                seatId: asSeatId('other-seat'),
                 name: 'Other',
                 hand: ['B'],
                 team: 1 as const,
@@ -563,8 +563,11 @@ describe('JoinRoomGatewayEffectsService', () => {
     expect((gameStateEvent?.payload as any).youSeatId).toBe('actual-seat');
     expect((gameStateEvent?.payload as any).players).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ seatId: 'actual-seat', hand: ['A'] }),
-        expect.objectContaining({ seatId: 'other-seat', hand: [] }),
+        expect.objectContaining({
+          seatId: asSeatId('actual-seat'),
+          hand: ['A'],
+        }),
+        expect.objectContaining({ seatId: asSeatId('other-seat'), hand: [] }),
       ]),
     );
   });
@@ -578,7 +581,7 @@ describe('JoinRoomGatewayEffectsService', () => {
       players: [
         {
           socketId: 'socket-1',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Host',
           hand: [],
           team: 0 as const,
@@ -615,8 +618,7 @@ describe('JoinRoomGatewayEffectsService', () => {
       clientId: 'socket-1',
       room: room as never,
       selfPlayer: {
-        seatId: 'player-1' as never,
-        playerId: 'player-1',
+        seatId: asSeatId('player-1'),
         name: 'Host',
         team: 0,
       },
@@ -666,7 +668,7 @@ describe('JoinRoomGatewayEffectsService', () => {
       players: [
         {
           socketId: 'socket-1',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Host',
           hand: [],
           team: 0 as const,

--- a/mei-tra-backend/src/services/__tests__/play.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/play.service.spec.ts
@@ -7,7 +7,7 @@ describe('PlayService', () => {
   const playService = new PlayService(new CardService());
 
   const makePlayer = (playerId: string, isCOM = false): DomainPlayer => ({
-    playerId,
+    seatId: asSeatId(playerId),
     name: playerId,
     hand: [],
     team: isCOM ? 1 : 0,
@@ -33,7 +33,7 @@ describe('PlayService', () => {
 
     const winner = playService.determineFieldWinner(field, players, null);
 
-    expect(winner?.playerId).toBe('player-2');
+    expect(winner?.seatId).toBe('player-2');
   });
 
   it('keeps COM seats in the play order when attributing cards to players', () => {
@@ -54,7 +54,7 @@ describe('PlayService', () => {
 
     const winner = playService.determineFieldWinner(field, players, null);
 
-    expect(winner?.playerId).toBe('com-1');
+    expect(winner?.seatId).toBe('com-1');
   });
 
   it('uses playedBy as the source of truth when card attribution differs from current seat order', () => {
@@ -75,7 +75,7 @@ describe('PlayService', () => {
 
     const winner = playService.determineFieldWinner(field, players, null);
 
-    expect(winner?.playerId).toBe('player-3');
+    expect(winner?.seatId).toBe('player-3');
   });
 
   it('falls back to dealer order for legacy fields without playedBy attribution', () => {
@@ -96,7 +96,7 @@ describe('PlayService', () => {
 
     const winner = playService.determineFieldWinner(field, players, null);
 
-    expect(winner?.playerId).toBe('player-2');
+    expect(winner?.seatId).toBe('player-2');
   });
 
   it('returns only base-suit cards when the hand can follow suit', () => {

--- a/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/reconnection.spec.ts
@@ -14,12 +14,12 @@ import { RoomMembershipService } from '../room-membership.service';
 import { asSeatId } from '../../types/identity.types';
 
 const makeGamePlayer = (
-  playerId: string,
+  seatId: string,
   name: string,
   team: 0 | 1,
   overrides: Partial<DomainPlayer> = {},
 ): DomainPlayer => ({
-  playerId,
+  seatId: asSeatId(seatId),
   name,
   team,
   hand: [],
@@ -30,13 +30,13 @@ const makeGamePlayer = (
 });
 
 const makeRoomPlayer = (
-  playerId: string,
+  seatId: string,
   name: string,
   team: 0 | 1,
   overrides: Partial<RoomPlayer> = {},
 ): RoomPlayer => ({
   socketId: '',
-  playerId,
+  seatId: asSeatId(seatId),
   name,
   team,
   hand: [],
@@ -113,7 +113,7 @@ describe('Reconnection Token Management', () => {
 
         const foundPlayer = gameStateService.findPlayerByReconnectToken(token);
         expect(foundPlayer).toBeTruthy();
-        expect(foundPlayer?.playerId).toBe(playerId);
+        expect(foundPlayer?.seatId).toBe(playerId);
       });
 
       it('should overwrite existing token', () => {
@@ -131,7 +131,7 @@ describe('Reconnection Token Management', () => {
         gameStateService.getState().players.push(player1, player2);
 
         const foundPlayer = gameStateService.findPlayerByReconnectToken(token);
-        expect(foundPlayer?.playerId).toBe(playerId2);
+        expect(foundPlayer?.seatId).toBe(playerId2);
       });
     });
 
@@ -146,9 +146,9 @@ describe('Reconnection Token Management', () => {
         gameStateService.registerPlayerToken(token, playerId);
 
         // Token should find player
-        expect(
-          gameStateService.findPlayerByReconnectToken(token)?.playerId,
-        ).toBe(playerId);
+        expect(gameStateService.findPlayerByReconnectToken(token)?.seatId).toBe(
+          playerId,
+        );
 
         // Remove token
         gameStateService.removePlayerToken(playerId);
@@ -156,7 +156,7 @@ describe('Reconnection Token Management', () => {
         // Should still find by fallback (playerId directly in players array)
         const foundPlayer =
           gameStateService.findPlayerByReconnectToken(playerId);
-        expect(foundPlayer?.playerId).toBe(playerId);
+        expect(foundPlayer?.seatId).toBe(playerId);
       });
 
       it('should only remove token for specified player', () => {
@@ -179,12 +179,12 @@ describe('Reconnection Token Management', () => {
 
         // Token1 should be removed, but can still find by playerId fallback
         expect(
-          gameStateService.findPlayerByReconnectToken(playerId1)?.playerId,
+          gameStateService.findPlayerByReconnectToken(playerId1)?.seatId,
         ).toBe(playerId1); // Fallback works
 
         // Token2 should still exist
         expect(
-          gameStateService.findPlayerByReconnectToken(token2)?.playerId,
+          gameStateService.findPlayerByReconnectToken(token2)?.seatId,
         ).toBe(playerId2);
       });
     });
@@ -195,7 +195,7 @@ describe('Reconnection Token Management', () => {
         const persistedState: GameState = {
           players: [
             {
-              playerId: 'player-1',
+              seatId: asSeatId('player-1'),
               name: 'Player 1',
               team: 0,
               hand: ['H2', 'D3'],
@@ -204,7 +204,7 @@ describe('Reconnection Token Management', () => {
               hasRequiredBroken: false,
             },
             {
-              playerId: 'player-2',
+              seatId: asSeatId('player-2'),
               name: 'Player 2',
               team: 1,
               hand: ['C4', 'S5'],
@@ -248,8 +248,8 @@ describe('Reconnection Token Management', () => {
         const foundPlayer2 =
           gameStateService.findPlayerByReconnectToken('player-2');
 
-        expect(foundPlayer1?.playerId).toBe('player-1');
-        expect(foundPlayer2?.playerId).toBe('player-2');
+        expect(foundPlayer1?.seatId).toBe('player-1');
+        expect(foundPlayer2?.seatId).toBe('player-2');
         expect(gameStateService.getState().currentSeatId).toBe('player-1');
         expect(gameStateRepository.update).not.toHaveBeenCalled();
       });
@@ -307,7 +307,7 @@ describe('Reconnection Token Management', () => {
         const roomPlayers: RoomPlayer[] = [
           {
             socketId: 'stale-socket',
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             userId: 'user-1',
             isAuthenticated: true,
             name: 'User 1',
@@ -330,7 +330,7 @@ describe('Reconnection Token Management', () => {
 
         expect(gameStateService.getState().players).toEqual([
           expect.objectContaining({
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             name: 'User 1',
             team: 1,
           }),
@@ -339,7 +339,7 @@ describe('Reconnection Token Management', () => {
           'seat-1': 1,
         });
         expect(gameStateService.findPlayerByReconnectToken('user-1')).toEqual(
-          expect.objectContaining({ playerId: 'seat-1' }),
+          expect.objectContaining({ seatId: asSeatId('seat-1') }),
         );
         expect(gameStateRepository.persistRoomRoster).toHaveBeenCalledWith(
           roomId,
@@ -458,13 +458,13 @@ describe('Reconnection Token Management', () => {
         claim: jest
           .fn()
           .mockImplementation(
-            (userId: string, roomId: string, playerId: string) =>
+            (userId: string, roomId: string, seatId: string) =>
               Promise.resolve({
                 result: 'reconnected',
                 membership: {
                   userId,
                   roomId,
-                  playerId,
+                  seatId: asSeatId(seatId),
                   status: 'active',
                   membershipVersion: 1,
                   transitionId: 'transition-1',
@@ -603,7 +603,7 @@ describe('Reconnection Token Management', () => {
         },
       ];
 
-      await roomService.updatePlayerInRoom(baseRoom.id, player.playerId, {
+      await roomService.updatePlayerInRoom(baseRoom.id, player.seatId, {
         team: 1,
       });
 
@@ -621,7 +621,7 @@ describe('Reconnection Token Management', () => {
         const playerId = 'player-1';
         const player: RoomPlayer = {
           socketId: 'socket-new',
-          playerId,
+          seatId: asSeatId(playerId),
           name: 'Test Player',
           team: 0,
           hand: ['H2'],
@@ -659,7 +659,7 @@ describe('Reconnection Token Management', () => {
 
         const player: RoomPlayer = {
           socketId: 'socket-1',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Test Player',
           team: 0,
           hand: ['H2', 'D3', 'C4'],
@@ -683,7 +683,7 @@ describe('Reconnection Token Management', () => {
 
         const persistedRoster =
           gameStateRepository.persistRoomRoster.mock.calls[0][1];
-        expect(persistedRoster[0].playerId).toBe(playerId);
+        expect(persistedRoster[0].seatId).toBe(playerId);
         expect(persistedRoster[0].isCOM).toBe(true);
         expect(persistedRoster[0].name).toBe('COM');
       });
@@ -694,7 +694,7 @@ describe('Reconnection Token Management', () => {
 
         const player: RoomPlayer = {
           socketId: 'socket-1',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Test Player',
           team: 0,
           hand: ['H2', 'D3'],
@@ -733,7 +733,7 @@ describe('Reconnection Token Management', () => {
 
         const player: RoomPlayer = {
           socketId: 'socket-1',
-          playerId,
+          seatId: asSeatId(playerId),
           name: 'Test Player',
           team: 0,
           hand: ['JOKER', '9♣'],
@@ -755,7 +755,7 @@ describe('Reconnection Token Management', () => {
         const gameState = await roomService.getRoomGameState(roomId);
         gameState.getState().players = [
           {
-            playerId,
+            seatId: asSeatId(playerId),
             name: player.name,
             team: player.team,
             hand: [...player.hand],
@@ -796,7 +796,7 @@ describe('Reconnection Token Management', () => {
         const result = await roomService.convertPlayerToCOM(roomId, playerId);
 
         expect(result).toBe(true);
-        const comPlayerId = gameState.getState().players[0].playerId;
+        const comPlayerId = gameState.getState().players[0].seatId;
         expect(comPlayerId).toBe(playerId);
         expect(gameState.getState().playState?.currentField?.dealerSeatId).toBe(
           comPlayerId,
@@ -829,7 +829,7 @@ describe('Reconnection Token Management', () => {
 
         const player: RoomPlayer = {
           socketId: 'socket-1',
-          playerId,
+          seatId: asSeatId(playerId),
           name: 'Test Player',
           team: 0,
           hand: ['JOKER', '9♣'],
@@ -851,7 +851,7 @@ describe('Reconnection Token Management', () => {
         const gameState = await roomService.getRoomGameState(roomId);
         gameState.getState().players = [
           {
-            playerId,
+            seatId: asSeatId(playerId),
             name: player.name,
             team: player.team,
             hand: [...player.hand],
@@ -898,7 +898,7 @@ describe('Reconnection Token Management', () => {
         const result = await roomService.convertPlayerToCOM(roomId, playerId);
 
         expect(result).toBe(true);
-        const comPlayerId = gameState.getState().players[0].playerId;
+        const comPlayerId = gameState.getState().players[0].seatId;
         expect(comPlayerId).toBe(playerId);
         expect(
           gameState.getState().blowState.currentHighestDeclaration?.seatId,
@@ -923,7 +923,7 @@ describe('Reconnection Token Management', () => {
 
         const existingCom: RoomPlayer = {
           socketId: existingComId,
-          playerId: existingComId,
+          seatId: asSeatId(existingComId),
           name: 'COM',
           team: 1,
           hand: ['7♣'],
@@ -938,7 +938,7 @@ describe('Reconnection Token Management', () => {
 
         const player: RoomPlayer = {
           socketId: 'socket-1',
-          playerId,
+          seatId: asSeatId(playerId),
           name: 'Test Player',
           team: 0,
           hand: ['JOKER', '9♣'],
@@ -960,7 +960,7 @@ describe('Reconnection Token Management', () => {
         const gameState = await roomService.getRoomGameState(roomId);
         gameState.getState().players = [
           {
-            playerId: existingCom.playerId,
+            seatId: asSeatId(existingCom.seatId),
             name: existingCom.name,
             team: existingCom.team,
             hand: [...existingCom.hand],
@@ -970,7 +970,7 @@ describe('Reconnection Token Management', () => {
             isCOM: true,
           },
           {
-            playerId,
+            seatId: asSeatId(playerId),
             name: player.name,
             team: player.team,
             hand: [...player.hand],
@@ -984,14 +984,14 @@ describe('Reconnection Token Management', () => {
 
         expect(result).toBe(true);
         const convertedPlayerId =
-          roomState.getPersistedRoom()?.players[1]?.playerId ?? '';
+          roomState.getPersistedRoom()?.players[1]?.seatId ?? '';
         expect(convertedPlayerId).toBe(playerId);
-        expect(convertedPlayerId).not.toBe(existingCom.playerId);
+        expect(convertedPlayerId).not.toBe(existingCom.seatId);
         expect(
           new Set(
             roomState
               .getPersistedRoom()
-              ?.players.map((player) => player.playerId) ?? [],
+              ?.players.map((player) => player.seatId) ?? [],
           ).size,
         ).toBe(roomState.getPersistedRoom()?.players.length);
       });
@@ -1029,7 +1029,7 @@ describe('Reconnection Token Management', () => {
         const roomId = 'room-newcomer';
         const host = {
           socketId: 'socket-host',
-          playerId: 'seat-host',
+          seatId: asSeatId('seat-host'),
           userId: 'user-host',
           isAuthenticated: true,
           name: 'Host',
@@ -1044,7 +1044,7 @@ describe('Reconnection Token Management', () => {
         };
         const comSeat = {
           socketId: 'com-1',
-          playerId: 'seat-com',
+          seatId: asSeatId('seat-com'),
           name: 'COM',
           team: 1 as const,
           hand: [],
@@ -1059,7 +1059,7 @@ describe('Reconnection Token Management', () => {
         const roomState = bindRoomRepositoryToState({
           ...baseRoom,
           id: roomId,
-          hostSeatId: asSeatId(host.playerId),
+          hostSeatId: host.seatId,
           status: RoomStatus.WAITING,
           players: [host, comSeat],
         });
@@ -1075,7 +1075,7 @@ describe('Reconnection Token Management', () => {
         expect(joined).toBe(true);
         expect(roomState.getPersistedRoom()?.players[1]).toEqual(
           expect.objectContaining({
-            playerId: comSeat.playerId,
+            seatId: comSeat.seatId,
             userId: 'user-new',
             name: 'New Player',
             isCOM: false,
@@ -1087,7 +1087,7 @@ describe('Reconnection Token Management', () => {
         const roomId = 'room-reserved-timeout-seat';
         const host: RoomPlayer = {
           socketId: 'socket-host',
-          playerId: 'seat-host',
+          seatId: asSeatId('seat-host'),
           userId: 'user-host',
           isAuthenticated: true,
           name: 'Host',
@@ -1102,7 +1102,7 @@ describe('Reconnection Token Management', () => {
         };
         const timeoutSeat: RoomPlayer = {
           socketId: '',
-          playerId: 'seat-timeout',
+          seatId: asSeatId('seat-timeout'),
           userId: 'user-disconnected',
           isAuthenticated: true,
           participantKey: 'user-disconnected',
@@ -1120,7 +1120,7 @@ describe('Reconnection Token Management', () => {
         const roomState = bindRoomRepositoryToState({
           ...baseRoom,
           id: roomId,
-          hostSeatId: asSeatId(host.playerId),
+          hostSeatId: asSeatId(host.seatId),
           status: RoomStatus.WAITING,
           settings: { ...baseRoom.settings, maxPlayers: 2 },
           players: [host, timeoutSeat],
@@ -1154,7 +1154,7 @@ describe('Reconnection Token Management', () => {
         const roomState = bindRoomRepositoryToState({
           ...baseRoom,
           id: roomId,
-          hostSeatId: asSeatId(host.playerId),
+          hostSeatId: asSeatId(host.seatId),
           status: RoomStatus.PLAYING,
           settings: { ...baseRoom.settings, maxPlayers: 3 },
           players: [host, timeoutSeat],
@@ -1162,9 +1162,9 @@ describe('Reconnection Token Management', () => {
         const gameState = await roomService.getRoomGameState(roomId);
         gameState.getState().gamePhase = 'play';
         gameState.getState().players = [
-          makeGamePlayer(host.playerId, host.name, host.team),
+          makeGamePlayer(host.seatId, host.name, host.team),
           makeGamePlayer(
-            timeoutSeat.playerId,
+            timeoutSeat.seatId,
             timeoutSeat.name,
             timeoutSeat.team,
             {
@@ -1186,7 +1186,7 @@ describe('Reconnection Token Management', () => {
         expect(
           gameState
             .getState()
-            .players.find((player) => player.playerId === timeoutSeat.playerId),
+            .players.find((player) => player.seatId === timeoutSeat.seatId),
         ).toEqual(expect.objectContaining({ isCOM: true }));
         expect(
           gameState
@@ -1200,7 +1200,7 @@ describe('Reconnection Token Management', () => {
         const seatId = 'seat-owner';
         const timeoutCOM: RoomPlayer = {
           socketId: 'com-timeout',
-          playerId: seatId,
+          seatId: asSeatId(seatId),
           name: 'COM',
           team: 0,
           hand: ['H2'],
@@ -1256,7 +1256,7 @@ describe('Reconnection Token Management', () => {
         expect(joined).toBe(true);
         expect(roomState.getPersistedRoom()?.players[0]).toEqual(
           expect.objectContaining({
-            playerId: seatId,
+            seatId: seatId,
             userId: 'user-owner',
             name: 'Owner',
             isCOM: false,
@@ -1284,7 +1284,7 @@ describe('Reconnection Token Management', () => {
         // Setup: player left, vacantSeat exists with their playerId
         const comPlayer: RoomPlayer = {
           socketId: 'com-0',
-          playerId,
+          seatId: asSeatId(playerId),
           name: 'COM',
           team: 0,
           hand: [],
@@ -1346,7 +1346,7 @@ describe('Reconnection Token Management', () => {
 
         // Verify player was restored to index 0
         const restoredRoom = roomState.getPersistedRoom();
-        expect(restoredRoom?.players[0].playerId).toBe(comPlayer.playerId);
+        expect(restoredRoom?.players[0].seatId).toBe(comPlayer.seatId);
         expect(restoredRoom?.players[0].hand).toEqual([]);
         const restoredState = await roomService.getRoomGameState(roomId);
         expect(restoredState.getState().players[0].hand).toEqual([
@@ -1361,7 +1361,7 @@ describe('Reconnection Token Management', () => {
         const roomId = 'room-123';
         const existingPlayer: RoomPlayer = {
           socketId: 'socket-old',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           userId: 'user-1',
           isAuthenticated: true,
           name: 'Test Player',
@@ -1391,15 +1391,17 @@ describe('Reconnection Token Management', () => {
         });
 
         expect(result).toBe(true);
-        expect(roomState.getPersistedRoom()?.players[0].playerId).toBe(
+        expect(roomState.getPersistedRoom()?.players[0].seatId).toBe(
           'player-1',
         );
         expect(roomState.getPersistedRoom()?.players[0].socketId).toBe('');
         expect(gameStateRepository.persistRoomRoster).toHaveBeenCalledWith(
           roomId,
-          [expect.objectContaining({ playerId: 'player-1' })],
+          [expect.objectContaining({ seatId: asSeatId('player-1') })],
           expect.objectContaining({
-            players: [expect.objectContaining({ playerId: 'player-1' })],
+            players: [
+              expect.objectContaining({ seatId: asSeatId('player-1') }),
+            ],
           }),
           'player-1',
           expect.objectContaining({
@@ -1413,13 +1415,13 @@ describe('Reconnection Token Management', () => {
         const roomId = 'room-123';
         const hostUser = {
           socketId: 'socket-host',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Host Player',
         };
 
         const comPlayer: RoomPlayer = {
           socketId: 'com-0',
-          playerId: 'com-0',
+          seatId: asSeatId('com-0'),
           name: 'COM',
           team: 0,
           hand: [],
@@ -1434,7 +1436,7 @@ describe('Reconnection Token Management', () => {
 
         const room: Room = {
           ...baseRoom,
-          hostSeatId: asSeatId(comPlayer.playerId),
+          hostSeatId: asSeatId(comPlayer.seatId),
           status: RoomStatus.WAITING,
           players: [comPlayer],
         };
@@ -1448,7 +1450,7 @@ describe('Reconnection Token Management', () => {
           roomId,
           [
             expect.objectContaining({
-              playerId: 'com-0',
+              seatId: asSeatId('com-0'),
               isHost: true,
             }),
           ],
@@ -1466,7 +1468,7 @@ describe('Reconnection Token Management', () => {
           players: [
             {
               socketId: 'socket-1',
-              playerId: 'player-1',
+              seatId: asSeatId('player-1'),
               name: 'Player1',
               team: 0,
               hand: [],
@@ -1479,7 +1481,7 @@ describe('Reconnection Token Management', () => {
             },
             {
               socketId: 'socket-2',
-              playerId: 'player-2',
+              seatId: asSeatId('player-2'),
               name: 'Player2',
               team: 1,
               hand: [],
@@ -1498,14 +1500,12 @@ describe('Reconnection Token Management', () => {
         const normalizedRoom = await roomService.getRoom(roomId);
 
         expect(
-          normalizedRoom?.players.find(
-            (player) => player.playerId === 'player-1',
-          )?.isHost,
+          normalizedRoom?.players.find((player) => player.seatId === 'player-1')
+            ?.isHost,
         ).toBe(false);
         expect(
-          normalizedRoom?.players.find(
-            (player) => player.playerId === 'player-2',
-          )?.isHost,
+          normalizedRoom?.players.find((player) => player.seatId === 'player-2')
+            ?.isHost,
         ).toBe(true);
       });
 
@@ -1520,7 +1520,7 @@ describe('Reconnection Token Management', () => {
 
         const otherCom: RoomPlayer = {
           socketId: 'com-other',
-          playerId: 'com-other',
+          seatId: asSeatId('com-other'),
           name: 'COM',
           team: 1,
           hand: [],
@@ -1534,7 +1534,7 @@ describe('Reconnection Token Management', () => {
 
         const targetCom: RoomPlayer = {
           socketId: 'com-target',
-          playerId,
+          seatId: asSeatId(playerId),
           name: 'COM',
           team: 0,
           hand: [],
@@ -1556,7 +1556,7 @@ describe('Reconnection Token Management', () => {
         const gameState = await roomService.getRoomGameState(roomId);
         gameState.getState().players = [
           {
-            playerId: otherCom.playerId,
+            seatId: asSeatId(otherCom.seatId),
             name: otherCom.name,
             team: otherCom.team,
             hand: [],
@@ -1566,7 +1566,7 @@ describe('Reconnection Token Management', () => {
             isCOM: true,
           },
           {
-            playerId: targetCom.playerId,
+            seatId: asSeatId(targetCom.seatId),
             name: targetCom.name,
             team: targetCom.team,
             hand: ['H2', 'D3', 'C4'],
@@ -1611,15 +1611,11 @@ describe('Reconnection Token Management', () => {
 
         expect(result).toBe(true);
         const updatedRoom = roomState.getPersistedRoom();
-        expect(updatedRoom?.players[0].playerId).toBe(otherCom.playerId);
-        expect(updatedRoom?.players[1].playerId).toBe(targetCom.playerId);
+        expect(updatedRoom?.players[0].seatId).toBe(otherCom.seatId);
+        expect(updatedRoom?.players[1].seatId).toBe(targetCom.seatId);
         expect(updatedRoom?.players[1].hand).toEqual([]);
-        expect(gameState.getState().players[0].playerId).toBe(
-          otherCom.playerId,
-        );
-        expect(gameState.getState().players[1].playerId).toBe(
-          targetCom.playerId,
-        );
+        expect(gameState.getState().players[0].seatId).toBe(otherCom.seatId);
+        expect(gameState.getState().players[1].seatId).toBe(targetCom.seatId);
         expect(gameState.getState().players[1].hand).toEqual([
           'H2',
           'D3',
@@ -1638,7 +1634,7 @@ describe('Reconnection Token Management', () => {
 
         const targetCom: RoomPlayer = {
           socketId: 'com-target',
-          playerId,
+          seatId: asSeatId(playerId),
           name: 'COM',
           team: 0,
           hand: ['H2', 'D3'],
@@ -1661,7 +1657,7 @@ describe('Reconnection Token Management', () => {
         const gameState = await roomService.getRoomGameState(roomId);
         gameState.getState().players = [
           {
-            playerId: targetCom.playerId,
+            seatId: asSeatId(targetCom.seatId),
             name: targetCom.name,
             team: targetCom.team,
             hand: ['H2', 'D3'],
@@ -1707,11 +1703,9 @@ describe('Reconnection Token Management', () => {
 
         expect(result).toBe(true);
         const updatedRoom = roomState.getPersistedRoom();
-        expect(updatedRoom?.players[0].playerId).toBe(targetCom.playerId);
+        expect(updatedRoom?.players[0].seatId).toBe(targetCom.seatId);
         expect(updatedRoom?.players[0].hand).toEqual([]);
-        expect(gameState.getState().players[0].playerId).toBe(
-          targetCom.playerId,
-        );
+        expect(gameState.getState().players[0].seatId).toBe(targetCom.seatId);
         expect(gameState.getState().players[0].hand).toEqual(['H2', 'D3']);
         expect(gameState.getState().players[0].isPasser).toBe(true);
       });
@@ -1727,7 +1721,7 @@ describe('Reconnection Token Management', () => {
 
         const targetCom: RoomPlayer = {
           socketId: 'com-target',
-          playerId,
+          seatId: asSeatId(playerId),
           name: 'COM',
           team: 0,
           hand: ['H2', 'D3'],
@@ -1750,7 +1744,7 @@ describe('Reconnection Token Management', () => {
         const gameState = await roomService.getRoomGameState(roomId);
         gameState.getState().players = [
           {
-            playerId: targetCom.playerId,
+            seatId: asSeatId(targetCom.seatId),
             name: targetCom.name,
             team: targetCom.team,
             hand: ['H2', 'D3'],
@@ -1763,31 +1757,31 @@ describe('Reconnection Token Management', () => {
         gameState.getState().playState = {
           currentField: {
             cards: ['9♥'],
-            playedBy: [targetCom.playerId],
+            playedBy: [targetCom.seatId],
             baseCard: '9♥',
-            dealerSeatId: asSeatId(targetCom.playerId),
+            dealerSeatId: asSeatId(targetCom.seatId),
             isComplete: false,
           },
           negriCard: null,
-          neguri: { [targetCom.playerId]: '5♦' },
+          neguri: { [targetCom.seatId]: '5♦' },
           fields: [
             {
               cards: ['7♣', '8♣', '9♣', '10♣'],
-              winnerSeatId: asSeatId(targetCom.playerId),
+              winnerSeatId: asSeatId(targetCom.seatId),
               winnerTeam: 0,
-              dealerSeatId: asSeatId(targetCom.playerId),
+              dealerSeatId: asSeatId(targetCom.seatId),
             },
           ],
-          lastWinnerSeatId: asSeatId(targetCom.playerId),
+          lastWinnerSeatId: asSeatId(targetCom.seatId),
           openDeclared: false,
-          openDeclarerSeatId: asSeatId(targetCom.playerId),
+          openDeclarerSeatId: asSeatId(targetCom.seatId),
         };
         gameState.getState().pendingBrokenHandReveal = {
-          seatId: asSeatId(targetCom.playerId),
+          seatId: asSeatId(targetCom.seatId),
           handSnapshot: ['H2', 'D3'],
           startedAt: 100,
         };
-        gameState.getState().teamAssignments[targetCom.playerId] = 0;
+        gameState.getState().teamAssignments[targetCom.seatId] = 0;
 
         (roomService as any)['vacantSeats'][roomId] = {
           [playerId]: {
@@ -1821,32 +1815,30 @@ describe('Reconnection Token Management', () => {
 
         expect(result).toBe(true);
         expect(gameState.getState().playState?.currentField?.dealerSeatId).toBe(
-          targetCom.playerId,
+          targetCom.seatId,
         );
         expect(gameState.getState().playState?.currentField?.playedBy).toEqual([
-          targetCom.playerId,
+          targetCom.seatId,
         ]);
         expect(gameState.getState().playState?.fields[0]?.winnerSeatId).toBe(
-          targetCom.playerId,
+          targetCom.seatId,
         );
         expect(gameState.getState().playState?.fields[0]?.dealerSeatId).toBe(
-          targetCom.playerId,
+          targetCom.seatId,
         );
         expect(gameState.getState().playState?.lastWinnerSeatId).toBe(
-          targetCom.playerId,
+          targetCom.seatId,
         );
         expect(gameState.getState().playState?.openDeclarerSeatId).toBe(
-          targetCom.playerId,
+          targetCom.seatId,
         );
         expect(gameState.getState().pendingBrokenHandReveal?.seatId).toBe(
-          targetCom.playerId,
+          targetCom.seatId,
         );
-        expect(gameState.getState().playState?.neguri[targetCom.playerId]).toBe(
+        expect(gameState.getState().playState?.neguri[targetCom.seatId]).toBe(
           '5♦',
         );
-        expect(gameState.getState().teamAssignments[targetCom.playerId]).toBe(
-          0,
-        );
+        expect(gameState.getState().teamAssignments[targetCom.seatId]).toBe(0);
       });
 
       it('should keep blow references on the stable seat when a player rejoins', async () => {
@@ -1860,7 +1852,7 @@ describe('Reconnection Token Management', () => {
 
         const targetCom: RoomPlayer = {
           socketId: 'com-target',
-          playerId,
+          seatId: asSeatId(playerId),
           name: 'COM',
           team: 0,
           hand: ['H2', 'D3'],
@@ -1883,7 +1875,7 @@ describe('Reconnection Token Management', () => {
         const gameState = await roomService.getRoomGameState(roomId);
         gameState.getState().players = [
           {
-            playerId: targetCom.playerId,
+            seatId: asSeatId(targetCom.seatId),
             name: targetCom.name,
             team: targetCom.team,
             hand: ['H2', 'D3'],
@@ -1896,14 +1888,14 @@ describe('Reconnection Token Management', () => {
         gameState.getState().blowState = {
           currentTrump: null,
           currentHighestDeclaration: {
-            seatId: asSeatId(targetCom.playerId),
+            seatId: asSeatId(targetCom.seatId),
             trumpType: 'club',
             numberOfPairs: 6,
             timestamp: 1,
           },
           declarations: [
             {
-              seatId: asSeatId(targetCom.playerId),
+              seatId: asSeatId(targetCom.seatId),
               trumpType: 'club',
               numberOfPairs: 6,
               timestamp: 1,
@@ -1912,18 +1904,18 @@ describe('Reconnection Token Management', () => {
           actionHistory: [
             {
               type: 'declare',
-              seatId: asSeatId(targetCom.playerId),
+              seatId: asSeatId(targetCom.seatId),
               trumpType: 'club',
               numberOfPairs: 6,
               timestamp: 1,
             },
             {
               type: 'pass',
-              seatId: asSeatId(targetCom.playerId),
+              seatId: asSeatId(targetCom.seatId),
               timestamp: 2,
             },
           ],
-          lastPasserSeatId: asSeatId(targetCom.playerId),
+          lastPasserSeatId: asSeatId(targetCom.seatId),
           isRoundCancelled: false,
           currentBlowIndex: 0,
         };
@@ -1961,17 +1953,17 @@ describe('Reconnection Token Management', () => {
         expect(result).toBe(true);
         expect(
           gameState.getState().blowState.currentHighestDeclaration?.seatId,
-        ).toBe(targetCom.playerId);
+        ).toBe(targetCom.seatId);
         expect(gameState.getState().blowState.declarations[0]?.seatId).toBe(
-          targetCom.playerId,
+          targetCom.seatId,
         );
         expect(
           gameState
             .getState()
             .blowState.actionHistory.map((action) => action.seatId),
-        ).toEqual([targetCom.playerId, targetCom.playerId]);
+        ).toEqual([targetCom.seatId, targetCom.seatId]);
         expect(gameState.getState().blowState.lastPasserSeatId).toBe(
-          targetCom.playerId,
+          targetCom.seatId,
         );
       });
 
@@ -1982,12 +1974,12 @@ describe('Reconnection Token Management', () => {
         const nextPlayerId = 'player-3';
         const user = {
           socketId: 'socket-new',
-          playerId: joiningPlayerId,
+          seatId: asSeatId(joiningPlayerId),
           name: 'Player 2',
         };
         const comPlayer: RoomPlayer = {
           socketId: 'com-socket',
-          playerId: replacingComId,
+          seatId: asSeatId(replacingComId),
           name: 'COM 2',
           team: 0,
           hand: ['H2', 'D3'],
@@ -2001,7 +1993,7 @@ describe('Reconnection Token Management', () => {
         };
         const nextRoomPlayer: RoomPlayer = {
           socketId: 'socket-3',
-          playerId: nextPlayerId,
+          seatId: asSeatId(nextPlayerId),
           name: 'Player 3',
           team: 1,
           hand: ['C4', 'S5'],
@@ -2031,7 +2023,7 @@ describe('Reconnection Token Management', () => {
         gameState.getState().gamePhase = 'blow';
         gameState.getState().players = [
           {
-            playerId: replacingComId,
+            seatId: asSeatId(replacingComId),
             name: 'COM 2',
             team: 0,
             hand: ['H2', 'D3'],
@@ -2041,7 +2033,7 @@ describe('Reconnection Token Management', () => {
             isCOM: true,
           },
           {
-            playerId: nextPlayerId,
+            seatId: asSeatId(nextPlayerId),
             name: 'Player 3',
             team: 1,
             hand: ['C4', 'S5'],
@@ -2084,7 +2076,7 @@ describe('Reconnection Token Management', () => {
         const result = await roomService.joinRoom(roomId, user);
 
         expect(result).toBe(true);
-        expect(gameState.getState().players[0]?.playerId).toBe(replacingComId);
+        expect(gameState.getState().players[0]?.seatId).toBe(replacingComId);
         expect(
           gameState.getState().blowState.currentHighestDeclaration?.seatId,
         ).toBe(replacingComId);
@@ -2107,12 +2099,12 @@ describe('Reconnection Token Management', () => {
         const nextPlayerId = 'player-next';
         const user = {
           socketId: 'socket-join',
-          playerId: joiningPlayerId,
+          seatId: asSeatId(joiningPlayerId),
           name: 'Joining Player',
         };
         const comPlayer: RoomPlayer = {
           socketId: 'com-socket',
-          playerId: seatId,
+          seatId: asSeatId(seatId),
           name: 'COM',
           team: 0,
           hand: ['H2', 'D3'],
@@ -2126,7 +2118,7 @@ describe('Reconnection Token Management', () => {
         };
         const nextRoomPlayer: RoomPlayer = {
           socketId: 'socket-next',
-          playerId: nextPlayerId,
+          seatId: asSeatId(nextPlayerId),
           name: 'Next Player',
           team: 1,
           hand: ['C4', 'S5'],
@@ -2156,7 +2148,7 @@ describe('Reconnection Token Management', () => {
         gameState.getState().gamePhase = 'blow';
         gameState.getState().players = [
           {
-            playerId: seatId,
+            seatId: asSeatId(seatId),
             name: 'COM',
             team: 0,
             hand: ['H2', 'D3'],
@@ -2166,7 +2158,7 @@ describe('Reconnection Token Management', () => {
             isCOM: true,
           },
           {
-            playerId: nextPlayerId,
+            seatId: asSeatId(nextPlayerId),
             name: 'Next Player',
             team: 1,
             hand: ['C4', 'S5'],
@@ -2221,7 +2213,7 @@ describe('Reconnection Token Management', () => {
           [seatId]: {
             roomPlayer: {
               socketId: 'socket-left',
-              playerId: seatId,
+              seatId: seatId,
               name: 'Left Player',
               team: 0,
               hand: ['H2', 'D3'],
@@ -2233,7 +2225,7 @@ describe('Reconnection Token Management', () => {
               joinedAt: new Date('2026-03-13T09:59:00.000Z'),
             },
             gamePlayer: {
-              playerId: seatId,
+              seatId: seatId,
               name: 'Left Player',
               team: 0,
               hand: ['H2', 'D3'],
@@ -2247,7 +2239,7 @@ describe('Reconnection Token Management', () => {
         const result = await roomService.joinRoom(roomId, user);
 
         expect(result).toBe(true);
-        expect(gameState.getState().players[0]?.playerId).toBe(seatId);
+        expect(gameState.getState().players[0]?.seatId).toBe(seatId);
         expect(
           gameState.getState().blowState.currentHighestDeclaration?.seatId,
         ).toBe(seatId);
@@ -2283,7 +2275,7 @@ describe('Reconnection Token Management', () => {
 
         const comPlayer: RoomPlayer = {
           socketId: 'com-0',
-          playerId: originalPlayerId,
+          seatId: asSeatId(originalPlayerId),
           name: 'COM',
           team: 0,
           hand: [],
@@ -2310,7 +2302,7 @@ describe('Reconnection Token Management', () => {
           [originalPlayerId]: {
             roomPlayer: {
               socketId: '',
-              playerId: originalPlayerId,
+              seatId: originalPlayerId,
               name: 'Test Player',
               team: 1,
               hand: ['H2', 'D3'],
@@ -2323,7 +2315,7 @@ describe('Reconnection Token Management', () => {
             },
             gamePlayer: {
               socketId: '',
-              playerId: originalPlayerId,
+              seatId: originalPlayerId,
               name: 'Test Player',
               team: 1,
               hand: ['H2', 'D3'],
@@ -2340,14 +2332,14 @@ describe('Reconnection Token Management', () => {
 
         // New player should get the seat
         const updatedRoom = roomState.getPersistedRoom();
-        expect(updatedRoom?.players[0].playerId).toBe(comPlayer.playerId);
+        expect(updatedRoom?.players[0].seatId).toBe(comPlayer.seatId);
         expect(updatedRoom?.players[0].participantKey).toBe('player-2');
         expect(updatedRoom?.players[0].hand).toEqual([]);
         expect(gameState.getState().players[0].hand).toEqual(['H2', 'D3']);
 
         expect(gameState.getState().players[0]).toEqual(
           expect.objectContaining({
-            playerId: originalPlayerId,
+            seatId: originalPlayerId,
             name: 'New Player',
             isCOM: false,
           }),
@@ -2366,7 +2358,7 @@ describe('Reconnection Token Management', () => {
         players: [
           {
             socketId: '',
-            playerId,
+            seatId: asSeatId(playerId),
             userId: 'user-1',
             isAuthenticated: true,
             participantKey: 'user-1',
@@ -2412,7 +2404,7 @@ describe('Reconnection Token Management', () => {
       expect(result).toEqual({ success: true });
       expect(roomState.getPersistedRoom()?.players[0]).toEqual(
         expect.objectContaining({
-          playerId,
+          seatId: asSeatId(playerId),
           userId: 'user-1',
           name: 'Original Player',
           isCOM: false,
@@ -2434,7 +2426,7 @@ describe('Reconnection Token Management', () => {
 
         const comPlayer: RoomPlayer = {
           socketId: 'com-0',
-          playerId,
+          seatId: asSeatId(playerId),
           name: 'COM',
           team: 0,
           hand: [],
@@ -2458,7 +2450,7 @@ describe('Reconnection Token Management', () => {
         const gameState = await roomService.getRoomGameState(roomId);
         gameState.getState().players = [
           {
-            playerId,
+            seatId: asSeatId(playerId),
             name: 'COM',
             team: 0,
             hand: [],
@@ -2470,7 +2462,7 @@ describe('Reconnection Token Management', () => {
 
         const roomSnapshot: RoomPlayer = {
           socketId: '',
-          playerId,
+          seatId: asSeatId(playerId),
           name: 'Restore Player',
           team: 1,
           hand: ['H2', 'D3'],
@@ -2507,11 +2499,9 @@ describe('Reconnection Token Management', () => {
 
         expect(restored).toBe(true);
         const updatedRoom = roomState.getPersistedRoom();
-        expect(updatedRoom?.players[0].playerId).toBe(comPlayer.playerId);
+        expect(updatedRoom?.players[0].seatId).toBe(comPlayer.seatId);
         expect(updatedRoom?.players[0].hand).toEqual([]);
-        expect(gameState.getState().players[0].playerId).toBe(
-          comPlayer.playerId,
-        );
+        expect(gameState.getState().players[0].seatId).toBe(comPlayer.seatId);
         expect(gameState.getState().players[0].hand).toEqual(['H2', 'D3']);
         expect(gameState.getState().players[0].isPasser).toBe(true);
         expect((roomService as any)['vacantSeats'][roomId]).toBeUndefined();
@@ -2525,7 +2515,7 @@ describe('Reconnection Token Management', () => {
 
         const hostPlayer: RoomPlayer = {
           socketId: 'socket-1',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Host Player',
           team: 0,
           hand: [],
@@ -2537,7 +2527,7 @@ describe('Reconnection Token Management', () => {
         };
         const leavingPlayer: RoomPlayer = {
           socketId: 'socket-2',
-          playerId,
+          seatId: asSeatId(playerId),
           name: 'Leaving Player',
           team: 1,
           hand: [],
@@ -2550,7 +2540,7 @@ describe('Reconnection Token Management', () => {
         const comPlayer2: RoomPlayer = {
           ...leavingPlayer,
           socketId: 'com-2',
-          playerId: 'com-2',
+          seatId: asSeatId('com-2'),
           name: 'COM',
           team: 0,
           isCOM: true,
@@ -2559,7 +2549,7 @@ describe('Reconnection Token Management', () => {
         const comPlayer3: RoomPlayer = {
           ...comPlayer2,
           socketId: 'com-3',
-          playerId: 'com-3',
+          seatId: asSeatId('com-3'),
           team: 1,
         };
 
@@ -2573,7 +2563,7 @@ describe('Reconnection Token Management', () => {
         const gameState = await roomService.getRoomGameState(roomId);
         gameState.getState().players = [
           {
-            playerId: hostPlayer.playerId,
+            seatId: asSeatId(hostPlayer.seatId),
             name: hostPlayer.name,
             team: hostPlayer.team,
             hand: [],
@@ -2582,7 +2572,7 @@ describe('Reconnection Token Management', () => {
             hasRequiredBroken: false,
           },
           {
-            playerId: leavingPlayer.playerId,
+            seatId: asSeatId(leavingPlayer.seatId),
             name: leavingPlayer.name,
             team: leavingPlayer.team,
             hand: [],
@@ -2590,48 +2580,38 @@ describe('Reconnection Token Management', () => {
             hasBroken: false,
             hasRequiredBroken: false,
           },
-          makeGamePlayer(
-            comPlayer2.playerId,
-            comPlayer2.name,
-            comPlayer2.team,
-            {
-              isCOM: true,
-              isPasser: true,
-            },
-          ),
-          makeGamePlayer(
-            comPlayer3.playerId,
-            comPlayer3.name,
-            comPlayer3.team,
-            {
-              isCOM: true,
-              isPasser: true,
-            },
-          ),
+          makeGamePlayer(comPlayer2.seatId, comPlayer2.name, comPlayer2.team, {
+            isCOM: true,
+            isPasser: true,
+          }),
+          makeGamePlayer(comPlayer3.seatId, comPlayer3.name, comPlayer3.team, {
+            isCOM: true,
+            isPasser: true,
+          }),
         ];
         gameState.getState().teamAssignments = {
-          [hostPlayer.playerId]: hostPlayer.team,
-          [leavingPlayer.playerId]: leavingPlayer.team,
-          [comPlayer2.playerId]: comPlayer2.team,
-          [comPlayer3.playerId]: comPlayer3.team,
+          [hostPlayer.seatId]: hostPlayer.team,
+          [leavingPlayer.seatId]: leavingPlayer.team,
+          [comPlayer2.seatId]: comPlayer2.team,
+          [comPlayer3.seatId]: comPlayer3.team,
         };
 
         await roomService.leaveRoom(roomId, playerId);
 
         const updatedRoom = roomState.getPersistedRoom();
         const replacementCom = updatedRoom?.players.find(
-          (player) => player.playerId === playerId,
+          (player) => player.seatId === playerId,
         );
         expect(
-          new Set(updatedRoom?.players.map((player) => player.playerId)).size,
+          new Set(updatedRoom?.players.map((player) => player.seatId)).size,
         ).toBe(4);
         expect(replacementCom?.team).toBe(1);
-        expect(gameState.getState().players[1].playerId).toBe(
-          replacementCom?.playerId,
+        expect(gameState.getState().players[1].seatId).toBe(
+          replacementCom?.seatId,
         );
         expect(gameState.getState().players[1].team).toBe(1);
         expect(
-          gameState.getState().teamAssignments[replacementCom?.playerId ?? ''],
+          gameState.getState().teamAssignments[replacementCom?.seatId ?? ''],
         ).toBe(1);
         expect(gameState.getState().teamAssignments[playerId]).toBe(1);
       });
@@ -2642,7 +2622,7 @@ describe('Reconnection Token Management', () => {
 
         const hostPlayer: RoomPlayer = {
           socketId: 'socket-1',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Host Player',
           team: 0,
           hand: [],
@@ -2654,7 +2634,7 @@ describe('Reconnection Token Management', () => {
         };
         const leavingPlayer: RoomPlayer = {
           socketId: 'socket-2',
-          playerId,
+          seatId: asSeatId(playerId),
           name: 'Leaving Player',
           team: 1,
           hand: [],
@@ -2667,7 +2647,7 @@ describe('Reconnection Token Management', () => {
         const comPlayer2: RoomPlayer = {
           ...leavingPlayer,
           socketId: 'com-2',
-          playerId: 'com-2',
+          seatId: asSeatId('com-2'),
           name: 'COM',
           team: 0,
           isCOM: true,
@@ -2676,7 +2656,7 @@ describe('Reconnection Token Management', () => {
         const comPlayer3: RoomPlayer = {
           ...comPlayer2,
           socketId: 'com-3',
-          playerId: 'com-3',
+          seatId: asSeatId('com-3'),
           team: 1,
         };
 
@@ -2689,39 +2669,29 @@ describe('Reconnection Token Management', () => {
         const roomState = bindRoomRepositoryToState(room);
         const gameState = await roomService.getRoomGameState(roomId);
         gameState.getState().players = [
-          makeGamePlayer(hostPlayer.playerId, hostPlayer.name, hostPlayer.team),
+          makeGamePlayer(hostPlayer.seatId, hostPlayer.name, hostPlayer.team),
+          makeGamePlayer(comPlayer2.seatId, comPlayer2.name, comPlayer2.team, {
+            isCOM: true,
+            isPasser: true,
+          }),
           makeGamePlayer(
-            comPlayer2.playerId,
-            comPlayer2.name,
-            comPlayer2.team,
-            {
-              isCOM: true,
-              isPasser: true,
-            },
-          ),
-          makeGamePlayer(
-            leavingPlayer.playerId,
+            leavingPlayer.seatId,
             leavingPlayer.name,
             leavingPlayer.team,
           ),
-          makeGamePlayer(
-            comPlayer3.playerId,
-            comPlayer3.name,
-            comPlayer3.team,
-            {
-              isCOM: true,
-              isPasser: true,
-            },
-          ),
+          makeGamePlayer(comPlayer3.seatId, comPlayer3.name, comPlayer3.team, {
+            isCOM: true,
+            isPasser: true,
+          }),
         ];
 
         await roomService.leaveRoom(roomId, playerId);
 
         const updatedRoom = roomState.getPersistedRoom();
-        const playerIds = updatedRoom?.players.map((player) => player.playerId);
+        const playerIds = updatedRoom?.players.map((player) => player.seatId);
         expect(playerIds).toContain(playerId);
         expect(new Set(playerIds).size).toBe(playerIds?.length);
-        expect(gameState.getState().players[2].playerId).toBe(playerId);
+        expect(gameState.getState().players[2].seatId).toBe(playerId);
       });
 
       it('should not remove reconnectToken when leaving during play', async () => {
@@ -2730,7 +2700,7 @@ describe('Reconnection Token Management', () => {
 
         const player: RoomPlayer = {
           socketId: 'socket-1',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Test Player',
           team: 0,
           hand: ['H2', 'D3'],
@@ -2752,7 +2722,7 @@ describe('Reconnection Token Management', () => {
         const gameState = await roomService.getRoomGameState(roomId);
         gameState.registerPlayerToken(playerId, playerId);
         gameState.getState().players.push({
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Test Player',
           team: 0,
           hand: ['H2', 'D3'],
@@ -2778,7 +2748,7 @@ describe('Reconnection Token Management', () => {
 
         const player: RoomPlayer = {
           socketId: 'socket-1',
-          playerId,
+          seatId: asSeatId(playerId),
           name: 'Test Player',
           team: 0,
           hand: ['H2', 'D3'],
@@ -2802,7 +2772,7 @@ describe('Reconnection Token Management', () => {
         gameState.getState().gamePhase = 'blow';
         gameState.getState().players = [
           {
-            playerId,
+            seatId: asSeatId(playerId),
             name: player.name,
             team: player.team,
             hand: [...player.hand],
@@ -2832,7 +2802,7 @@ describe('Reconnection Token Management', () => {
           players: [
             {
               socketId: 'socket-1',
-              playerId,
+              seatId: asSeatId(playerId),
               name: 'Player 1',
               hand: [],
               team: 0,
@@ -2854,7 +2824,7 @@ describe('Reconnection Token Management', () => {
         // Verify player was converted to com
         const comPlayer = roomState
           .getPersistedRoom()
-          ?.players.find((player) => player.playerId === playerId);
+          ?.players.find((player) => player.seatId === playerId);
         expect(comPlayer).toBeDefined();
         expect(comPlayer?.isCOM).toBe(true);
 
@@ -2867,7 +2837,7 @@ describe('Reconnection Token Management', () => {
         const vacantSeat = Object.values(
           (roomService as any)['vacantSeats'][roomId],
         )[0] as any;
-        expect(vacantSeat.roomPlayer.playerId).toBe(playerId);
+        expect(vacantSeat.roomPlayer.seatId).toBe(playerId);
         /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument */
       });
     });

--- a/mei-tra-backend/src/services/__tests__/room-membership-lifecycle.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room-membership-lifecycle.spec.ts
@@ -119,7 +119,7 @@ describe('RoomService active membership lifecycle', () => {
       players: [
         {
           socketId: 'socket-old',
-          playerId: 'seat-1',
+          seatId: asSeatId('seat-1'),
           userId: 'user-1',
           isAuthenticated: true,
           name: 'Player 1',
@@ -147,7 +147,7 @@ describe('RoomService active membership lifecycle', () => {
     expect(membershipService.claim).not.toHaveBeenCalled();
     const joinRequest: unknown = roomJoinService.joinRoom.mock.calls[0]?.[0];
     expect(joinRequest).toMatchObject({
-      user: { seatId: 'seat-1' },
+      user: { seatId: asSeatId('seat-1') },
     });
     expect(membershipService.get).toHaveBeenCalledWith('user-1');
   });
@@ -168,8 +168,8 @@ describe('RoomService active membership lifecycle', () => {
     jest.spyOn(service, 'getRoom').mockResolvedValue({
       ...room,
       players: [
-        { ...duplicatePlayer, playerId: 'seat-1' },
-        { ...duplicatePlayer, playerId: 'seat-2' },
+        { ...duplicatePlayer, seatId: asSeatId('seat-1') },
+        { ...duplicatePlayer, seatId: asSeatId('seat-2') },
       ],
     });
 

--- a/mei-tra-backend/src/services/__tests__/room-membership-reconciler.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room-membership-reconciler.service.spec.ts
@@ -19,7 +19,7 @@ describe('RoomMembershipReconcilerService', () => {
 
   it('removes a duplicate seat while preserving the authoritative room', async () => {
     const authoritativePlayer = {
-      playerId: 'player-1',
+      seatId: asSeatId('player-1'),
       userId: 'user-1',
       isAuthenticated: true,
     };
@@ -34,7 +34,7 @@ describe('RoomMembershipReconcilerService', () => {
           id: 'room-duplicate',
           players: [
             {
-              playerId: 'player-stale',
+              seatId: asSeatId('player-stale'),
               userId: 'user-1',
               isAuthenticated: true,
             },
@@ -46,6 +46,10 @@ describe('RoomMembershipReconcilerService', () => {
     const membershipService = {
       list: jest.fn().mockResolvedValue([membership]),
       release: jest.fn(),
+      claim: jest.fn().mockResolvedValue({
+        result: 'reconnected',
+        membership,
+      }),
       cancelReservation: jest.fn(),
     } as unknown as RoomMembershipService;
     const service = new RoomMembershipReconcilerService(
@@ -102,7 +106,7 @@ describe('RoomMembershipReconcilerService', () => {
         id: 'room-authoritative',
         players: [
           {
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             userId: 'user-1',
             isAuthenticated: true,
           },

--- a/mei-tra-backend/src/services/__tests__/room-update-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room-update-gateway-effects.service.spec.ts
@@ -12,7 +12,7 @@ describe('RoomUpdateGatewayEffectsService', () => {
         getState: jest.fn(() => ({
           players: [
             {
-              playerId: 'player-1',
+              seatId: asSeatId('player-1'),
               name: 'Player 1',
               hand: [],
               team: 0,
@@ -33,15 +33,14 @@ describe('RoomUpdateGatewayEffectsService', () => {
         getTransportPlayers: jest.fn(
           (players?: DomainPlayer[]): TransportPlayer[] =>
             (players ?? []).map((player) => ({
-              socketId:
-                player.playerId === 'player-1' ? 'socket-1' : 'socket-2',
-              seatId: asSeatId(player.playerId),
+              socketId: player.seatId === 'player-1' ? 'socket-1' : 'socket-2',
+              seatId: asSeatId(player.seatId),
               name: player.name,
               hand: [...player.hand],
               team: player.team,
               isPasser: player.isPasser,
               isCOM: player.isCOM,
-              isHost: player.playerId === 'player-1',
+              isHost: player.seatId === 'player-1',
             })),
         ),
       }),
@@ -56,7 +55,7 @@ describe('RoomUpdateGatewayEffectsService', () => {
       players: [
         {
           socketId: 'socket-1',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Player 1',
           hand: [],
           team: 0 as const,

--- a/mei-tra-backend/src/services/__tests__/room.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/room.service.spec.ts
@@ -6,7 +6,7 @@ import { asSeatId } from '../../types/identity.types';
 
 const createRoomPlayer = (overrides: Partial<RoomPlayer> = {}): RoomPlayer => ({
   socketId: 'socket-1',
-  playerId: 'player-1',
+  seatId: asSeatId('player-1'),
   userId: 'user-1',
   name: 'Player 1',
   team: 0,
@@ -103,7 +103,7 @@ describe('RoomService join rollback', () => {
           mutableRoom.players.push(
             createRoomPlayer({
               socketId: 'ghost-socket',
-              playerId: 'ghost-player',
+              seatId: asSeatId('ghost-player'),
               userId: 'ghost-user',
               name: 'Ghost',
               isHost: false,
@@ -111,7 +111,7 @@ describe('RoomService join rollback', () => {
             }),
           );
           gameState.getState().players.push({
-            playerId: 'ghost-player',
+            seatId: asSeatId('ghost-player'),
             name: 'Ghost',
             hand: [],
             team: 1,
@@ -139,13 +139,13 @@ describe('RoomService join rollback', () => {
       roomJoinService as never,
     );
     const originalVacantSeat = createRoomPlayer({
-      playerId: 'vacant-player',
+      seatId: asSeatId('vacant-player'),
       userId: 'vacant-user',
       socketId: '',
       name: 'Vacant',
       isHost: false,
     });
-    const vacantSeatId = asSeatId(originalVacantSeat.playerId);
+    const vacantSeatId = asSeatId(originalVacantSeat.seatId);
     (
       service as unknown as { vacantSeats: Record<string, unknown> }
     ).vacantSeats['room-1'] = {
@@ -172,7 +172,7 @@ describe('RoomService join rollback', () => {
     expect(
       internals.vacantSeats['room-1'][vacantSeatId].roomPlayer,
     ).toMatchObject({
-      playerId: 'vacant-player',
+      seatId: asSeatId('vacant-player'),
       userId: 'vacant-user',
     });
     expect(internals.vacantSeats['room-1'][vacantSeatId].roomPlayer).not.toBe(

--- a/mei-tra-backend/src/services/__tests__/rule-services.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/rule-services.spec.ts
@@ -37,10 +37,10 @@ describe('Rule service characterization', () => {
 
   it('determines field winner using dealer-relative play order', () => {
     const players = [
-      { playerId: 'p1', name: 'A', team: 0 },
-      { playerId: 'p2', name: 'B', team: 1 },
-      { playerId: 'p3', name: 'C', team: 0 },
-      { playerId: 'p4', name: 'D', team: 1 },
+      { seatId: asSeatId('p1'), name: 'A', team: 0 },
+      { seatId: asSeatId('p2'), name: 'B', team: 1 },
+      { seatId: asSeatId('p3'), name: 'C', team: 0 },
+      { seatId: asSeatId('p4'), name: 'D', team: 1 },
     ].map(
       (player) =>
         ({
@@ -60,7 +60,7 @@ describe('Rule service characterization', () => {
     };
 
     expect(
-      playService.determineFieldWinner(field, players, 'club')?.playerId,
+      playService.determineFieldWinner(field, players, 'club')?.seatId,
     ).toBe('p3');
   });
 
@@ -78,7 +78,7 @@ describe('Rule service characterization', () => {
 
   it('records and reports chombo violations across teams only', () => {
     const player = {
-      playerId: 'p1',
+      seatId: asSeatId('p1'),
       name: 'A',
       team: 0,
       hand: ['J♠', 'J♣', 'J♥', 'J♦'],

--- a/mei-tra-backend/src/services/__tests__/runtime-seat-roster.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/runtime-seat-roster.spec.ts
@@ -8,7 +8,6 @@ import type { Room, RoomPlayer } from '../../types/room.types';
 
 const roomPlayer = (overrides: Partial<RoomPlayer> = {}): RoomPlayer => ({
   seatId: asSeatId('seat-1'),
-  playerId: 'seat-1',
   socketId: 'socket-1',
   name: 'Player 1',
   hand: [],
@@ -28,7 +27,6 @@ const state = (): Pick<GameState, 'players' | 'teamAssignments'> => ({
   players: [
     {
       seatId: asSeatId('seat-1'),
-      playerId: 'seat-1',
       name: 'Player 1',
       hand: ['A♠'],
       team: 0,
@@ -57,14 +55,14 @@ describe('runtime seat roster', () => {
     );
 
     expect(projection.roomPlayer).toMatchObject({
-      playerId: 'seat-1',
+      seatId: asSeatId('seat-1'),
       name: 'COM',
       isCOM: true,
     });
     expect(projection.roomPlayer.hand).toEqual([]);
     expect(projection.roomPlayer.isPasser).toBe(false);
     expect(runtimeState.players[0]).toMatchObject({
-      playerId: 'seat-1',
+      seatId: asSeatId('seat-1'),
       name: 'COM',
       isCOM: true,
       hand: ['A♠'],
@@ -79,7 +77,6 @@ describe('runtime seat roster', () => {
       roomPlayer({ name: 'Reconnected' }),
       roomPlayer({
         seatId: asSeatId('seat-2'),
-        playerId: 'seat-2',
         name: 'COM',
         team: 1,
         isCOM: true,
@@ -90,12 +87,12 @@ describe('runtime seat roster', () => {
 
     expect(runtimeState.players).toEqual([
       expect.objectContaining({
-        playerId: 'seat-1',
+        seatId: asSeatId('seat-1'),
         name: 'Reconnected',
         hand: ['A♠'],
       }),
       expect.objectContaining({
-        playerId: 'seat-2',
+        seatId: asSeatId('seat-2'),
         name: 'COM',
         team: 1,
       }),
@@ -113,7 +110,6 @@ describe('runtime seat roster', () => {
         state(),
         roomPlayer({
           seatId: asSeatId('seat-2'),
-          playerId: 'seat-2',
         }),
         { replaceSeatId: 'seat-1' },
       ),

--- a/mei-tra-backend/src/services/__tests__/start-game-gateway-effects.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/start-game-gateway-effects.service.spec.ts
@@ -1,6 +1,7 @@
 import { StartGameGatewayEffectsService } from '../start-game-gateway-effects.service';
 import { IRoomService } from '../interfaces/room-service.interface';
 import { RoomUpdateGatewayEffectsService } from '../room-update-gateway-effects.service';
+import { asSeatId } from '../../types/identity.types';
 
 describe('StartGameGatewayEffectsService', () => {
   it('builds contractized start-game room events', async () => {
@@ -11,7 +12,7 @@ describe('StartGameGatewayEffectsService', () => {
         settings: { teamNames: undefined },
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             socketId: 'socket-1',
             name: 'Host',
             hand: [],
@@ -33,7 +34,7 @@ describe('StartGameGatewayEffectsService', () => {
         getTransportPlayers: jest.fn(() => [
           {
             socketId: 'socket-1',
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Host',
             hand: ['AS'],
             team: 0,
@@ -93,7 +94,7 @@ describe('StartGameGatewayEffectsService', () => {
       roomId: 'room-1',
       players: [
         {
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Host',
           hand: ['AS'],
           team: 0,
@@ -156,7 +157,7 @@ describe('StartGameGatewayEffectsService', () => {
         payload: {
           players: [
             expect.objectContaining({
-              playerId: 'player-1',
+              seatId: asSeatId('player-1'),
               team: 0,
             }),
           ],
@@ -170,10 +171,11 @@ describe('StartGameGatewayEffectsService', () => {
           roomId: 'room-1',
           players: [
             expect.objectContaining({
-              playerId: 'player-1',
+              seatId: asSeatId('player-1'),
             }),
           ],
           pointsToWin: 10,
+          teamNames: undefined,
         },
       },
       {
@@ -203,7 +205,7 @@ describe('StartGameGatewayEffectsService', () => {
     const [roomEventsArgs] = buildRoomEventsMock.mock.calls[0] ?? [];
     expect(roomEventsArgs).toBeDefined();
     expect(roomEventsArgs?.room.id).toBe('room-1');
-    expect(roomEventsArgs?.statePlayers?.[0]?.playerId).toBe('player-1');
+    expect(roomEventsArgs?.statePlayers?.[0]?.seatId).toBe('player-1');
     expect(roomEventsArgs?.scope).toBe('room');
     expect(roomEventsArgs?.roomId).toBe('room-1');
     expect(roomService.listRooms).toHaveBeenCalledTimes(1);

--- a/mei-tra-backend/src/services/__tests__/turn-monitor.service.spec.ts
+++ b/mei-tra-backend/src/services/__tests__/turn-monitor.service.spec.ts
@@ -21,7 +21,7 @@ describe('TurnMonitorService', () => {
         getState: () => ({
           players: [
             {
-              playerId: 'p1',
+              seatId: asSeatId('p1'),
               socketId: 'socket-1',
               userId: 'user-1',
               isCOM: false,
@@ -67,7 +67,7 @@ describe('TurnMonitorService', () => {
         getState: () => ({
           players: [
             {
-              playerId: 'p1',
+              seatId: asSeatId('p1'),
               socketId: 'socket-1',
               userId: 'user-1',
               isCOM: false,
@@ -111,7 +111,7 @@ describe('TurnMonitorService', () => {
         getState: () => ({
           players: [
             {
-              playerId: 'p1',
+              seatId: asSeatId('p1'),
               socketId: 'socket-1',
               userId: 'user-1',
               isCOM: false,

--- a/mei-tra-backend/src/services/chombo.service.ts
+++ b/mei-tra-backend/src/services/chombo.service.ts
@@ -145,7 +145,7 @@ export class ChomboService implements IChomboService {
     if (validCards.length !== hand.length) {
       // Log warning if undefined cards detected
       console.warn(
-        `Player ${player.playerId} has ${hand.length - validCards.length} undefined cards`,
+        `Player ${player.seatId} has ${hand.length - validCards.length} undefined cards`,
       );
     }
 

--- a/mei-tra-backend/src/services/com-player.service.ts
+++ b/mei-tra-backend/src/services/com-player.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { DomainPlayer, Team } from '../types/game.types';
 import { IComPlayerService } from './interfaces/com-player-service.interface';
+import { asSeatId } from '../types/identity.types';
 
 @Injectable()
 export class ComPlayerService implements IComPlayerService {
   createComPlayer(seatIndex: number, team: Team): DomainPlayer {
     return {
-      playerId: `com-${seatIndex}`,
+      seatId: asSeatId(`com-${seatIndex}`),
       name: `COM ${seatIndex + 1}`,
       hand: [],
       team,
@@ -18,8 +19,8 @@ export class ComPlayerService implements IComPlayerService {
   }
 
   isComPlayer(
-    player: DomainPlayer | { isCOM?: boolean; playerId: string },
+    player: DomainPlayer | { isCOM?: boolean; seatId: string },
   ): boolean {
-    return player.isCOM === true || player.playerId.startsWith('com-');
+    return player.isCOM === true || player.seatId.startsWith('com-');
   }
 }

--- a/mei-tra-backend/src/services/com-session.service.ts
+++ b/mei-tra-backend/src/services/com-session.service.ts
@@ -33,7 +33,6 @@ export class ComSessionService {
       participantKey: `com-${idStr}-${seatId}`,
       gameplay: {
         seatId,
-        playerId: seatId,
         name: 'COM',
         isCOM: true,
         hand,
@@ -50,7 +49,7 @@ export class ComSessionService {
 
   private createActiveCOMReplacement(
     index: number | string,
-    sourcePlayer: Pick<RoomPlayer, 'seatId' | 'playerId' | 'team'>,
+    sourcePlayer: Pick<RoomPlayer, 'seatId' | 'team'>,
   ): RoomPlayer {
     return this.createCOMPlaceholder(
       index,
@@ -98,7 +97,7 @@ export class ComSessionService {
       const team = (team0Count <= team1Count ? 0 : 1) as Team;
       const placeholder = this.createCOMPlaceholder(idx, team);
       upsertRuntimeSeat(room, state, placeholder);
-      gameState.registerPlayerToken(placeholder.playerId, placeholder.playerId);
+      gameState.registerPlayerToken(placeholder.seatId, placeholder.seatId);
       rosterChanged = true;
     }
 
@@ -120,7 +119,7 @@ export class ComSessionService {
       }
       roomPlayer.isReady = true;
       const statePlayer = state.players.find(
-        (player) => player.playerId === roomPlayer.playerId,
+        (player) => player.seatId === roomPlayer.seatId,
       );
       upsertRuntimeSeat(room, state, roomPlayer, {
         gameplaySource: statePlayer ? { ...statePlayer, isCOM: true } : null,
@@ -153,11 +152,10 @@ export class ComSessionService {
           seatId,
           name: comPlayer.name,
         },
-        participantKey: comPlayer.playerId,
+        participantKey: comPlayer.seatId,
         gameplay: {
           ...comPlayer,
           seatId,
-          playerId: seatId,
         },
         isReady: true,
         isHost: false,
@@ -165,10 +163,7 @@ export class ComSessionService {
       });
 
       upsertRuntimeSeat(room, state, roomComPlayer);
-      gameState.registerPlayerToken(
-        roomComPlayer.playerId,
-        roomComPlayer.playerId,
-      );
+      gameState.registerPlayerToken(roomComPlayer.seatId, roomComPlayer.seatId);
     }
 
     await gameState.persistRoster(room.players, room.hostSeatId);
@@ -183,7 +178,7 @@ export class ComSessionService {
     membershipMutation?: RosterMembershipMutation,
   ): Promise<boolean> {
     const playerIndex = room.players.findIndex(
-      (player) => player.playerId === playerId,
+      (player) => player.seatId === playerId,
     );
     if (playerIndex === -1) {
       return false;
@@ -195,7 +190,7 @@ export class ComSessionService {
 
     const state = gameState.getState();
     const gsIndex = state.players.findIndex(
-      (player) => player.playerId === playerId,
+      (player) => player.seatId === playerId,
     );
 
     const uniqueIdx = `timeout-${playerIndex}-${Date.now()}`;

--- a/mei-tra-backend/src/services/com-strategy.service.ts
+++ b/mei-tra-backend/src/services/com-strategy.service.ts
@@ -80,7 +80,7 @@ export class ComStrategyService implements IComStrategyService {
     // The bid already belongs to the stable seat, so the COM sees it directly.
     // Returning 'skip' lets the caller advance the turn instead of retrying an
     // action the rules forbid.
-    if (hasPlayerDeclaredInBlow(state.blowState, comPlayer.playerId)) {
+    if (hasPlayerDeclaredInBlow(state.blowState, comPlayer.seatId)) {
       return { type: 'skip' };
     }
 
@@ -96,7 +96,7 @@ export class ComStrategyService implements IComStrategyService {
     // otherwise make the COM defer to itself and pass.
     const currentHighestIsPartner =
       currentHighestPlayer != null &&
-      currentHighestPlayer.playerId !== comPlayer.playerId &&
+      currentHighestPlayer.seatId !== comPlayer.seatId &&
       currentHighestPlayer.team === comPlayer.team;
     const evaluations = TRUMP_TYPES.map((trumpType) =>
       this.evaluateHandForTrump(comPlayer.hand, trumpType),
@@ -370,7 +370,7 @@ export class ComStrategyService implements IComStrategyService {
   ): string | null {
     if (
       declaration == null ||
-      declaration.seatId === comPlayer.playerId ||
+      declaration.seatId === comPlayer.seatId ||
       this.findPlayer(state, declaration.seatId)?.team !== comPlayer.team
     ) {
       return null;
@@ -783,7 +783,7 @@ export class ComStrategyService implements IComStrategyService {
   }
 
   private findPlayer(state: GameState, playerId: string): DomainPlayer | null {
-    return state.players.find((player) => player.playerId === playerId) ?? null;
+    return state.players.find((player) => player.seatId === playerId) ?? null;
   }
 
   private countSuits(

--- a/mei-tra-backend/src/services/connection-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/connection-gateway-effects.service.ts
@@ -153,7 +153,7 @@ export class ConnectionGatewayEffectsService {
       }
       const roomGameState = await this.roomService.getRoomGameState(roomId);
       return (
-        roomGameState.getPlayerConnectionState(player.playerId)?.socketId ||
+        roomGameState.getPlayerConnectionState(player.seatId)?.socketId ||
         player.socketId ||
         null
       );

--- a/mei-tra-backend/src/services/disconnect-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/disconnect-gateway-effects.service.ts
@@ -59,10 +59,10 @@ export class DisconnectGatewayEffectsService {
     }
 
     const roomPlayer = room.players.find(
-      (candidate) => candidate.playerId === player.playerId,
+      (candidate) => candidate.seatId === player.seatId,
     );
     const initialConnectionState = roomGameState.getPlayerConnectionState(
-      player.playerId,
+      player.seatId,
     );
     if (
       initialConnectionState?.socketId &&
@@ -80,7 +80,7 @@ export class DisconnectGatewayEffectsService {
     }
 
     const latestConnectionState = roomGameState.getPlayerConnectionState(
-      player.playerId,
+      player.seatId,
     );
     if (
       latestConnectionState?.socketId &&
@@ -89,7 +89,7 @@ export class DisconnectGatewayEffectsService {
       return null;
     }
 
-    await roomGameState.applyPlayerConnectionState(player.playerId, {
+    await roomGameState.applyPlayerConnectionState(player.seatId, {
       socketId: '',
     });
 
@@ -102,7 +102,7 @@ export class DisconnectGatewayEffectsService {
     });
 
     return {
-      playerId: player.playerId,
+      playerId: player.seatId,
       playerName: displayName ?? player.name,
       roomGameState,
       timeoutMode: this.resolveTimeoutMode(state.gamePhase),
@@ -288,7 +288,7 @@ export class DisconnectGatewayEffectsService {
     }
 
     return (
-      players.find((candidate) => candidate.playerId === roomPlayer.playerId) ??
+      players.find((candidate) => candidate.seatId === roomPlayer.seatId) ??
       null
     );
   }
@@ -304,14 +304,13 @@ export class DisconnectGatewayEffectsService {
     let room = params.room;
     const events: GatewayEvent[] = [];
 
-    if (room?.hostSeatId === player.playerId) {
+    if (room?.hostSeatId === player.seatId) {
       const nextHost = room.players.find(
-        (candidate) =>
-          candidate.playerId !== player.playerId && !candidate.isCOM,
+        (candidate) => candidate.seatId !== player.seatId && !candidate.isCOM,
       );
       if (nextHost) {
         await this.roomService.updateRoom(roomId, {
-          hostSeatId: asSeatId(nextHost.playerId),
+          hostSeatId: asSeatId(nextHost.seatId),
         });
         room = await this.roomService.getRoom(roomId);
         if (room) {
@@ -361,7 +360,7 @@ export class DisconnectGatewayEffectsService {
         roomId,
         event: 'player-left',
         payload: {
-          seatId: asSeatId(player.playerId),
+          seatId: asSeatId(player.seatId),
           roomId,
         },
       },
@@ -370,7 +369,7 @@ export class DisconnectGatewayEffectsService {
         roomId,
         event: 'player-disconnected',
         payload: {
-          seatId: asSeatId(player.playerId),
+          seatId: asSeatId(player.seatId),
           playerName,
           roomId,
         },

--- a/mei-tra-backend/src/services/game-state.service.ts
+++ b/mei-tra-backend/src/services/game-state.service.ts
@@ -245,10 +245,10 @@ export class GameStateService implements IGameStateService {
       }
 
       this.state.players.forEach((player) => {
-        if (player.playerId) {
+        if (player.seatId) {
           this.connectionManager.registerPlayerToken(
-            player.playerId,
-            player.playerId,
+            player.seatId,
+            player.seatId,
           );
         }
       });
@@ -293,19 +293,16 @@ export class GameStateService implements IGameStateService {
     reconcileRuntimeRoster(this.state, roomPlayers);
 
     roomPlayers.forEach((player) => {
-      this.connectionManager.registerPlayerToken(
-        player.playerId,
-        player.playerId,
-      );
+      this.connectionManager.registerPlayerToken(player.seatId, player.seatId);
       if (player.userId) {
         this.connectionManager.registerPlayerToken(
           player.userId,
-          player.playerId,
+          player.seatId,
         );
       }
     });
 
-    const hostId = roomPlayers.find((player) => player.isHost)?.playerId;
+    const hostId = roomPlayers.find((player) => player.isHost)?.seatId;
     try {
       await this.persistRoster(roomPlayers, hostId);
     } catch (error) {
@@ -398,7 +395,7 @@ export class GameStateService implements IGameStateService {
     userId?: string,
   ): Promise<void> {
     const player = this.state.players.find(
-      (candidate) => candidate.playerId === playerId,
+      (candidate) => candidate.seatId === playerId,
     );
     if (!player) {
       return;
@@ -416,7 +413,7 @@ export class GameStateService implements IGameStateService {
     connectionState: PlayerConnectionState,
   ): Promise<void> {
     const player = this.state.players.find(
-      (candidate) => candidate.playerId === playerId,
+      (candidate) => candidate.seatId === playerId,
     );
     if (!player) {
       return;
@@ -465,7 +462,7 @@ export class GameStateService implements IGameStateService {
     for (const player of this.state.players) {
       if (!Array.isArray(player.hand)) {
         throw new Error(
-          `Player ${player.playerId} has invalid hand: ${typeof player.hand}`,
+          `Player ${player.seatId} has invalid hand: ${typeof player.hand}`,
         );
       }
     }
@@ -517,7 +514,7 @@ export class GameStateService implements IGameStateService {
       throw new Error('Current seat is not initialized');
     }
     const nextIndex = (currentIndex + 1) % this.state.players.length;
-    setCurrentSeat(this.state, this.state.players[nextIndex]?.playerId ?? null);
+    setCurrentSeat(this.state, this.state.players[nextIndex]?.seatId ?? null);
   }
 
   getCurrentPlayer(): DomainPlayer | null {
@@ -534,7 +531,7 @@ export class GameStateService implements IGameStateService {
 
   isPlayerTurn(playerId: string): boolean {
     const currentPlayer = this.getCurrentPlayer();
-    return currentPlayer?.playerId === playerId;
+    return currentPlayer?.seatId === playerId;
   }
 
   completeField(field: Field, winnerSeatId: string): CompletedField | null {
@@ -549,7 +546,7 @@ export class GameStateService implements IGameStateService {
     }
 
     field.isComplete = true;
-    const winner = state.players.find((p) => p.playerId === winnerSeatId);
+    const winner = state.players.find((p) => p.seatId === winnerSeatId);
     if (!winner) {
       return null;
     }
@@ -627,7 +624,7 @@ export class GameStateService implements IGameStateService {
         playedBy: [],
         playedBySeatIds: [],
         baseCard: '',
-        dealerSeatId: asSeatId(state.players[0].playerId),
+        dealerSeatId: asSeatId(state.players[0].seatId),
         isComplete: false,
       },
       negriCard: null,
@@ -641,7 +638,7 @@ export class GameStateService implements IGameStateService {
 
     // Randomize the first blow player
     const firstBlowIndex = Math.floor(Math.random() * state.players.length);
-    this.setCurrentSeat(state.players[firstBlowIndex]?.playerId ?? null);
+    this.setCurrentSeat(state.players[firstBlowIndex]?.seatId ?? null);
 
     // Initialize blow state
     state.blowState = {

--- a/mei-tra-backend/src/services/gameplay-notification.service.ts
+++ b/mei-tra-backend/src/services/gameplay-notification.service.ts
@@ -99,7 +99,7 @@ export class GameplayNotificationService implements OnModuleDestroy {
         }
 
         const targetPlayer = context.room.players.find(
-          (player) => player.playerId === playerId,
+          (player) => player.seatId === playerId,
         );
         if (!targetPlayer) {
           return;
@@ -180,10 +180,10 @@ export class GameplayNotificationService implements OnModuleDestroy {
       ...new Set(
         players
           .filter((player) => !player.isCOM)
-          .filter((player) => !excludedPlayerIds.has(player.playerId))
+          .filter((player) => !excludedPlayerIds.has(player.seatId))
           .filter(
             (player) =>
-              player.playerId !== options.excludeActorId &&
+              player.seatId !== options.excludeActorId &&
               player.userId !== options.excludeActorId,
           )
           .map((player) => player.userId)

--- a/mei-tra-backend/src/services/interfaces/com-player-service.interface.ts
+++ b/mei-tra-backend/src/services/interfaces/com-player-service.interface.ts
@@ -3,6 +3,6 @@ import { DomainPlayer, Team } from '../../types/game.types';
 export interface IComPlayerService {
   createComPlayer(seatIndex: number, team: Team): DomainPlayer;
   isComPlayer(
-    player: DomainPlayer | { isCOM?: boolean; playerId: string },
+    player: DomainPlayer | { isCOM?: boolean; seatId: string },
   ): boolean;
 }

--- a/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
+++ b/mei-tra-backend/src/services/join-room-gateway-effects.service.ts
@@ -43,7 +43,6 @@ interface BuildRoomEntryEventsParams {
   room: JoinRoomSuccess['room'];
   selfPlayer: {
     seatId: SeatId;
-    playerId: string;
     name: string;
     team: Team;
   };
@@ -84,7 +83,7 @@ export class JoinRoomGatewayEffectsService {
         `Joined seat could not be resolved: room=${roomId} user=${normalizedUser.userId ?? 'unknown'}`,
       );
     }
-    const selfPlayerId = selfRoomPlayer.playerId;
+    const selfPlayerId = selfRoomPlayer.seatId;
 
     if (currentRoomId && currentRoomId !== roomId && previousRoomNotification) {
       events.push({
@@ -147,12 +146,12 @@ export class JoinRoomGatewayEffectsService {
 
     if (!joinData.resumeGame) {
       for (const existingPlayer of room.players) {
-        if (existingPlayer.playerId === selfPlayerId) {
+        if (existingPlayer.seatId === selfPlayerId) {
           continue;
         }
 
         const existingPlayerJoinedPayload: GamePlayerJoinedPayload = {
-          seatId: asSeatId(existingPlayer.playerId),
+          seatId: asSeatId(existingPlayer.seatId),
           roomId,
           isHost: existingPlayer.isHost,
           roomStatus: joinData.roomStatus,
@@ -297,7 +296,7 @@ export class JoinRoomGatewayEffectsService {
     }
 
     return room.players.find(
-      (player) => player.playerId === normalizedUser.seatId,
+      (player) => player.seatId === normalizedUser.seatId,
     );
   }
 
@@ -306,11 +305,11 @@ export class JoinRoomGatewayEffectsService {
     gamePlayers: DomainPlayer[],
     normalizedUser: SessionUser,
   ): string {
-    const gamePlayerIds = new Set(gamePlayers.map((player) => player.playerId));
+    const gamePlayerIds = new Set(gamePlayers.map((player) => player.seatId));
 
     const selfRoomPlayer = this.resolveSelfRoomPlayer(room, normalizedUser);
-    if (selfRoomPlayer && gamePlayerIds.has(selfRoomPlayer.playerId)) {
-      return selfRoomPlayer.playerId;
+    if (selfRoomPlayer && gamePlayerIds.has(selfRoomPlayer.seatId)) {
+      return selfRoomPlayer.seatId;
     }
 
     if (normalizedUser.seatId && gamePlayerIds.has(normalizedUser.seatId)) {

--- a/mei-tra-backend/src/services/play.service.ts
+++ b/mei-tra-backend/src/services/play.service.ts
@@ -36,22 +36,20 @@ export class PlayService implements IPlayService {
     let highestStrength = -1;
 
     // ディーラーのインデックスを取得
-    let dealerIndex = players.findIndex(
-      (p) => p.playerId === field.dealerSeatId,
-    );
+    let dealerIndex = players.findIndex((p) => p.seatId === field.dealerSeatId);
 
     // ディーラーが見つからない場合、最初の有効なプレイヤーをディーラーとする
     if (dealerIndex === -1) {
       dealerIndex = 0;
-      field.dealerSeatId = asSeatId(players[0].playerId);
+      field.dealerSeatId = asSeatId(players[0].seatId);
     }
 
     const playersById = new Map(
-      players.map((player) => [player.playerId, player]),
+      players.map((player) => [player.seatId, player]),
     );
     const playedByOrder =
       field.playedBy.length === field.cards.length
-        ? field.playedBy.map((playerId) => playersById.get(playerId))
+        ? field.playedBy.map((playerId) => playersById.get(asSeatId(playerId)))
         : [];
 
     // Prefer the explicit card -> player attribution recorded when each card was

--- a/mei-tra-backend/src/services/player-connection-manager.service.ts
+++ b/mei-tra-backend/src/services/player-connection-manager.service.ts
@@ -175,10 +175,10 @@ export class PlayerConnectionManager {
   ): DomainPlayer | null {
     const playerId = this.playerIds.get(token);
     if (playerId) {
-      return players.find((player) => player.playerId === playerId) || null;
+      return players.find((player) => player.seatId === playerId) || null;
     }
 
-    return players.find((player) => player.playerId === token) || null;
+    return players.find((player) => player.seatId === token) || null;
   }
 
   getPlayerConnectionState(playerId: string): PlayerConnectionState | null {

--- a/mei-tra-backend/src/services/room-join.service.ts
+++ b/mei-tra-backend/src/services/room-join.service.ts
@@ -40,7 +40,7 @@ export class RoomJoinService {
     const existingPlayer = this.findExistingRoomPlayer(room.players, user);
     if (existingPlayer) {
       const statePlayer = state.players.find(
-        (player) => player.playerId === existingPlayer.playerId,
+        (player) => player.seatId === existingPlayer.seatId,
       );
       const isWaitingRoom =
         state.gamePhase === null || state.gamePhase === 'waiting';
@@ -51,7 +51,7 @@ export class RoomJoinService {
       const reclaimingVacantSeatId = Object.entries(
         vacantSeats[roomId] ?? {},
       ).find(([seatId, seatData]) => {
-        if (seatId !== existingPlayer.playerId) {
+        if (seatId !== existingPlayer.seatId) {
           return false;
         }
         return user.userId
@@ -67,30 +67,26 @@ export class RoomJoinService {
         ...existingPlayer,
         ...user,
         seatId: resolveSeatId(existingPlayer),
-        playerId: resolveSeatId(existingPlayer),
         participantKey:
           user.userId ?? existingPlayer.participantKey ?? user.seatId,
         userId: user.userId ?? existingPlayer.userId,
         isAuthenticated: user.isAuthenticated ?? existingPlayer.isAuthenticated,
-        isHost: room.hostSeatId === existingPlayer.playerId,
+        isHost: room.hostSeatId === existingPlayer.seatId,
         isCOM: reclaimingCOMSeat ? false : existingPlayer.isCOM,
       };
       upsertRuntimeSeat(room, state, updatedPlayer, {
         gameplaySource: statePlayer,
       });
 
-      gameState.registerPlayerToken(
-        updatedPlayer.playerId,
-        updatedPlayer.playerId,
-      );
+      gameState.registerPlayerToken(updatedPlayer.seatId, updatedPlayer.seatId);
       if (updatedPlayer.userId) {
         gameState.registerPlayerToken(
           updatedPlayer.userId,
-          updatedPlayer.playerId,
+          updatedPlayer.seatId,
         );
       }
-      gameState.clearDisconnectTimeout(updatedPlayer.playerId);
-      await gameState.applyPlayerConnectionState(updatedPlayer.playerId, {
+      gameState.clearDisconnectTimeout(updatedPlayer.seatId);
+      await gameState.applyPlayerConnectionState(updatedPlayer.seatId, {
         socketId: updatedPlayer.socketId,
         userId: updatedPlayer.userId,
         isAuthenticated: updatedPlayer.isAuthenticated,
@@ -147,7 +143,7 @@ export class RoomJoinService {
     } else {
       const availableVacantEntry = vacantEntries.find(([vacantSeatId]) => {
         const currentSeat = room.players.find(
-          (player) => player.playerId === vacantSeatId,
+          (player) => player.seatId === vacantSeatId,
         );
         return Boolean(currentSeat && !currentSeat.userId);
       });
@@ -158,7 +154,7 @@ export class RoomJoinService {
         const seatRoomPlayer = seatData.roomPlayer;
         team = seatRoomPlayer.team;
 
-        const originalPlayerId = seatRoomPlayer.playerId;
+        const originalPlayerId = seatRoomPlayer.seatId;
         gameState.removePlayerToken(originalPlayerId);
         gameState.clearDisconnectTimeout(originalPlayerId);
 
@@ -176,12 +172,12 @@ export class RoomJoinService {
           this.isReplaceableCOMSeat(player),
         );
         if (comIndex !== -1) {
-          const comPlayerId = room.players[comIndex].playerId;
+          const comPlayerId = room.players[comIndex].seatId;
           team = room.players[comIndex].team;
           replacingComId = comPlayerId;
           assignedIndex = comIndex;
           gsAssignedIndex = state.players.findIndex(
-            (player) => player.playerId === comPlayerId,
+            (player) => player.seatId === comPlayerId,
           );
         }
       }
@@ -201,7 +197,7 @@ export class RoomJoinService {
           (player) => this.isReplaceableCOMSeat(player) && !player.isReady,
         );
         if (waitingComIndex !== -1) {
-          replacingComId = room.players[waitingComIndex].playerId;
+          replacingComId = room.players[waitingComIndex].seatId;
           assignedIndex = waitingComIndex;
         }
       }
@@ -218,12 +214,12 @@ export class RoomJoinService {
     const seatGameSnapshot = restoredSeatData?.gamePlayer;
 
     if (assignedIndex !== -1) {
-      replacingComId = room.players[assignedIndex]?.playerId || null;
+      replacingComId = room.players[assignedIndex]?.seatId || null;
     }
 
     const currentSeatRoomPlayer =
       replacingComId != null
-        ? room.players.find((player) => player.playerId === replacingComId)
+        ? room.players.find((player) => player.seatId === replacingComId)
         : assignedIndex !== -1
           ? room.players[assignedIndex]
           : undefined;
@@ -237,7 +233,6 @@ export class RoomJoinService {
       ...user,
       socketId: user.socketId,
       seatId: assignedSeatId,
-      playerId: assignedSeatId,
       participantKey: user.userId ?? user.seatId ?? assignedSeatId,
       team: currentSeatRoomPlayer?.team ?? team,
       hand: [],
@@ -255,30 +250,30 @@ export class RoomJoinService {
 
     if (gsAssignedIndex === -1 && replacingComId) {
       gsAssignedIndex = state.players.findIndex(
-        (statePlayer) => statePlayer.playerId === replacingComId,
+        (statePlayer) => statePlayer.seatId === replacingComId,
       );
     }
 
     const currentSeatGamePlayer =
       replacingComId != null
         ? state.players.find(
-            (statePlayer) => statePlayer.playerId === replacingComId,
+            (statePlayer) => statePlayer.seatId === replacingComId,
           )
         : undefined;
 
     upsertRuntimeSeat(room, state, player, {
-      replaceSeatId: replacingComId ?? player.playerId,
+      replaceSeatId: replacingComId ?? player.seatId,
       gameplaySource:
         currentSeatGamePlayer ??
         seatGameSnapshot ??
         (gsAssignedIndex === -1 ? null : state.players[gsAssignedIndex]),
     });
 
-    gameState.registerPlayerToken(player.playerId, player.playerId);
+    gameState.registerPlayerToken(player.seatId, player.seatId);
     if (player.userId) {
-      gameState.registerPlayerToken(player.userId, player.playerId);
+      gameState.registerPlayerToken(player.userId, player.seatId);
     }
-    await gameState.applyPlayerConnectionState(player.playerId, {
+    await gameState.applyPlayerConnectionState(player.seatId, {
       socketId: player.socketId,
       userId: player.userId,
       isAuthenticated: player.isAuthenticated,
@@ -302,7 +297,7 @@ export class RoomJoinService {
   }
 
   private resolveVacantSeatIndex(room: Room, vacantSeatId: string): number {
-    return room.players.findIndex((player) => player.playerId === vacantSeatId);
+    return room.players.findIndex((player) => player.seatId === vacantSeatId);
   }
 
   private buildMembershipClaim(
@@ -355,7 +350,7 @@ export class RoomJoinService {
       const candidateIndex = (currentIndex + offset) % state.players.length;
       const candidatePlayer = state.players[candidateIndex];
       if (!this.hasActedInBlow(state.blowState, candidatePlayer)) {
-        setCurrentSeat(state, candidatePlayer.playerId);
+        setCurrentSeat(state, candidatePlayer.seatId);
         return true;
       }
     }
@@ -367,10 +362,10 @@ export class RoomJoinService {
     return (
       player.isPasser ||
       blowState.declarations.some(
-        (declaration) => declaration.seatId === player.playerId,
+        (declaration) => declaration.seatId === player.seatId,
       ) ||
       (blowState.actionHistory ?? []).some(
-        (action) => action.seatId === player.playerId,
+        (action) => action.seatId === player.seatId,
       )
     );
   }

--- a/mei-tra-backend/src/services/room-membership-reconciler.service.ts
+++ b/mei-tra-backend/src/services/room-membership-reconciler.service.ts
@@ -38,7 +38,7 @@ export class RoomMembershipReconcilerService implements OnModuleInit {
       const room = await this.roomService.getRoom(membership.roomId);
       const player = room?.players.find(
         (candidate) =>
-          candidate.playerId === membership.seatId &&
+          candidate.seatId === membership.seatId &&
           candidate.userId === membership.userId,
       );
       if (player) {
@@ -54,12 +54,12 @@ export class RoomMembershipReconcilerService implements OnModuleInit {
         const repaired = await this.roomMembershipService.claim(
           membership.userId,
           membership.roomId,
-          authenticatedRoomPlayers[0].playerId,
+          authenticatedRoomPlayers[0].seatId,
         );
         if (repaired.result !== 'conflict') {
           authoritativeMemberships.set(membership.userId, repaired.membership);
           this.logger.warn(
-            `[MembershipReconcile] Repaired seat identity user=${membership.userId} room=${membership.roomId} from=${membership.seatId} to=${authenticatedRoomPlayers[0].playerId}`,
+            `[MembershipReconcile] Repaired seat identity user=${membership.userId} room=${membership.roomId} from=${membership.seatId} to=${authenticatedRoomPlayers[0].seatId}`,
           );
           continue;
         }
@@ -87,15 +87,14 @@ export class RoomMembershipReconcilerService implements OnModuleInit {
         const membership = authoritativeMemberships.get(player.userId);
         if (
           !membership?.roomId ||
-          (membership.roomId === room.id &&
-            membership.seatId === player.playerId)
+          (membership.roomId === room.id && membership.seatId === player.seatId)
         ) {
           continue;
         }
 
         const removed = await this.roomService.leaveRoom(
           room.id,
-          player.playerId,
+          player.seatId,
         );
         if (removed) {
           this.logger.warn(

--- a/mei-tra-backend/src/services/room.service.ts
+++ b/mei-tra-backend/src/services/room.service.ts
@@ -51,7 +51,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       ...room,
       players: room.players.map((player) => ({
         ...player,
-        isHost: player.playerId === room.hostSeatId,
+        isHost: player.seatId === room.hostSeatId,
       })),
     };
   }
@@ -218,7 +218,6 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       participantKey: hostUserId,
       gameplay: {
         seatId: hostSeatId,
-        playerId: hostSeatId,
         name: hostUser.name,
         hand: [],
         team: 0,
@@ -277,7 +276,6 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     return {
       socketId: `com-${idStr}`,
       seatId,
-      playerId: seatId,
       participantKey: `com-${idStr}-${seatId}`,
       name: 'COM',
       isCOM: true,
@@ -293,13 +291,13 @@ export class RoomService implements IRoomService, OnModuleDestroy {
 
   private createActiveCOMReplacement(
     index: number | string,
-    sourcePlayer: Pick<RoomPlayer, 'seatId' | 'playerId' | 'team'>,
+    sourcePlayer: Pick<RoomPlayer, 'seatId' | 'team'>,
   ): RoomPlayer {
     return this.createCOMPlaceholder(
       index,
       sourcePlayer.team,
       [],
-      asSeatId(sourcePlayer.seatId ?? sourcePlayer.playerId),
+      sourcePlayer.seatId,
     );
   }
 
@@ -318,7 +316,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       preferredIndex ?? fallbackIndex,
       team,
       [],
-      asSeatId(sourcePlayer.seatId ?? sourcePlayer.playerId),
+      asSeatId(sourcePlayer.seatId ?? sourcePlayer.seatId),
     );
   }
 
@@ -425,13 +423,11 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       const state = gameState.getState();
 
       // 退出したプレイヤーのindexを記録
-      const playerIndex = room.players.findIndex(
-        (p) => p.playerId === playerId,
-      );
+      const playerIndex = room.players.findIndex((p) => p.seatId === playerId);
       if (playerIndex !== -1) {
         if (!this.vacantSeats[roomId]) this.vacantSeats[roomId] = {};
 
-        const gsIndex = state.players.findIndex((p) => p.playerId === playerId);
+        const gsIndex = state.players.findIndex((p) => p.seatId === playerId);
 
         // 席UUIDを維持したまま占有者をCOMへ切り替える。
         // uniqueIdxはsocket/participant metadataだけを識別する。
@@ -461,13 +457,11 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       }
     } else {
       // ロビー状態: 退室プレイヤーをCOMに置き換え（空席を常時COMで維持）
-      const playerIndex = room.players.findIndex(
-        (p) => p.playerId === playerId,
-      );
+      const playerIndex = room.players.findIndex((p) => p.seatId === playerId);
       if (playerIndex !== -1) {
         const leavingPlayer = room.players[playerIndex];
         const state = gameState.getState();
-        const gsIndex = state.players.findIndex((p) => p.playerId === playerId);
+        const gsIndex = state.players.findIndex((p) => p.seatId === playerId);
         const seatIndex = gsIndex !== -1 ? gsIndex : playerIndex;
         const comPlaceholder = this.createWaitingCOMReplacement(
           seatIndex,
@@ -497,12 +491,12 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     if (room.hostSeatId === playerId) {
       const newHost = room.players.find((p) => !p.isCOM);
       if (newHost) {
-        room.hostSeatId = asSeatId(newHost.playerId);
+        room.hostSeatId = asSeatId(newHost.seatId);
       }
     }
 
     room.players.forEach((player) => {
-      player.isHost = player.playerId === room.hostSeatId;
+      player.isHost = player.seatId === room.hostSeatId;
     });
     await gameState.persistRoster(
       room.players,
@@ -606,7 +600,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       (player) => player.userId === user.userId,
     );
     if (roomMatches.length === 1) {
-      const seatId = asSeatId(roomMatches[0].playerId);
+      const seatId = asSeatId(roomMatches[0].seatId);
       return { ...user, seatId };
     }
     if (roomMatches.length > 1) {
@@ -619,7 +613,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       (seat) => seat.roomPlayer.userId === user.userId,
     );
     if (vacantMatches.length === 1) {
-      const seatId = asSeatId(vacantMatches[0].roomPlayer.playerId);
+      const seatId = asSeatId(vacantMatches[0].roomPlayer.seatId);
       return {
         ...user,
         seatId,
@@ -722,7 +716,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
 
     for (const [playerId, updates] of Object.entries(updatesByPlayerId)) {
       const roomPlayer = room.players.find(
-        (player) => player.playerId === playerId,
+        (player) => player.seatId === playerId,
       );
       if (!roomPlayer) {
         return false;
@@ -734,7 +728,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
       }
 
       const statePlayerIndex = state.players.findIndex(
-        (player) => player.playerId === playerId,
+        (player) => player.seatId === playerId,
       );
       const statePlayer =
         statePlayerIndex === -1 ? null : state.players[statePlayerIndex];
@@ -744,7 +738,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     }
 
     room.players.forEach((player) => {
-      player.isHost = player.playerId === room.hostSeatId;
+      player.isHost = player.seatId === room.hostSeatId;
     });
     await gameState.persistRoster(room.players, room.hostSeatId);
     return true;
@@ -832,14 +826,14 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     }
 
     const state = roomGameState.getState();
-    const player = state.players.find((p) => p.playerId === playerId);
+    const player = state.players.find((p) => p.seatId === playerId);
     if (!player) {
       return { success: false, error: 'Player not found in room' };
     }
 
     const room = await this.getRoom(roomId);
     const roomPlayer = room?.players.find(
-      (candidate) => candidate.playerId === playerId,
+      (candidate) => candidate.seatId === playerId,
     );
     if (!roomPlayer) {
       return { success: false, error: 'Room player not found' };
@@ -911,7 +905,7 @@ export class RoomService implements IRoomService, OnModuleDestroy {
     }
 
     for (const [seatId, seatData] of Object.entries(roomVacantSeats)) {
-      if (seatId === playerId || seatData.roomPlayer.playerId === playerId) {
+      if (seatId === playerId || seatData.roomPlayer.seatId === playerId) {
         delete roomVacantSeats[asSeatId(seatId)];
       }
     }

--- a/mei-tra-backend/src/services/runtime-seat-roster.ts
+++ b/mei-tra-backend/src/services/runtime-seat-roster.ts
@@ -27,7 +27,7 @@ function replaceOrAppend<T>(items: T[], index: number, value: T): void {
 
 export function rebuildTeamAssignments(state: RuntimeGameRoster): void {
   state.teamAssignments = Object.fromEntries(
-    state.players.map((player) => [player.playerId, player.team]),
+    state.players.map((player) => [player.seatId, player.team]),
   );
 }
 
@@ -70,8 +70,7 @@ export function upsertRuntimeSeat(
     (gameIndex === -1 ? null : state.players[gameIndex]);
   const normalizedRoomPlayer: RoomPlayer = {
     ...roomPlayer,
-    seatId,
-    playerId: seatId,
+    seatId: seatId,
     hand: [],
     isPasser: false,
     hasBroken: false,

--- a/mei-tra-backend/src/services/seat-restoration.service.ts
+++ b/mei-tra-backend/src/services/seat-restoration.service.ts
@@ -26,7 +26,7 @@ export class SeatRestorationService {
     }
 
     const vacancyEntry = Object.entries(vacantSeatsForRoom).find(
-      ([, data]) => data.roomPlayer.playerId === playerId,
+      ([, data]) => data.roomPlayer.seatId === playerId,
     );
     if (!vacancyEntry) {
       return false;
@@ -34,40 +34,37 @@ export class SeatRestorationService {
 
     const [vacantSeatId, seatData] = vacancyEntry;
     const currentSeatPlayer = room.players.find(
-      (player) => player.playerId === vacantSeatId,
+      (player) => player.seatId === vacantSeatId,
     );
     if (!currentSeatPlayer || !currentSeatPlayer.isCOM) {
       return false;
     }
 
     const currentSeatIndex = room.players.findIndex(
-      (player) => player.playerId === currentSeatPlayer.playerId,
+      (player) => player.seatId === currentSeatPlayer.seatId,
     );
     if (currentSeatIndex === -1) {
       return false;
     }
 
-    const comPlayerId = currentSeatPlayer.playerId;
+    const comPlayerId = currentSeatPlayer.seatId;
     const seatId = resolveSeatId(currentSeatPlayer);
     const restoredRoomPlayer: RoomPlayer = {
       ...seatData.roomPlayer,
       socketId: '',
-      seatId,
-      playerId: seatId,
+      seatId: seatId,
       joinedAt: new Date(seatData.roomPlayer.joinedAt),
     };
 
     const state = gameState.getState();
     const gsIndex = state.players.findIndex(
-      (player) =>
-        player.playerId === comPlayerId || player.playerId === playerId,
+      (player) => player.seatId === comPlayerId || player.seatId === playerId,
     );
 
     const restoredGamePlayerBase: DomainPlayer = seatData.gamePlayer
       ? {
           ...toDomainPlayer(seatData.gamePlayer),
           seatId,
-          playerId: seatId,
           hand: [
             ...(state.players[gsIndex]?.hand.length
               ? state.players[gsIndex].hand
@@ -119,7 +116,7 @@ export class SeatRestorationService {
       const candidateIndex = (currentIndex + offset) % state.players.length;
       const candidatePlayer = state.players[candidateIndex];
       if (!this.hasActedInBlow(state.blowState, candidatePlayer)) {
-        setCurrentSeat(state, candidatePlayer.playerId);
+        setCurrentSeat(state, candidatePlayer.seatId);
         return true;
       }
     }
@@ -131,10 +128,10 @@ export class SeatRestorationService {
     return (
       player.isPasser ||
       blowState.declarations.some(
-        (declaration) => declaration.seatId === player.playerId,
+        (declaration) => declaration.seatId === player.seatId,
       ) ||
       (blowState.actionHistory ?? []).some(
-        (action) => action.seatId === player.playerId,
+        (action) => action.seatId === player.seatId,
       )
     );
   }

--- a/mei-tra-backend/src/services/turn-monitor.service.ts
+++ b/mei-tra-backend/src/services/turn-monitor.service.ts
@@ -74,11 +74,11 @@ export class TurnMonitorService implements OnModuleDestroy {
     const roomGameState = await this.roomService.getRoomGameState(roomId);
     const state = roomGameState.getState();
     const currentPlayer = state.players.find(
-      (candidate) => candidate.playerId === playerId,
+      (candidate) => candidate.seatId === playerId,
     );
 
     const currentPlayerConnection = currentPlayer
-      ? roomGameState.getPlayerConnectionState(currentPlayer.playerId)
+      ? roomGameState.getPlayerConnectionState(currentPlayer.seatId)
       : null;
 
     if (
@@ -163,10 +163,10 @@ export class TurnMonitorService implements OnModuleDestroy {
     const roomGameState = await this.roomService.getRoomGameState(roomId);
     const state = roomGameState.getState();
     const currentPlayer = state.players.find(
-      (player) => player.playerId === monitor.playerId,
+      (player) => player.seatId === monitor.playerId,
     );
     const currentPlayerConnection = currentPlayer
-      ? roomGameState.getPlayerConnectionState(currentPlayer.playerId)
+      ? roomGameState.getPlayerConnectionState(currentPlayer.seatId)
       : null;
     const matchesCurrentTurnPlayer =
       currentPlayerConnection &&
@@ -202,7 +202,7 @@ export class TurnMonitorService implements OnModuleDestroy {
 
     return (
       (state.gamePhase === 'play' || state.gamePhase === 'blow') &&
-      currentPlayer?.playerId === playerId
+      currentPlayer?.seatId === playerId
     );
   }
 }

--- a/mei-tra-backend/src/types/current-turn.spec.ts
+++ b/mei-tra-backend/src/types/current-turn.spec.ts
@@ -10,7 +10,6 @@ import type { DomainPlayer, GameState } from './game.types';
 const players: DomainPlayer[] = [
   {
     seatId: asSeatId('seat-1'),
-    playerId: 'seat-1',
     name: 'Player 1',
     team: 0,
     hand: [],
@@ -18,7 +17,6 @@ const players: DomainPlayer[] = [
   },
   {
     seatId: asSeatId('seat-2'),
-    playerId: 'seat-2',
     name: 'Player 2',
     team: 1,
     hand: [],
@@ -40,7 +38,7 @@ describe('current turn identity', () => {
 
     expect(resolveCurrentSeatId(state)).toBe('seat-1');
     expect(resolveCurrentPlayerIndex(state)).toBe(0);
-    expect(resolveCurrentPlayer(state)?.playerId).toBe('seat-1');
+    expect(resolveCurrentPlayer(state)?.seatId).toBe('seat-1');
   });
 
   it('updates only the canonical seat assignment', () => {
@@ -48,7 +46,7 @@ describe('current turn identity', () => {
 
     const currentPlayer = setCurrentSeat(state, 'seat-2');
 
-    expect(currentPlayer?.playerId).toBe('seat-2');
+    expect(currentPlayer?.seatId).toBe('seat-2');
     expect(state.currentSeatId).toBe('seat-2');
   });
 

--- a/mei-tra-backend/src/types/current-turn.ts
+++ b/mei-tra-backend/src/types/current-turn.ts
@@ -4,7 +4,7 @@ import type { DomainPlayer, GameState } from './game.types';
 type CurrentTurnState = Pick<GameState, 'players' | 'currentSeatId'>;
 
 function playerSeatId(player: DomainPlayer): SeatId {
-  return player.seatId ?? asSeatId(player.playerId);
+  return player.seatId ?? asSeatId(player.seatId);
 }
 
 export function resolveCurrentSeatId(state: CurrentTurnState): SeatId | null {

--- a/mei-tra-backend/src/types/game-state-identity.spec.ts
+++ b/mei-tra-backend/src/types/game-state-identity.spec.ts
@@ -9,7 +9,6 @@ describe('normalizeGameStateIdentityAliases', () => {
       players: [
         {
           seatId: asSeatId('seat-1'),
-          playerId: 'legacy-player',
           name: 'Player 1',
           team: 0,
           hand: [],
@@ -58,7 +57,10 @@ describe('normalizeGameStateIdentityAliases', () => {
     const normalized = normalizeGameStateIdentityAliases(state);
 
     expect(normalized.players[0]).toEqual(
-      expect.objectContaining({ seatId: 'seat-1', playerId: 'seat-1' }),
+      expect.objectContaining({
+        seatId: asSeatId('seat-1'),
+        playerId: 'seat-1',
+      }),
     );
     expect(normalized.currentSeatId).toBe('seat-1');
     expect(normalized.blowState.lastPasserSeatId).toBe('seat-1');
@@ -82,7 +84,6 @@ describe('normalizeGameStateIdentityAliases', () => {
       players: [
         {
           seatId: asSeatId('seat-1'),
-          playerId: 'seat-1',
           name: 'Player 1',
           team: 0,
           hand: [],
@@ -90,7 +91,6 @@ describe('normalizeGameStateIdentityAliases', () => {
         },
         {
           seatId: asSeatId('seat-2'),
-          playerId: 'seat-2',
           name: 'Player 2',
           team: 1,
           hand: [],

--- a/mei-tra-backend/src/types/game-state-identity.ts
+++ b/mei-tra-backend/src/types/game-state-identity.ts
@@ -23,7 +23,7 @@ export function normalizeGameStateIdentityAliases(state: GameState): GameState {
     ? asSeatId(state.currentSeatId)
     : null;
   const players = state.players.map((player) => {
-    const seatId = player.seatId ?? asSeatId(player.playerId);
+    const seatId = player.seatId ?? asSeatId(player.seatId);
     return { ...player, seatId, playerId: seatId };
   });
   const blowState = {

--- a/mei-tra-backend/src/types/game.types.ts
+++ b/mei-tra-backend/src/types/game.types.ts
@@ -5,9 +5,7 @@ export type Team = 0 | 1;
 export type TeamNames = Partial<Record<Team, string>>;
 
 export interface PlayerIdentity {
-  seatId?: SeatId;
-  /** @deprecated Use seatId. This alias is kept equal to seatId. */
-  playerId: string;
+  seatId: SeatId;
   name: string;
 }
 

--- a/mei-tra-backend/src/types/identity.types.ts
+++ b/mei-tra-backend/src/types/identity.types.ts
@@ -4,24 +4,8 @@ import { asRoomId, asSeatId, asSocketId, asUserId } from '@contracts/ids';
 export type { RoomId, SeatId, SocketId, UserId };
 export { asRoomId, asSeatId, asSocketId, asUserId };
 
-export interface SeatIdentityAlias {
-  seatId?: SeatId;
-  playerId: string;
-}
-
-export function resolveSeatId(identity: SeatIdentityAlias): SeatId {
-  return identity.seatId ?? asSeatId(identity.playerId);
-}
-
-export function withSeatAlias<T extends { playerId: string }>(
-  value: T,
-  seatId: SeatId = asSeatId(value.playerId),
-): T & { seatId: SeatId; playerId: string } {
-  return {
-    ...value,
-    seatId,
-    playerId: seatId,
-  };
+export function resolveSeatId(identity: { seatId: SeatId }): SeatId {
+  return identity.seatId;
 }
 
 export function isUuid(value: string): boolean {

--- a/mei-tra-backend/src/types/player-adapters.spec.ts
+++ b/mei-tra-backend/src/types/player-adapters.spec.ts
@@ -3,13 +3,14 @@ import {
   toRuntimePlayer,
   toTransportPlayers,
 } from './player-adapters';
+import { asSeatId } from './identity.types';
 
 describe('player-adapters', () => {
   describe('toRuntimePlayer', () => {
     it('uses an explicit fallback team when persisted player team is missing', () => {
       const player = toRuntimePlayer(
         {
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Player 1',
           hand: [],
           isPasser: false,
@@ -22,7 +23,7 @@ describe('player-adapters', () => {
 
     it('rejects players without a persisted or fallback team', () => {
       const player = toRuntimePlayer({
-        playerId: 'player-1',
+        seatId: asSeatId('player-1'),
         name: 'Player 1',
         hand: [],
         isPasser: false,
@@ -36,7 +37,7 @@ describe('player-adapters', () => {
     it('persists gameplay fields without duplicating player identity', () => {
       const states = toPersistedPlayerStates([
         {
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Player 1',
           hand: ['S1'],
           team: 1,
@@ -66,7 +67,7 @@ describe('player-adapters', () => {
       const [player] = toTransportPlayers(
         [
           {
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             name: 'Player2',
             hand: ['S1'],
             team: 0,
@@ -83,7 +84,7 @@ describe('player-adapters', () => {
           roomPlayers: [
             {
               socketId: '',
-              playerId: 'seat-1',
+              seatId: asSeatId('seat-1'),
               participantKey: 'com-seat-1',
               name: 'COM',
               team: 0,
@@ -100,7 +101,7 @@ describe('player-adapters', () => {
 
       expect(player).toEqual(
         expect.objectContaining({
-          seatId: 'seat-1',
+          seatId: asSeatId('seat-1'),
           name: 'COM',
           socketId: '',
           userId: undefined,

--- a/mei-tra-backend/src/types/player-adapters.ts
+++ b/mei-tra-backend/src/types/player-adapters.ts
@@ -29,14 +29,13 @@ export type TransportPlayer = PlayerContract;
 export function toDomainPlayer(
   player: Pick<
     RoomPlayer | DomainPlayer,
-    'seatId' | 'playerId' | 'name' | 'team' | 'isCOM'
+    'seatId' | 'name' | 'team' | 'isCOM'
   > &
     Partial<PlayerGameplayState>,
 ): DomainPlayer {
   const seatId = resolveSeatId(player);
   return {
     seatId,
-    playerId: seatId,
     name: player.name,
     hand: [...(player.hand ?? [])],
     team: player.team,
@@ -79,16 +78,16 @@ export function toTransportPlayers(
 ): TransportPlayer[] {
   const roomPlayersById = new Map(
     (options?.roomPlayers ?? []).map((roomPlayer) => [
-      roomPlayer.playerId,
+      roomPlayer.seatId,
       roomPlayer,
     ]),
   );
 
   return players.map((player) => {
-    const roomPlayer = roomPlayersById.get(player.playerId);
+    const roomPlayer = roomPlayersById.get(player.seatId);
     const transportPlayer = withConnectionMetadata(
       player,
-      options?.getConnectionState?.(player.playerId) ?? roomPlayer,
+      options?.getConnectionState?.(player.seatId) ?? roomPlayer,
     );
 
     const visiblePlayer = roomPlayer?.isCOM
@@ -123,7 +122,7 @@ export function toPersistedPlayerStates(
 ): PersistedPlayerStates {
   return Object.fromEntries(
     players.map((player) => [
-      player.playerId,
+      player.seatId,
       {
         hand: [...player.hand],
         isPasser: player.isPasser,
@@ -140,7 +139,7 @@ export function toRuntimePlayer(
 ): DomainPlayer | null {
   if (
     !player ||
-    typeof player.playerId !== 'string' ||
+    typeof player.seatId !== 'string' ||
     typeof player.name !== 'string'
   ) {
     return null;
@@ -151,10 +150,8 @@ export function toRuntimePlayer(
     return null;
   }
 
-  const seatId = player.seatId ?? asSeatId(player.playerId);
   return {
-    seatId,
-    playerId: seatId,
+    seatId: asSeatId(player.seatId),
     name: player.name,
     hand: Array.isArray(player.hand) ? [...player.hand] : [],
     team,
@@ -167,22 +164,16 @@ export function toRuntimePlayer(
 
 export function toRoomPlayer(params: {
   session: SessionUser;
-  gameplay: PlayerGameplayState &
-    Pick<DomainPlayer, 'name' | 'playerId' | 'seatId'>;
+  gameplay: PlayerGameplayState & Pick<DomainPlayer, 'name' | 'seatId'>;
   participantKey?: string;
   isReady: boolean;
   isHost: boolean;
   joinedAt: Date;
 }): RoomPlayer {
-  const seatId =
-    params.session.seatId ??
-    (params.gameplay.seatId
-      ? params.gameplay.seatId
-      : asSeatId(params.gameplay.playerId));
+  const seatId = params.session.seatId ?? params.gameplay.seatId;
   return {
     socketId: params.session.socketId,
     seatId,
-    playerId: seatId,
     participantKey: params.participantKey ?? params.session.userId ?? seatId,
     name: params.gameplay.name,
     userId: params.session.userId,

--- a/mei-tra-backend/src/types/room.types.ts
+++ b/mei-tra-backend/src/types/room.types.ts
@@ -11,8 +11,7 @@ export enum RoomStatus {
 }
 
 export interface RoomPlayer extends SessionUser, PlayerGameplayState {
-  /** @deprecated Use seatId. */
-  playerId: string;
+  seatId: SeatId;
   participantKey?: string;
   isReady: boolean;
   isHost: boolean;

--- a/mei-tra-backend/src/use-cases/__tests__/blow-phase-transition.helper.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/blow-phase-transition.helper.spec.ts
@@ -17,14 +17,14 @@ describe('transitionToPlayPhase', () => {
     const state: GameState = {
       players: [
         {
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Player 1',
           team: 0 as const,
           hand: ['H-7'],
           isPasser: false,
         },
         {
-          playerId: 'player-2',
+          seatId: asSeatId('player-2'),
           name: 'Player 2',
           team: 1 as const,
           hand: ['S-9'],
@@ -73,7 +73,7 @@ describe('transitionToPlayPhase', () => {
       players: [
         {
           socketId: 'socket-from-room',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Player 1',
           team: 0,
           hand: [],
@@ -138,7 +138,7 @@ describe('transitionToPlayPhase', () => {
       event: 'reveal-agari',
       payload: {
         agari: 'H-A',
-        seatId: 'player-1',
+        seatId: asSeatId('player-1'),
       },
     });
     const updatePhaseEvent = result.delayedEvents.find(
@@ -164,7 +164,7 @@ describe('transitionToPlayPhase', () => {
     const state: GameState = {
       players: [
         {
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Player 1',
           team: 0 as const,
           hand: ['J♠', 'J♣', 'J♥'],

--- a/mei-tra-backend/src/use-cases/__tests__/com-autoplay-stall-warning.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/com-autoplay-stall-warning.spec.ts
@@ -1,9 +1,10 @@
 import { Logger } from '@nestjs/common';
 import { ComAutoPlayUseCase } from '../com-autoplay.use-case';
 import { DomainPlayer } from '../../types/game.types';
+import { asSeatId } from '../../types/identity.types';
 
 const HUMAN: DomainPlayer = {
-  playerId: 'human-1',
+  seatId: asSeatId('human-1'),
   name: 'Human',
   hand: ['9♣'],
   team: 0,
@@ -17,7 +18,7 @@ const buildUseCase = (options: {
 }) => {
   const state = {
     players: [HUMAN],
-    currentPlayerId: options.currentPlayer?.playerId ?? null,
+    currentPlayerId: options.currentPlayer?.seatId ?? null,
     gamePhase: 'play',
     pendingBrokenHandReveal: null,
     playState: { currentField: null },

--- a/mei-tra-backend/src/use-cases/__tests__/create-room-with-chat.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/create-room-with-chat.spec.ts
@@ -15,7 +15,7 @@ describe('CreateRoomUseCase', () => {
   const userId = 'user-123';
   const hostPlayer: RoomPlayer = {
     socketId: '',
-    playerId: userId,
+    seatId: asSeatId(userId),
     userId,
     isAuthenticated: true,
     name: 'Test Player',

--- a/mei-tra-backend/src/use-cases/__tests__/game-event-instrumentation.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game-event-instrumentation.spec.ts
@@ -16,7 +16,7 @@ describe('Game event instrumentation', () => {
         settings: { pointsToWin: 7 },
         players: [
           {
-            playerId: 'host-1',
+            seatId: asSeatId('host-1'),
             hand: [],
             isPasser: false,
             hasBroken: false,
@@ -28,7 +28,7 @@ describe('Game event instrumentation', () => {
         getState: () => ({
           players: [
             {
-              playerId: 'host-1',
+              seatId: asSeatId('host-1'),
               team: 0,
               hand: [],
               isPasser: false,
@@ -76,12 +76,12 @@ describe('Game event instrumentation', () => {
     const state = {
       players: [
         {
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           userId: 'user-1',
           hand: ['AS'],
         },
         {
-          playerId: 'player-2',
+          seatId: asSeatId('player-2'),
           userId: 'user-2',
           hand: [],
         },
@@ -139,7 +139,7 @@ describe('Game event instrumentation', () => {
         id: 'room-1',
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             team: 0,
             hand: [],

--- a/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/game.use-cases.spec.ts
@@ -101,7 +101,7 @@ describe('Game Use Cases', () => {
     const determineFieldWinnerMock = jest.fn<
       ReturnType<IPlayService['determineFieldWinner']>,
       Parameters<IPlayService['determineFieldWinner']>
-    >((_, players) => players.find((p) => p.playerId === winnerSeatId) || null);
+    >((_, players) => players.find((p) => p.seatId === winnerSeatId) || null);
 
     const mock: Partial<jest.Mocked<IPlayService>> = {
       determineFieldWinner: determineFieldWinnerMock,
@@ -131,7 +131,7 @@ describe('Game Use Cases', () => {
   const basePlayers: RoomPlayer[] = [
     {
       socketId: 'socket-1',
-      playerId: 'player-1',
+      seatId: asSeatId('player-1'),
       name: 'Player 1',
       team: 0 as const,
       hand: [],
@@ -143,7 +143,7 @@ describe('Game Use Cases', () => {
     },
     {
       socketId: 'socket-2',
-      playerId: 'player-2',
+      seatId: asSeatId('player-2'),
       name: 'Player 2',
       team: 1 as const,
       hand: [],
@@ -185,7 +185,7 @@ describe('Game Use Cases', () => {
         players: [
           {
             ...basePlayers[0],
-            playerId: 'user-1',
+            seatId: asSeatId('user-1'),
             userId: 'user-1',
             isAuthenticated: true,
           },
@@ -255,7 +255,7 @@ describe('Game Use Cases', () => {
       const useCase = new JoinRoomUseCase(roomService);
       const joinedPlayer: RoomPlayer = {
         ...basePlayers[0],
-        playerId: 'seat-1',
+        seatId: asSeatId('seat-1'),
         userId: 'user-1',
         isAuthenticated: true,
       };
@@ -427,7 +427,7 @@ describe('Game Use Cases', () => {
       const room: Room = { ...baseRoom, status: RoomStatus.PLAYING };
       const statePlayers: DomainPlayer[] = [
         {
-          playerId: 'player-2',
+          seatId: asSeatId('player-2'),
           name: 'Player 2',
           team: 1 as const,
           hand: [],
@@ -488,7 +488,7 @@ describe('Game Use Cases', () => {
       expect(result.success).toBe(true);
       expect(result.data?.updatedPlayers).toEqual([
         expect.objectContaining({
-          seatId: 'player-2',
+          seatId: asSeatId('player-2'),
           socketId: 'socket-2',
           name: 'Player 2',
           team: 1,
@@ -519,7 +519,7 @@ describe('Game Use Cases', () => {
         players: [
           {
             socketId: 'com-0',
-            playerId: 'com-0',
+            seatId: asSeatId('com-0'),
             name: 'COM',
             team: 0 as const,
             hand: [],
@@ -532,7 +532,7 @@ describe('Game Use Cases', () => {
           },
           {
             socketId: 'socket-2',
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'Player 2',
             team: 1 as const,
             hand: [],
@@ -549,7 +549,7 @@ describe('Game Use Cases', () => {
         players: [
           {
             socketId: 'com-0',
-            playerId: 'com-0',
+            seatId: asSeatId('com-0'),
             name: 'COM',
             team: 0 as const,
             hand: [],
@@ -558,7 +558,7 @@ describe('Game Use Cases', () => {
           },
           {
             socketId: 'socket-2',
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'Player 2',
             team: 1 as const,
             hand: [],
@@ -589,19 +589,19 @@ describe('Game Use Cases', () => {
       expect(result.success).toBe(true);
       expect(result.data?.updatedPlayers).toEqual([
         expect.objectContaining({
-          seatId: 'com-0',
+          seatId: asSeatId('com-0'),
           socketId: 'com-0',
           isHost: false,
         }),
         expect.objectContaining({
-          seatId: 'player-2',
+          seatId: asSeatId('player-2'),
           socketId: 'socket-2',
           isHost: true,
         }),
       ]);
       expect(result.data?.updatedPlayers).toContainEqual(
         expect.objectContaining({
-          seatId: 'player-2',
+          seatId: asSeatId('player-2'),
           isHost: true,
         }),
       );
@@ -640,7 +640,7 @@ describe('Game Use Cases', () => {
           ...baseRoom.players,
           {
             socketId: 'socket-2',
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'Player 2',
             team: 1 as const,
             hand: ['H2', 'D3'],
@@ -655,14 +655,14 @@ describe('Game Use Cases', () => {
 
       const statePlayers: DomainPlayer[] = [
         {
-          playerId: 'com-0',
+          seatId: asSeatId('com-0'),
           name: 'COM',
           team: 0 as Team,
           hand: [],
           isPasser: false,
         },
         {
-          playerId: 'player-2',
+          seatId: asSeatId('player-2'),
           name: 'Player 2',
           team: 1 as const,
           hand: ['H2', 'D3'],
@@ -695,11 +695,11 @@ describe('Game Use Cases', () => {
       expect(result.success).toBe(true);
       expect(result.data?.updatedPlayers).toEqual([
         expect.objectContaining({
-          seatId: expect.stringContaining('com-'),
+          seatId: asSeatId(expect.stringContaining('com-')),
           team: 0,
         }),
         expect.objectContaining({
-          seatId: 'player-2',
+          seatId: asSeatId('player-2'),
           socketId: 'socket-2',
           team: 1,
         }),
@@ -710,7 +710,7 @@ describe('Game Use Cases', () => {
       expect(leaveRoomMock).toHaveBeenCalledWith(playingRoom.id, 'player-1');
 
       // Verify com player is in the list
-      expect(statePlayers[0].playerId).toContain('com-');
+      expect(statePlayers[0].seatId).toContain('com-');
     });
   });
 
@@ -745,14 +745,14 @@ describe('Game Use Cases', () => {
       } = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             team: 0 as const,
             hand: [],
             isPasser: false,
           },
           {
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'Player 2',
             team: 1 as const,
             hand: [],
@@ -820,14 +820,14 @@ describe('Game Use Cases', () => {
       const state = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             team: 0 as const,
             hand: [],
             isPasser: false,
           },
           {
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'Player 2',
             team: 1 as const,
             hand: [],
@@ -892,7 +892,7 @@ describe('Game Use Cases', () => {
         players: [
           {
             socketId: 'socket-1',
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             team: 0 as const,
             hand: [],
@@ -904,7 +904,7 @@ describe('Game Use Cases', () => {
           },
           {
             socketId: 'socket-2',
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'Player 2',
             team: 0 as const,
             hand: [],
@@ -916,7 +916,7 @@ describe('Game Use Cases', () => {
           },
           {
             socketId: 'socket-3',
-            playerId: 'player-3',
+            seatId: asSeatId('player-3'),
             name: 'Player 3',
             team: 1 as const,
             hand: [],
@@ -928,7 +928,7 @@ describe('Game Use Cases', () => {
           },
           {
             socketId: 'socket-4',
-            playerId: 'player-4',
+            seatId: asSeatId('player-4'),
             name: 'Player 4',
             team: 1 as const,
             hand: [],
@@ -944,21 +944,21 @@ describe('Game Use Cases', () => {
       const state = {
         players: [
           {
-            playerId: 'player-4',
+            seatId: asSeatId('player-4'),
             name: 'Player 4',
             team: 1 as const,
             hand: ['H4'],
             isPasser: false,
           },
           {
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'Player 2',
             team: 1 as const,
             hand: ['H2'],
             isPasser: false,
           },
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             team: 1 as const,
             hand: ['H1'],
@@ -1014,7 +1014,7 @@ describe('Game Use Cases', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(state.players.map((player) => player.playerId)).toEqual([
+      expect(state.players.map((player) => player.seatId)).toEqual([
         'player-1',
         'player-3',
         'player-2',
@@ -1037,7 +1037,7 @@ describe('Game Use Cases', () => {
       const persistedPlayers = persistRosterMock.mock.calls[0]?.[0] as
         | RoomPlayer[]
         | undefined;
-      expect(persistedPlayers?.map((player) => player.playerId)).toEqual([
+      expect(persistedPlayers?.map((player) => player.seatId)).toEqual([
         'player-1',
         'player-3',
         'player-2',
@@ -1045,7 +1045,7 @@ describe('Game Use Cases', () => {
       ]);
       expect(
         persistedPlayers?.map((player) => ({
-          playerId: player.playerId,
+          playerId: player.seatId,
           seatIndex: player.seatIndex,
         })),
       ).toEqual([
@@ -1074,7 +1074,7 @@ describe('Game Use Cases', () => {
           players: [
             {
               socketId: 'socket-1',
-              playerId: 'player-1',
+              seatId: asSeatId('player-1'),
               name: 'Player 1',
               team: 0 as const,
               hand: [],
@@ -1175,7 +1175,7 @@ describe('Game Use Cases', () => {
           },
           {
             socketId: 'socket-3',
-            playerId: 'player-3',
+            seatId: asSeatId('player-3'),
             name: 'Player 3',
             team: 0 as const,
             hand: [],
@@ -1187,7 +1187,7 @@ describe('Game Use Cases', () => {
           } as RoomPlayer,
           {
             socketId: 'socket-4',
-            playerId: 'player-4',
+            seatId: asSeatId('player-4'),
             name: 'Player 4',
             team: 1 as const,
             hand: [],
@@ -1242,9 +1242,9 @@ describe('Game Use Cases', () => {
           (players ?? []).map((player) => ({
             socketId:
               room.players.find(
-                (roomPlayer) => roomPlayer.playerId === player.playerId,
+                (roomPlayer) => roomPlayer.seatId === player.seatId,
               )?.socketId ?? '',
-            playerId: player.playerId,
+            seatId: asSeatId(player.seatId),
             name: player.name,
             hand: [...player.hand],
             team: player.team,
@@ -1252,7 +1252,7 @@ describe('Game Use Cases', () => {
             isCOM: player.isCOM,
             isHost:
               room.players.find(
-                (roomPlayer) => roomPlayer.playerId === player.playerId,
+                (roomPlayer) => roomPlayer.seatId === player.seatId,
               )?.isHost ?? false,
           })),
         ),
@@ -1290,7 +1290,7 @@ describe('Game Use Cases', () => {
           ...(baseRoom.players.map((p) => ({ ...p })) as RoomPlayer[]),
           {
             socketId: 'socket-3',
-            playerId: 'player-3',
+            seatId: asSeatId('player-3'),
             name: 'Player 3',
             team: 0 as const,
             hand: [],
@@ -1335,7 +1335,7 @@ describe('Game Use Cases', () => {
           },
           {
             socketId: 'com-1',
-            playerId: 'com-1',
+            seatId: asSeatId('com-1'),
             name: 'COM 1',
             team: 1 as const,
             hand: [],
@@ -1348,7 +1348,7 @@ describe('Game Use Cases', () => {
           } as RoomPlayer,
           {
             socketId: 'com-2',
-            playerId: 'com-2',
+            seatId: asSeatId('com-2'),
             name: 'COM 2',
             team: 1 as const,
             hand: [],
@@ -1389,7 +1389,7 @@ describe('Game Use Cases', () => {
       const updatedRoom = {
         ...room,
         players: room.players.map((p) =>
-          p.playerId === 'player-2' ? { ...p, team: 0 as Team } : p,
+          p.seatId === 'player-2' ? { ...p, team: 0 as Team } : p,
         ),
       };
 
@@ -1411,8 +1411,7 @@ describe('Game Use Cases', () => {
         'player-2': { team: 0 },
       });
       expect(
-        result.updatedRoom?.players.find((p) => p.playerId === 'player-2')
-          ?.team,
+        result.updatedRoom?.players.find((p) => p.seatId === 'player-2')?.team,
       ).toBe(0);
     });
   });
@@ -1421,7 +1420,7 @@ describe('Game Use Cases', () => {
     const buildRequiredBrokenState = () => ({
       players: [
         {
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Player 1',
           hand: ['J♠', 'J♣', 'J♥', 'J♦'],
           team: 0 as Team,
@@ -1659,14 +1658,14 @@ describe('Game Use Cases', () => {
       } = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['C1', 'C2'],
             team: 0,
             isPasser: false,
           },
           {
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'Player 2',
             hand: ['D1', 'D2'],
             team: 1,
@@ -1687,13 +1686,12 @@ describe('Game Use Cases', () => {
         }),
         findPlayerByActorId: jest.fn((actorId: string) =>
           actorId === 'user-1'
-            ? (state.players.find((player) => player.playerId === 'player-1') ??
+            ? (state.players.find((player) => player.seatId === 'player-1') ??
               null)
             : actorId === 'user-2'
-              ? (state.players.find(
-                  (player) => player.playerId === 'player-2',
-                ) ?? null)
-              : (state.players.find((player) => player.playerId === actorId) ??
+              ? (state.players.find((player) => player.seatId === 'player-2') ??
+                null)
+              : (state.players.find((player) => player.seatId === actorId) ??
                 null),
         ),
         isPlayerTurn: jest.fn(
@@ -1714,7 +1712,7 @@ describe('Game Use Cases', () => {
         (evt) => evt.event === 'card-played',
       );
       expect(cardPlayedEvent?.payload).toMatchObject({
-        seatId: 'player-1',
+        seatId: asSeatId('player-1'),
         card: 'C1',
         field: expect.objectContaining({
           cards: ['C1'],
@@ -1748,7 +1746,7 @@ describe('Game Use Cases', () => {
       const state = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['C1'],
             team: 0 as Team,
@@ -1803,7 +1801,7 @@ describe('Game Use Cases', () => {
       } = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['C4'],
             team: 0,
@@ -1822,9 +1820,9 @@ describe('Game Use Cases', () => {
         nextTurn: jest.fn(),
         findPlayerByActorId: jest.fn((actorId: string) =>
           actorId === 'user-1'
-            ? (state.players.find((player) => player.playerId === 'player-1') ??
+            ? (state.players.find((player) => player.seatId === 'player-1') ??
               null)
-            : (state.players.find((player) => player.playerId === actorId) ??
+            : (state.players.find((player) => player.seatId === actorId) ??
               null),
         ),
         isPlayerTurn: jest.fn(
@@ -1854,7 +1852,7 @@ describe('Game Use Cases', () => {
       const state = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['C1'],
             team: 0 as Team,
@@ -1862,7 +1860,7 @@ describe('Game Use Cases', () => {
             isCOM: false,
           },
           {
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'Player 2',
             hand: ['D1'],
             team: 1 as Team,
@@ -1923,7 +1921,7 @@ describe('Game Use Cases', () => {
       expect(cardPlayedEvent?.payload).toMatchObject({
         players: expect.arrayContaining([
           expect.objectContaining({
-            seatId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'COM',
             socketId: '',
             isCOM: true,
@@ -1948,7 +1946,7 @@ describe('Game Use Cases', () => {
       const state = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['5♠', 'A♥'],
             team: 0 as Team,
@@ -1996,14 +1994,14 @@ describe('Game Use Cases', () => {
       const state = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['A♥'],
             team: 0 as Team,
             isPasser: false,
           },
           {
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'Player 2',
             hand: [],
             team: 1 as Team,
@@ -2052,7 +2050,7 @@ describe('Game Use Cases', () => {
       const state = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['JOKER', 'A♥'],
             team: 0 as Team,
@@ -2128,7 +2126,7 @@ describe('Game Use Cases', () => {
       );
 
       const comPlayer: DomainPlayer = {
-        playerId: 'com-0',
+        seatId: asSeatId('com-0'),
         name: 'COM',
         hand: ['9♣'],
         team: 0,
@@ -2150,7 +2148,7 @@ describe('Game Use Cases', () => {
         players: [
           comPlayer,
           {
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'Player 2',
             hand: ['7♠'],
             team: 1 as const,
@@ -2266,7 +2264,7 @@ describe('Game Use Cases', () => {
       );
 
       const comPlayer: DomainPlayer = {
-        playerId: 'com-timeout-1',
+        seatId: asSeatId('com-timeout-1'),
         name: 'COM',
         hand: ['6♥', 'A♠'],
         team: 0,
@@ -2279,7 +2277,7 @@ describe('Game Use Cases', () => {
           comPlayer,
           {
             socketId: 'socket-2',
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             userId: 'user-2',
             name: 'Player 2',
             hand: ['7♠'],
@@ -2405,7 +2403,7 @@ describe('Game Use Cases', () => {
       );
 
       const comPlayer: DomainPlayer = {
-        playerId: 'com-0',
+        seatId: asSeatId('com-0'),
         name: 'COM',
         hand: ['JOKER', 'J♥', 'A♥'],
         team: 0,
@@ -2508,7 +2506,7 @@ describe('Game Use Cases', () => {
       );
 
       const comPlayer: DomainPlayer = {
-        playerId: 'com-0',
+        seatId: asSeatId('com-0'),
         name: 'COM',
         hand: ['J♠', 'J♣', 'J♥', 'J♦'],
         team: 0,
@@ -2574,7 +2572,7 @@ describe('Game Use Cases', () => {
         players: [
           {
             socketId: 'com-timeout-1',
-            playerId: 'com-timeout-1',
+            seatId: asSeatId('com-timeout-1'),
             name: 'COM',
             hand: ['6♥', 'A♠'],
             team: 0 as const,
@@ -2583,7 +2581,7 @@ describe('Game Use Cases', () => {
           },
           {
             socketId: 'socket-2',
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             userId: 'user-2',
             name: 'Player 2',
             hand: ['7♠'],
@@ -2610,7 +2608,7 @@ describe('Game Use Cases', () => {
         isPlayerTurn: jest.fn(() => true),
         findPlayerByActorId: jest.fn(
           (actorId: string) =>
-            state.players.find((player) => player.playerId === actorId) ?? null,
+            state.players.find((player) => player.seatId === actorId) ?? null,
         ),
         saveState: jest.fn(),
       } as unknown as GameStateService;
@@ -2652,7 +2650,7 @@ describe('Game Use Cases', () => {
       } = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['C1'],
             team: 0,
@@ -2660,7 +2658,7 @@ describe('Game Use Cases', () => {
             hasRequiredBroken: false,
           },
           {
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'Player 2',
             hand: ['D1'],
             team: 1,
@@ -2688,13 +2686,12 @@ describe('Game Use Cases', () => {
         }),
         findPlayerByActorId: jest.fn((actorId: string) =>
           actorId === 'user-1'
-            ? (state.players.find((player) => player.playerId === 'player-1') ??
+            ? (state.players.find((player) => player.seatId === 'player-1') ??
               null)
             : actorId === 'user-2'
-              ? (state.players.find(
-                  (player) => player.playerId === 'player-2',
-                ) ?? null)
-              : (state.players.find((player) => player.playerId === actorId) ??
+              ? (state.players.find((player) => player.seatId === 'player-2') ??
+                null)
+              : (state.players.find((player) => player.seatId === actorId) ??
                 null),
         ),
       } as unknown as GameStateService;
@@ -2747,7 +2744,7 @@ describe('Game Use Cases', () => {
       } = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['C1'],
             team: 0,
@@ -2755,7 +2752,7 @@ describe('Game Use Cases', () => {
             hasRequiredBroken: true,
           },
           {
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'Player 2',
             hand: ['D1'],
             team: 1,
@@ -2788,13 +2785,12 @@ describe('Game Use Cases', () => {
         dealCards: dealCardsMock,
         findPlayerByActorId: jest.fn((actorId: string) =>
           actorId === 'user-1'
-            ? (state.players.find((player) => player.playerId === 'player-1') ??
+            ? (state.players.find((player) => player.seatId === 'player-1') ??
               null)
             : actorId === 'user-2'
-              ? (state.players.find(
-                  (player) => player.playerId === 'player-2',
-                ) ?? null)
-              : (state.players.find((player) => player.playerId === actorId) ??
+              ? (state.players.find((player) => player.seatId === 'player-2') ??
+                null)
+              : (state.players.find((player) => player.seatId === actorId) ??
                 null),
         ),
         saveState: jest.fn(),
@@ -2812,7 +2808,7 @@ describe('Game Use Cases', () => {
       expect(preparation.delayMs).toBe(3000);
       expect(preparation.followUp).toBeDefined();
       expect(state.pendingBrokenHandReveal).toEqual({
-        seatId: 'player-1',
+        seatId: asSeatId('player-1'),
         handSnapshot: ['C1'],
         startedAt: expect.any(Number),
       });
@@ -2851,7 +2847,7 @@ describe('Game Use Cases', () => {
       const state = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['C1'],
             team: 0,
@@ -2894,7 +2890,7 @@ describe('Game Use Cases', () => {
       const state = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['C1'],
             team: 0,
@@ -2944,7 +2940,7 @@ describe('Game Use Cases', () => {
       const state = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['C1'],
             team: 0,
@@ -2998,14 +2994,14 @@ describe('Game Use Cases', () => {
       } = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['C1'],
             team: 0,
             isPasser: false,
           },
           {
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'Player 2',
             hand: ['D1'],
             team: 1,
@@ -3013,7 +3009,7 @@ describe('Game Use Cases', () => {
             hasRequiredBroken: false,
           },
           {
-            playerId: 'player-3',
+            seatId: asSeatId('player-3'),
             name: 'Player 3',
             hand: ['H1'],
             team: 0,
@@ -3021,7 +3017,7 @@ describe('Game Use Cases', () => {
             hasRequiredBroken: true,
           },
           {
-            playerId: 'player-4',
+            seatId: asSeatId('player-4'),
             name: 'Player 4',
             hand: ['S1'],
             team: 1,
@@ -3084,7 +3080,7 @@ describe('Game Use Cases', () => {
         dealCards: dealCardsMock,
         findPlayerByActorId: jest.fn(
           (actorId: string) =>
-            state.players.find((player) => player.playerId === actorId) ?? null,
+            state.players.find((player) => player.seatId === actorId) ?? null,
         ),
         saveState: jest.fn(),
       } as unknown as GameStateService;
@@ -3149,7 +3145,7 @@ describe('Game Use Cases', () => {
       } = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['C1'],
             team: 0,
@@ -3182,7 +3178,7 @@ describe('Game Use Cases', () => {
 
       expect(preparation.success).toBe(true);
       expect(state.pendingBrokenHandReveal).toEqual({
-        seatId: 'player-1',
+        seatId: asSeatId('player-1'),
         handSnapshot: ['C1'],
         startedAt: expect.any(Number),
       });
@@ -3215,7 +3211,7 @@ describe('Game Use Cases', () => {
       } = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['new-card'],
             team: 0,
@@ -3285,7 +3281,7 @@ describe('Game Use Cases', () => {
       } = {
         players: [
           {
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'Player 1',
             hand: ['2♣', '3♦'],
             team: 0,
@@ -3315,7 +3311,7 @@ describe('Game Use Cases', () => {
         }),
         findPlayerByActorId: jest.fn(
           (actorId: string) =>
-            state.players.find((player) => player.playerId === actorId) ?? null,
+            state.players.find((player) => player.seatId === actorId) ?? null,
         ),
         saveState: jest.fn(),
       } as unknown as GameStateService;
@@ -3353,28 +3349,28 @@ describe('Game Use Cases', () => {
       players: [
         {
           socketId: 'socket-1',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Player 1',
           hand: ['A', 'B'],
           team: 0 as const,
           isPasser: false,
         },
         {
-          playerId: 'player-2',
+          seatId: asSeatId('player-2'),
           name: 'Player 2',
           hand: ['C', 'D'],
           team: 1 as const,
           isPasser: false,
         },
         {
-          playerId: 'player-3',
+          seatId: asSeatId('player-3'),
           name: 'Player 3',
           hand: [],
           team: 0 as const,
           isPasser: false,
         },
         {
-          playerId: 'player-4',
+          seatId: asSeatId('player-4'),
           name: 'Player 4',
           hand: [],
           team: 1 as const,
@@ -3393,7 +3389,7 @@ describe('Game Use Cases', () => {
       },
       blowState: {
         currentHighestDeclaration: {
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           team: 0 as Team,
           trumpType: 'tra',
           numberOfPairs: 6,
@@ -3573,7 +3569,7 @@ describe('Game Use Cases', () => {
       });
       state.blowState.currentHighestDeclaration = {
         ...state.blowState.currentHighestDeclaration,
-        playerId: 'player-2',
+        seatId: asSeatId('player-2'),
         team: 1,
       };
 
@@ -3595,7 +3591,7 @@ describe('Game Use Cases', () => {
         completeField: jest.fn(
           (completedField: Field, winnerSeatId: string) => {
             const winner = state.players.find(
-              (player) => player.playerId === winnerSeatId,
+              (player) => player.seatId === winnerSeatId,
             );
             if (!winner) {
               return null;
@@ -3758,7 +3754,7 @@ describe('Game Use Cases', () => {
       const state = buildState();
       state.blowState.currentHighestDeclaration = {
         ...state.blowState.currentHighestDeclaration,
-        playerId: 'player-2',
+        seatId: asSeatId('player-2'),
         team: 1,
       };
       state.players[0].hand = [];
@@ -3815,7 +3811,7 @@ describe('Game Use Cases', () => {
       const state = buildState();
       state.blowState.currentHighestDeclaration = {
         ...state.blowState.currentHighestDeclaration,
-        playerId: 'stale-player-id',
+        seatId: asSeatId('stale-player-id'),
         team: 1,
       };
       state.players[0].hand = [];
@@ -3871,7 +3867,7 @@ describe('Game Use Cases', () => {
       const state = buildState();
       state.blowState.currentHighestDeclaration = {
         ...state.blowState.currentHighestDeclaration,
-        playerId: 'player-2',
+        seatId: asSeatId('player-2'),
         team: 1,
       };
       state.players[0].hand = [];
@@ -4007,7 +4003,7 @@ describe('Game Use Cases', () => {
       });
       roomService.getRoomGameState.mockResolvedValue({
         findSessionUserByPlayerId: jest.fn().mockReturnValue({
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           socketId: 'socket-1',
           name: 'Player 1',
           userId: 'user-1',
@@ -4120,7 +4116,7 @@ describe('Game Use Cases', () => {
       const authService = createAuthServiceMock();
       const users = [] as Array<{
         socketId: string;
-        playerId: string;
+        seatId: ReturnType<typeof asSeatId>;
         name: string;
         userId?: string;
         isAuthenticated?: boolean;
@@ -4130,7 +4126,7 @@ describe('Game Use Cases', () => {
         upsertSessionUser: jest.fn(() => {
           users.push({
             socketId: 'socket-1',
-            playerId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'User Display',
             userId: 'user-1',
             isAuthenticated: true,

--- a/mei-tra-backend/src/use-cases/__tests__/moderate-player.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/moderate-player.use-case.spec.ts
@@ -11,7 +11,7 @@ describe('ModeratePlayerUseCase', () => {
     status: RoomStatus.PLAYING,
     players: [
       {
-        playerId: 'host',
+        seatId: asSeatId('host'),
         isCOM: false,
         socketId: 'host-socket',
         name: 'Host',
@@ -20,7 +20,7 @@ describe('ModeratePlayerUseCase', () => {
         isPasser: false,
       },
       {
-        playerId: 'target',
+        seatId: asSeatId('target'),
         isCOM: false,
         socketId: '',
         name: 'Target',
@@ -53,7 +53,7 @@ describe('ModeratePlayerUseCase', () => {
         getState: () => ({
           players: [
             {
-              playerId: 'target',
+              seatId: asSeatId('target'),
               name: 'Target',
               hand: [],
               team: 1,

--- a/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/reconnection.use-case.spec.ts
@@ -97,7 +97,7 @@ describe('ReconnectionUseCase', () => {
       getState: () => ({
         players: [
           {
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             name: 'User 1',
             team: 0,
             hand: ['A♠'],
@@ -106,7 +106,7 @@ describe('ReconnectionUseCase', () => {
             hasRequiredBroken: false,
           },
           {
-            playerId: 'p2',
+            seatId: asSeatId('p2'),
             name: 'User 2',
             team: 1,
             hand: ['K♠'],
@@ -148,7 +148,7 @@ describe('ReconnectionUseCase', () => {
         settings: { teamNames: undefined },
         players: [
           {
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             socketId: 'stale-socket',
             userId: 'user-1',
             isAuthenticated: true,
@@ -236,7 +236,7 @@ describe('ReconnectionUseCase', () => {
       getState: () => ({
         players: [
           {
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             name: 'COM',
             team: 0,
             hand: ['A♠'],
@@ -278,7 +278,7 @@ describe('ReconnectionUseCase', () => {
       settings: { teamNames: undefined },
       players: [
         {
-          playerId: 'seat-1',
+          seatId: asSeatId('seat-1'),
           socketId: '',
           userId: 'user-1',
           isAuthenticated: true,
@@ -358,7 +358,7 @@ describe('ReconnectionUseCase', () => {
       getState: () => ({
         players: [
           {
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             name: 'User 1',
             team: 0,
             hand: ['A♠'],
@@ -367,7 +367,7 @@ describe('ReconnectionUseCase', () => {
             hasRequiredBroken: false,
           },
           {
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'User 2',
             team: 1,
             hand: ['K♠'],
@@ -416,7 +416,7 @@ describe('ReconnectionUseCase', () => {
         settings: { teamNames: undefined },
         players: [
           {
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             socketId: 'socket-1',
             userId: 'user-1',
             isAuthenticated: true,
@@ -489,7 +489,7 @@ describe('ReconnectionUseCase', () => {
       getState: () => ({
         players: [
           {
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             name: 'User 1',
             team: 0,
             hand: ['A♠'],
@@ -498,7 +498,7 @@ describe('ReconnectionUseCase', () => {
             hasRequiredBroken: false,
           },
           {
-            playerId: 'player-2',
+            seatId: asSeatId('player-2'),
             name: 'User 2',
             team: 1,
             hand: ['K♠'],
@@ -542,7 +542,7 @@ describe('ReconnectionUseCase', () => {
         settings: { teamNames: undefined },
         players: [
           {
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             socketId: 'socket-1',
             userId: 'user-1',
             isAuthenticated: true,
@@ -584,7 +584,7 @@ describe('ReconnectionUseCase', () => {
   it('reconciles persisted players before reconnecting to a waiting room', async () => {
     const roomPlayers = [
       {
-        playerId: 'p1',
+        seatId: asSeatId('p1'),
         socketId: 'stale-socket',
         userId: 'user-1',
         isAuthenticated: true,
@@ -696,7 +696,7 @@ describe('ReconnectionUseCase', () => {
   it('prefers the unique authenticated room seat over a stale waiting-room session', async () => {
     const roomPlayers = [
       {
-        playerId: 'seat-1',
+        seatId: asSeatId('seat-1'),
         socketId: 'stale-socket',
         userId: 'user-1',
         isAuthenticated: true,
@@ -709,7 +709,7 @@ describe('ReconnectionUseCase', () => {
         joinedAt: new Date(),
       },
       {
-        playerId: 'seat-2',
+        seatId: asSeatId('seat-2'),
         socketId: 'other-socket',
         userId: 'user-2',
         isAuthenticated: true,
@@ -782,7 +782,7 @@ describe('ReconnectionUseCase', () => {
       getState: jest.fn(() => ({
         players: [
           {
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             name: 'User 1',
             team: 0,
             hand: [],
@@ -795,11 +795,11 @@ describe('ReconnectionUseCase', () => {
     const roomService = {
       getRoom: jest.fn().mockResolvedValue({
         id: 'room-stale',
-        hostId: 'seat-1',
+        hostSeatId: asSeatId('seat-1'),
         status: RoomStatus.PLAYING,
         players: [
           {
-            playerId: 'seat-1',
+            seatId: asSeatId('seat-1'),
             userId: 'user-1',
             isAuthenticated: true,
           },
@@ -814,7 +814,7 @@ describe('ReconnectionUseCase', () => {
         membership: {
           userId: 'user-1',
           roomId: 'room-current',
-          playerId: 'seat-current',
+          seatId: asSeatId('seat-current'),
           status: 'active',
           membershipVersion: 4,
           transitionId: 'transition-current',

--- a/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/update-auth.use-case.spec.ts
@@ -71,7 +71,7 @@ describe('UpdateAuthUseCase', () => {
       players: [
         {
           socketId: 'socket-1',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'Old Name',
           userId: 'user-1',
           isAuthenticated: true,
@@ -85,16 +85,14 @@ describe('UpdateAuthUseCase', () => {
       getState: jest.fn(() => roomState),
       findPlayerByActorId: jest.fn((actorId: string) =>
         actorId === 'user-1'
-          ? (roomState.players.find(
-              (player) => player.playerId === 'player-1',
-            ) ?? null)
+          ? (roomState.players.find((player) => player.seatId === 'player-1') ??
+            null)
           : null,
       ),
       findPlayerBySocketId: jest.fn((socketId: string) =>
         socketId === 'socket-1'
-          ? (roomState.players.find(
-              (player) => player.playerId === 'player-1',
-            ) ?? null)
+          ? (roomState.players.find((player) => player.seatId === 'player-1') ??
+            null)
           : null,
       ),
       applyPlayerConnectionState: jest
@@ -118,7 +116,7 @@ describe('UpdateAuthUseCase', () => {
       players: [
         {
           socketId: 'socket-1',
-          playerId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'User Display',
           userId: 'user-1',
           isAuthenticated: true,
@@ -165,7 +163,7 @@ describe('UpdateAuthUseCase', () => {
     expect(gameState.upsertSessionUser).toHaveBeenCalledWith(
       expect.objectContaining({
         socketId: 'socket-1',
-        seatId: 'player-1',
+        seatId: asSeatId('player-1'),
         name: 'User Display',
         userId: 'user-1',
         isAuthenticated: true,
@@ -193,7 +191,7 @@ describe('UpdateAuthUseCase', () => {
         payload: [
           expect.objectContaining({
             socketId: 'socket-1',
-            seatId: 'player-1',
+            seatId: asSeatId('player-1'),
             name: 'User Display',
             userId: 'user-1',
             isAuthenticated: true,
@@ -224,7 +222,7 @@ describe('UpdateAuthUseCase', () => {
       players: [
         {
           socketId: 'socket-1',
-          seatId: 'player-1',
+          seatId: asSeatId('player-1'),
           name: 'User Display',
         },
       ],

--- a/mei-tra-backend/src/use-cases/__tests__/watch-room.use-case.spec.ts
+++ b/mei-tra-backend/src/use-cases/__tests__/watch-room.use-case.spec.ts
@@ -11,17 +11,17 @@ import { asSeatId } from '../../types/identity.types';
 import { Room, RoomStatus } from '../../types/room.types';
 
 describe('WatchRoomUseCase', () => {
-  const player = (playerId: string, team: Team, hand: string[]) => ({
-    socketId: `${playerId}-socket`,
-    playerId,
-    name: playerId,
-    userId: playerId,
+  const player = (seatId: string, team: Team, hand: string[]) => ({
+    socketId: `${seatId}-socket`,
+    seatId: asSeatId(seatId),
+    name: seatId,
+    userId: seatId,
     isAuthenticated: true,
     team,
     hand,
     isPasser: false,
     isReady: true,
-    isHost: playerId === 'p1',
+    isHost: seatId === 'p1',
     joinedAt: new Date(),
   });
 
@@ -62,7 +62,7 @@ describe('WatchRoomUseCase', () => {
 
   const gameState = (roomValue: Room): GameState => ({
     players: roomValue.players.map((roomPlayer) => ({
-      playerId: roomPlayer.playerId,
+      seatId: roomPlayer.seatId,
       name: roomPlayer.name,
       team: roomPlayer.team,
       hand: [...roomPlayer.hand],
@@ -71,7 +71,7 @@ describe('WatchRoomUseCase', () => {
       hasRequiredBroken: false,
     })),
     deck: [],
-    currentSeatId: asSeatId(roomValue.players[0].playerId),
+    currentSeatId: asSeatId(roomValue.players[0].seatId),
     gamePhase: 'play',
     blowState: blowState(),
     playState: {
@@ -100,10 +100,10 @@ describe('WatchRoomUseCase', () => {
       getTransportPlayers: jest.fn(
         (players: DomainPlayer[]): TransportPlayer[] =>
           players.map((domainPlayer) => ({
-            socketId: `${domainPlayer.playerId}-socket`,
-            seatId: asSeatId(domainPlayer.playerId),
+            socketId: `${domainPlayer.seatId}-socket`,
+            seatId: asSeatId(domainPlayer.seatId),
             name: domainPlayer.name,
-            userId: domainPlayer.playerId,
+            userId: domainPlayer.seatId,
             isAuthenticated: true,
             team: domainPlayer.team,
             hand: [...domainPlayer.hand],

--- a/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
+++ b/mei-tra-backend/src/use-cases/blow-phase-transition.helper.ts
@@ -40,7 +40,7 @@ export async function transitionToPlayPhase({
     state.blowState.declarations,
   );
   const winningPlayer = state.players.find(
-    (p) => p.playerId === highestDeclaration.seatId,
+    (p) => p.seatId === highestDeclaration.seatId,
   );
 
   if (!winningPlayer) {
@@ -56,7 +56,7 @@ export async function transitionToPlayPhase({
   const nextState = roomGameState.getState();
 
   nextState.blowState.currentTrump = highestDeclaration.trumpType;
-  setCurrentSeat(nextState, winningPlayer.playerId);
+  setCurrentSeat(nextState, winningPlayer.seatId);
 
   const events: GatewayEvent[] = buildPlayerSyncEvents(
     roomGameState,
@@ -79,7 +79,7 @@ export async function transitionToPlayPhase({
       scope: 'room',
       roomId,
       event: 'update-turn',
-      payload: asSeatId(winningPlayer.playerId),
+      payload: asSeatId(winningPlayer.seatId),
       delayMs: 3000,
     },
     {
@@ -92,18 +92,18 @@ export async function transitionToPlayPhase({
   ];
 
   const winningPlayerSession = roomGameState.findSessionUserByPlayerId(
-    winningPlayer.playerId,
+    winningPlayer.seatId,
   );
   const winningPlayerSocketId =
     winningPlayerSession?.socketId ??
-    room?.players.find((player) => player.playerId === winningPlayer.playerId)
+    room?.players.find((player) => player.seatId === winningPlayer.seatId)
       ?.socketId;
 
   if (state.agari && winningPlayerSocketId) {
     const revealAgariPayload: RevealAgariPayload = {
       agari: state.agari,
       message: 'Select a card from your hand as Negri',
-      seatId: asSeatId(winningPlayer.playerId),
+      seatId: asSeatId(winningPlayer.seatId),
     };
     delayedEvents.unshift({
       scope: 'socket',
@@ -117,12 +117,12 @@ export async function transitionToPlayPhase({
   await gameEventLogService?.log({
     roomId,
     actionType: 'play_phase_started',
-    actorSeatId: asSeatId(winningPlayer.playerId),
+    actorSeatId: asSeatId(winningPlayer.seatId),
     state: nextState,
     actionData: {
       currentHighestDeclaration: nextState.blowState.currentHighestDeclaration,
       currentTrump: nextState.blowState.currentTrump,
-      winnerSeatId: winningPlayer.playerId,
+      winnerSeatId: winningPlayer.seatId,
     },
   });
 

--- a/mei-tra-backend/src/use-cases/change-player-team.use-case.ts
+++ b/mei-tra-backend/src/use-cases/change-player-team.use-case.ts
@@ -26,9 +26,7 @@ export class ChangePlayerTeamUseCase implements IChangePlayerTeamUseCase {
       }
 
       // Find the requesting player
-      const requestingPlayer = room.players.find(
-        (p) => p.playerId === playerId,
-      );
+      const requestingPlayer = room.players.find((p) => p.seatId === playerId);
       if (!requestingPlayer) {
         return { success: false, error: 'Player not found in room' };
       }
@@ -52,7 +50,7 @@ export class ChangePlayerTeamUseCase implements IChangePlayerTeamUseCase {
           };
         }
 
-        const player = room.players.find((p) => p.playerId === playerId);
+        const player = room.players.find((p) => p.seatId === playerId);
         if (!player) {
           return {
             success: false,

--- a/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
+++ b/mei-tra-backend/src/use-cases/com-autoplay.use-case.ts
@@ -92,13 +92,13 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       this.logger.warn(
         `Turn unplayable in room ${roomId}: no current player resolved ` +
           `(currentSeatId=${resolveCurrentSeatId(state) ?? 'null'}, ` +
-          `roster=[${state.players.map((player) => player.playerId).join(', ')}])`,
+          `roster=[${state.players.map((player) => player.seatId).join(', ')}])`,
       );
       return;
     }
 
     const isConnected = Boolean(
-      gameState.getPlayerConnectionState(currentPlayer.playerId)?.socketId,
+      gameState.getPlayerConnectionState(currentPlayer.seatId)?.socketId,
     );
     if (isConnected) {
       return;
@@ -106,7 +106,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
 
     this.logger.warn(
       `Turn unplayable in room ${roomId}: auto-play skipped non-COM player ` +
-        `${currentPlayer.playerId} which has no live socket ` +
+        `${currentPlayer.seatId} which has no live socket ` +
         `(phase=${state.gamePhase}, currentSeatId=${resolveCurrentSeatId(state) ?? 'null'}, ` +
         `isCOM=${String(currentPlayer.isCOM)})`,
     );
@@ -167,7 +167,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
 
     if (
       state.playState?.negriCard == null &&
-      state.blowState.currentHighestDeclaration?.seatId === comPlayer.playerId
+      state.blowState.currentHighestDeclaration?.seatId === comPlayer.seatId
     ) {
       const negriCard = this.comStrategyService.chooseNegriCard(
         state,
@@ -186,7 +186,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       const negriResult: SelectNegriResponse =
         await this.selectNegriUseCase.execute({
           roomId,
-          actorId: comPlayer.playerId,
+          actorId: comPlayer.seatId,
           card: negriCard,
         });
 
@@ -209,7 +209,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
 
     const result: PlayCardResponse = await this.playCardUseCase.execute({
       roomId,
-      actorId: comPlayer.playerId,
+      actorId: comPlayer.seatId,
       card: bestCard,
     });
 
@@ -225,7 +225,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       updatedField &&
       updatedField.baseCard === 'JOKER' &&
       !updatedField.baseSuit &&
-      updatedField.dealerSeatId === comPlayer.playerId
+      updatedField.dealerSeatId === comPlayer.seatId
     ) {
       updatedField.baseSuit = this.comStrategyService.chooseBaseSuit(
         updatedState,
@@ -246,7 +246,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
           scope: 'room',
           roomId,
           event: 'update-turn',
-          payload: nextPlayer.playerId,
+          payload: nextPlayer.seatId,
         });
       }
 
@@ -293,12 +293,12 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       action.type === 'declare'
         ? await this.declareBlowUseCase.execute({
             roomId,
-            actorId: comPlayer.playerId,
+            actorId: comPlayer.seatId,
             declaration: action.declaration,
           })
         : await this.passBlowUseCase.execute({
             roomId,
-            actorId: comPlayer.playerId,
+            actorId: comPlayer.seatId,
           });
 
     const { events = [], delayedEvents = [] } =
@@ -372,7 +372,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
     }
 
     this.logger.warn(
-      `Blow turn sat on ${comPlayer.playerId} in room ${roomId}, which has already declared; advancing the turn`,
+      `Blow turn sat on ${comPlayer.seatId} in room ${roomId}, which has already declared; advancing the turn`,
     );
 
     const maxAttempts = state.players.length;
@@ -383,7 +383,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
       if (!candidate) break;
 
       const acted =
-        hasPlayerDeclaredInBlow(state.blowState, candidate.playerId) ||
+        hasPlayerDeclaredInBlow(state.blowState, candidate.seatId) ||
         hasPlayerPassedInBlow(state.blowState, candidate);
       if (!acted) break;
     }
@@ -397,7 +397,7 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
             scope: 'room',
             roomId,
             event: 'update-turn',
-            payload: nextPlayer.playerId,
+            payload: nextPlayer.seatId,
           },
         ]
       : [];
@@ -417,8 +417,8 @@ export class ComAutoPlayUseCase implements IComAutoPlayUseCase {
   ): Promise<ComAutoPlayResponse> {
     const preparation = await this.revealBrokenHandUseCase.prepare({
       roomId,
-      actorId: comPlayer.playerId,
-      playerId: comPlayer.playerId,
+      actorId: comPlayer.seatId,
+      playerId: comPlayer.seatId,
     });
 
     if (!preparation.success || !preparation.followUp) {

--- a/mei-tra-backend/src/use-cases/complete-field.use-case.ts
+++ b/mei-tra-backend/src/use-cases/complete-field.use-case.ts
@@ -66,10 +66,7 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
 
       this.removeCardsFromHands(state, field.cards);
 
-      const completedField = roomGameState.completeField(
-        field,
-        winner.playerId,
-      );
+      const completedField = roomGameState.completeField(field, winner.seatId);
 
       if (!completedField) {
         return { success: false, error: 'Failed to persist completed field' };
@@ -78,11 +75,11 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
       await this.gameEventLogService?.log({
         roomId,
         actionType: 'field_completed',
-        actorSeatId: asSeatId(winner.playerId),
+        actorSeatId: asSeatId(winner.seatId),
         state,
         actionData: {
           completedField,
-          winnerSeatId: winner.playerId,
+          winnerSeatId: winner.seatId,
           winnerTeam: winner.team,
           cards: [...field.cards],
         },
@@ -92,7 +89,7 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
         (player) => player.hand.length === 0,
       );
 
-      setCurrentSeat(state, winner.playerId);
+      setCurrentSeat(state, winner.seatId);
 
       if (state.playState) {
         state.playState.currentField = {
@@ -100,15 +97,15 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
           playedBy: [],
           playedBySeatIds: [],
           baseCard: '',
-          dealerSeatId: asSeatId(winner.playerId),
+          dealerSeatId: asSeatId(winner.seatId),
           isComplete: false,
         };
       }
 
       const fieldCompletePayload: FieldCompletePayload = {
-        winnerSeatId: asSeatId(winner.playerId),
+        winnerSeatId: asSeatId(winner.seatId),
         field: toCompletedFieldContract(completedField),
-        nextSeatId: asSeatId(winner.playerId),
+        nextSeatId: asSeatId(winner.seatId),
       };
       const room = await this.roomService.getRoom(roomId);
 
@@ -134,7 +131,7 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
           scope: 'room',
           roomId,
           event: 'update-turn',
-          payload: winner.playerId,
+          payload: winner.seatId,
         });
 
         await roomGameState.saveState();
@@ -261,7 +258,9 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
       return 'Field is not complete';
     }
 
-    const playerIds = new Set(state.players.map((player) => player.playerId));
+    const playerIds = new Set<string>(
+      state.players.map((player) => player.seatId),
+    );
     if (field.playedBy.some((playerId) => !playerIds.has(playerId))) {
       return 'Field contains unknown player attribution';
     }
@@ -305,7 +304,7 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
     }
 
     const player = state.players.find(
-      (p) => p.playerId === highestDeclaration.seatId,
+      (p) => p.seatId === highestDeclaration.seatId,
     );
     if (player) {
       return player.team;
@@ -384,7 +383,7 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
         playedBy: [],
         playedBySeatIds: [],
         baseCard: '',
-        dealerSeatId: asSeatId(nextBlowPlayer.playerId),
+        dealerSeatId: asSeatId(nextBlowPlayer.seatId),
         isComplete: false,
       },
       negriCard: null,
@@ -410,14 +409,14 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
     roomGameState.updateState({
       playState: newPlayState,
       blowState: newBlowState,
-      currentSeatId: asSeatId(nextBlowPlayer.playerId),
+      currentSeatId: asSeatId(nextBlowPlayer.seatId),
     });
 
     const newRoundPayload: NewRoundStartedPayload = {
       players: resolveTransportPlayers(roomGameState, updatedState.players, {
         roomPlayers: room?.players,
       }),
-      currentTurnSeatId: asSeatId(nextBlowPlayer.playerId),
+      currentTurnSeatId: asSeatId(nextBlowPlayer.seatId),
       gamePhase: 'blow',
       currentField: null,
       completedFields: [],
@@ -455,7 +454,7 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
         scope: 'room',
         roomId,
         event: 'update-turn',
-        payload: nextBlowPlayer.playerId,
+        payload: nextBlowPlayer.seatId,
         delayMs: 3000,
       },
       {
@@ -472,15 +471,15 @@ export class CompleteFieldUseCase implements ICompleteFieldUseCase {
     await this.gameEventLogService?.log({
       roomId,
       actionType: 'round_reset',
-      actorSeatId: asSeatId(nextBlowPlayer.playerId),
+      actorSeatId: asSeatId(nextBlowPlayer.seatId),
       state: updatedState,
       actionData: {
-        nextDealerSeatId: nextBlowPlayer.playerId,
+        nextDealerSeatId: nextBlowPlayer.seatId,
         nextRoundNumber: updatedState.roundNumber,
         nextBlowIndex,
         startingHandsBySeatId: Object.fromEntries(
           updatedState.players.map((player) => [
-            player.playerId,
+            player.seatId,
             [...player.hand],
           ]),
         ),

--- a/mei-tra-backend/src/use-cases/declare-blow.use-case.ts
+++ b/mei-tra-backend/src/use-cases/declare-blow.use-case.ts
@@ -63,7 +63,7 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
         return { success: false, error: pendingError };
       }
 
-      if (!roomGameState.isPlayerTurn(player.playerId)) {
+      if (!roomGameState.isPlayerTurn(player.seatId)) {
         return { success: false, error: "It's not your turn to declare" };
       }
 
@@ -73,7 +73,7 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
       }
 
       // Check if player has already declared in this blow phase
-      if (hasPlayerDeclaredInBlow(state.blowState, player.playerId)) {
+      if (hasPlayerDeclaredInBlow(state.blowState, player.seatId)) {
         return {
           success: false,
           error: 'You have already declared in this blow phase',
@@ -98,7 +98,7 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
       }
 
       const newDeclaration = this.blowService.createDeclaration(
-        player.playerId,
+        player.seatId,
         player.team,
         declaration.trumpType,
         declaration.numberOfPairs,
@@ -108,7 +108,7 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
       state.blowState.declarations.push(newDeclaration);
       state.blowState.actionHistory.push({
         type: 'declare',
-        seatId: asSeatId(player.playerId),
+        seatId: asSeatId(player.seatId),
         trumpType: declaration.trumpType,
         numberOfPairs: declaration.numberOfPairs,
         timestamp: newDeclaration.timestamp,
@@ -118,7 +118,7 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
       await this.gameEventLogService?.log({
         roomId,
         actionType: 'blow_declared',
-        actorSeatId: asSeatId(player.playerId),
+        actorSeatId: asSeatId(player.seatId),
         state,
         actionData: {
           declaration: {
@@ -182,7 +182,7 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
           break;
         }
         const hasActed =
-          hasPlayerDeclaredInBlow(state.blowState, currentPlayer.playerId) ||
+          hasPlayerDeclaredInBlow(state.blowState, currentPlayer.seatId) ||
           hasPlayerPassedInBlow(state.blowState, currentPlayer);
 
         if (!hasActed) {
@@ -202,7 +202,7 @@ export class DeclareBlowUseCase implements IDeclareBlowUseCase {
           scope: 'room',
           roomId,
           event: 'update-turn',
-          payload: nextPlayer.playerId,
+          payload: nextPlayer.seatId,
         });
       }
 

--- a/mei-tra-backend/src/use-cases/fill-with-com.use-case.ts
+++ b/mei-tra-backend/src/use-cases/fill-with-com.use-case.ts
@@ -25,9 +25,7 @@ export class FillWithComUseCase implements IFillWithComUseCase {
       }
 
       // Find the requesting player by playerId
-      const requestingPlayer = room.players.find(
-        (p) => p.playerId === playerId,
-      );
+      const requestingPlayer = room.players.find((p) => p.seatId === playerId);
       if (!requestingPlayer) {
         return {
           success: false,

--- a/mei-tra-backend/src/use-cases/helpers/blow-action.helper.ts
+++ b/mei-tra-backend/src/use-cases/helpers/blow-action.helper.ts
@@ -21,7 +21,7 @@ export function hasPlayerPassedInBlow(
   return (
     player.isPasser ||
     (blowState.actionHistory ?? []).some(
-      (action) => action.seatId === player.playerId && action.type === 'pass',
+      (action) => action.seatId === player.seatId && action.type === 'pass',
     )
   );
 }
@@ -32,7 +32,7 @@ export function countPlayersActedInBlow(
 ): number {
   return players.filter(
     (player) =>
-      hasPlayerDeclaredInBlow(blowState, player.playerId) ||
+      hasPlayerDeclaredInBlow(blowState, player.seatId) ||
       hasPlayerPassedInBlow(blowState, player),
   ).length;
 }

--- a/mei-tra-backend/src/use-cases/join-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/join-room.use-case.ts
@@ -80,11 +80,11 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
       }
       const resolvedUser: SessionUser = {
         ...normalizedUser,
-        seatId: asSeatId(joinedPlayer.playerId),
+        seatId: asSeatId(joinedPlayer.seatId),
       };
       const data: JoinRoomSuccess = {
         room,
-        isHost: room.hostSeatId === joinedPlayer.playerId,
+        isHost: room.hostSeatId === joinedPlayer.seatId,
         roomStatus: room.status,
         roomsList: await this.roomService.listRooms(),
         resumeGame: await this.buildResumePayloadIfNeeded(room.id, room),
@@ -171,7 +171,7 @@ export class JoinRoomUseCase implements IJoinRoomUseCase {
     return {
       roomId: currentRoomId,
       playerId:
-        currentRoomPlayer?.playerId ??
+        currentRoomPlayer?.seatId ??
         normalizedUser.seatId ??
         normalizedUser.userId!,
     };

--- a/mei-tra-backend/src/use-cases/leave-room.use-case.ts
+++ b/mei-tra-backend/src/use-cases/leave-room.use-case.ts
@@ -28,7 +28,7 @@ export class LeaveRoomUseCase implements ILeaveRoomUseCase {
         };
       }
 
-      const player = room.players.find((p) => p.playerId === playerId);
+      const player = room.players.find((p) => p.seatId === playerId);
       if (!player) {
         return {
           success: false,
@@ -48,7 +48,7 @@ export class LeaveRoomUseCase implements ILeaveRoomUseCase {
       const roomExists = await this.roomService.getRoom(roomId);
 
       const baseResponse: LeaveRoomSuccessData = {
-        playerId: player.playerId,
+        playerId: player.seatId,
         roomDeleted: !roomExists,
         roomsList,
       };

--- a/mei-tra-backend/src/use-cases/moderate-player.use-case.ts
+++ b/mei-tra-backend/src/use-cases/moderate-player.use-case.ts
@@ -60,7 +60,7 @@ export class ModeratePlayerUseCase {
     }
 
     const targetPlayer = room.players.find(
-      (player) => player.playerId === request.targetPlayerId,
+      (player) => player.seatId === request.targetPlayerId,
     );
     if (!targetPlayer || targetPlayer.isCOM) {
       return { success: false, error: 'Target player not found' };
@@ -110,7 +110,7 @@ export class ModeratePlayerUseCase {
 
     const state = roomGameState.getState();
     const targetStatePlayer = state.players.find(
-      (player) => player.playerId === request.targetPlayerId,
+      (player) => player.seatId === request.targetPlayerId,
     );
     const canReplaceDisconnected = Boolean(
       room.status === RoomStatus.PLAYING &&

--- a/mei-tra-backend/src/use-cases/pass-blow.use-case.ts
+++ b/mei-tra-backend/src/use-cases/pass-blow.use-case.ts
@@ -71,7 +71,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
         return { success: false, error: pendingError };
       }
 
-      if (!roomGameState.isPlayerTurn(player.playerId)) {
+      if (!roomGameState.isPlayerTurn(player.seatId)) {
         return { success: false, error: "It's not your turn to pass" };
       }
 
@@ -89,7 +89,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
       }
 
       // Check if player has already declared in this blow phase
-      if (hasPlayerDeclaredInBlow(state.blowState, player.playerId)) {
+      if (hasPlayerDeclaredInBlow(state.blowState, player.seatId)) {
         return {
           success: false,
           error: 'You have already declared in this blow phase',
@@ -100,15 +100,15 @@ export class PassBlowUseCase implements IPassBlowUseCase {
       player.isPasser = true;
       state.blowState.actionHistory.push({
         type: 'pass',
-        seatId: asSeatId(player.playerId),
+        seatId: asSeatId(player.seatId),
         timestamp: Date.now(),
       });
-      state.blowState.lastPasserSeatId = asSeatId(player.playerId);
+      state.blowState.lastPasserSeatId = asSeatId(player.seatId);
 
       await this.gameEventLogService?.log({
         roomId,
         actionType: 'blow_passed',
-        actorSeatId: asSeatId(player.playerId),
+        actorSeatId: asSeatId(player.seatId),
         state,
         actionData: {
           declarationsCount: state.blowState.declarations.length,
@@ -183,7 +183,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
           break;
         }
         const hasActed =
-          hasPlayerDeclaredInBlow(state.blowState, currentPlayer.playerId) ||
+          hasPlayerDeclaredInBlow(state.blowState, currentPlayer.seatId) ||
           hasPlayerPassedInBlow(state.blowState, currentPlayer);
 
         if (!hasActed) {
@@ -203,7 +203,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
           scope: 'room',
           roomId,
           event: 'update-turn',
-          payload: nextPlayer.playerId,
+          payload: nextPlayer.seatId,
         });
       }
 
@@ -239,7 +239,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
       return { events: [] };
     }
 
-    setCurrentSeat(state, firstBlowPlayer.playerId);
+    setCurrentSeat(state, firstBlowPlayer.seatId);
     state.deck = this.cardService.generateDeck();
     roomGameState.dealCards();
 
@@ -250,7 +250,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
       state,
       actionData: {
         reason: 'no_declarations',
-        nextDealerSeatId: firstBlowPlayer.playerId,
+        nextDealerSeatId: firstBlowPlayer.seatId,
         nextBlowIndex: firstBlowIndex,
       },
     });
@@ -267,7 +267,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
       },
     );
     const roundCancelledPayload: RoundCancelledPayload = {
-      nextDealerSeatId: asSeatId(firstBlowPlayer.playerId),
+      nextDealerSeatId: asSeatId(firstBlowPlayer.seatId),
       players: resolveTransportPlayers(roomGameState, state.players, {
         roomPlayers: room?.players,
       }),
@@ -296,7 +296,7 @@ export class PassBlowUseCase implements IPassBlowUseCase {
         scope: 'room',
         roomId,
         event: 'update-turn',
-        payload: firstBlowPlayer.playerId,
+        payload: firstBlowPlayer.seatId,
       },
     ];
     return { events };

--- a/mei-tra-backend/src/use-cases/play-card.use-case.ts
+++ b/mei-tra-backend/src/use-cases/play-card.use-case.ts
@@ -63,7 +63,7 @@ export class PlayCardUseCase implements IPlayCardUseCase {
         };
       }
 
-      if (!roomGameState.isPlayerTurn(player.playerId)) {
+      if (!roomGameState.isPlayerTurn(player.seatId)) {
         return { success: false, error: "It's not your turn to play" };
       }
 
@@ -95,7 +95,7 @@ export class PlayCardUseCase implements IPlayCardUseCase {
           ? currentField.playedBySeatIds
           : currentField.playedBy
       ).map(asSeatId);
-      playedBySeatIds.push(asSeatId(player.playerId));
+      playedBySeatIds.push(asSeatId(player.seatId));
       currentField.cards.push(card);
       currentField.playedBy = [...playedBySeatIds];
       currentField.playedBySeatIds = [...playedBySeatIds];
@@ -106,7 +106,7 @@ export class PlayCardUseCase implements IPlayCardUseCase {
       await this.gameEventLogService?.log({
         roomId,
         actionType: 'card_played',
-        actorSeatId: asSeatId(player.playerId),
+        actorSeatId: asSeatId(player.seatId),
         state,
         actionData: {
           card,
@@ -118,7 +118,7 @@ export class PlayCardUseCase implements IPlayCardUseCase {
       });
 
       const cardPlayedPayload: CardPlayedPayload = {
-        seatId: asSeatId(player.playerId),
+        seatId: asSeatId(player.seatId),
         card,
         field: toFieldContract(currentField),
         players: resolveTransportPlayers(roomGameState, state.players, {
@@ -159,12 +159,12 @@ export class PlayCardUseCase implements IPlayCardUseCase {
       roomGameState.nextTurn();
       const nextPlayer = resolveCurrentPlayer(state);
       if (nextPlayer) {
-        cardPlayedPayload.nextSeatId = asSeatId(nextPlayer.playerId);
+        cardPlayedPayload.nextSeatId = asSeatId(nextPlayer.seatId);
         events.push({
           scope: 'room',
           roomId,
           event: 'update-turn',
-          payload: asSeatId(nextPlayer.playerId),
+          payload: asSeatId(nextPlayer.seatId),
         });
       }
 

--- a/mei-tra-backend/src/use-cases/process-game-over.use-case.ts
+++ b/mei-tra-backend/src/use-cases/process-game-over.use-case.ts
@@ -6,6 +6,7 @@ import {
 import { IRoomService } from '../services/interfaces/room-service.interface';
 import { IGameEventLogService } from '../services/interfaces/game-event-log.service.interface';
 import { SessionUser } from '../types/session.types';
+import type { SeatId } from '@contracts/ids';
 
 @Injectable()
 export class ProcessGameOverUseCase implements IProcessGameOverUseCase {
@@ -35,7 +36,7 @@ export class ProcessGameOverUseCase implements IProcessGameOverUseCase {
         const sessionUser =
           roomGameState &&
           typeof roomGameState.findSessionUserByPlayerId === 'function'
-            ? roomGameState.findSessionUserByPlayerId(roomPlayer.playerId)
+            ? roomGameState.findSessionUserByPlayerId(roomPlayer.seatId)
             : null;
         const userId = this.resolveAuthenticatedUserId(roomPlayer, sessionUser);
 
@@ -44,14 +45,19 @@ export class ProcessGameOverUseCase implements IProcessGameOverUseCase {
         }
 
         return {
-          playerId: roomPlayer.playerId,
+          playerId: roomPlayer.seatId,
           team: roomPlayer.team,
           userId,
         };
       })
       .filter(
-        (player): player is { playerId: string; team: 0 | 1; userId: string } =>
-          player !== null,
+        (
+          player,
+        ): player is {
+          playerId: SeatId;
+          team: 0 | 1;
+          userId: string;
+        } => player !== null,
       );
 
     const updatePromises = authenticatedPlayers.map(async (player) => {
@@ -95,10 +101,10 @@ export class ProcessGameOverUseCase implements IProcessGameOverUseCase {
           .filter(
             (roomPlayer) =>
               !authenticatedPlayers.some(
-                (player) => player.playerId === roomPlayer.playerId,
+                (player) => player.playerId === roomPlayer.seatId,
               ),
           )
-          .map((roomPlayer) => roomPlayer.playerId),
+          .map((roomPlayer) => roomPlayer.seatId),
         failedCount: failedUpdates,
         finalScores: teamScores,
       },

--- a/mei-tra-backend/src/use-cases/reconnection.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reconnection.use-case.ts
@@ -145,7 +145,7 @@ export class ReconnectionUseCase {
           !(await this.claimMembership(
             authenticatedUser.id,
             roomId,
-            existingWaitingPlayer.playerId,
+            existingWaitingPlayer.seatId,
           ))
         ) {
           return this.buildMembershipConflict(roomId);
@@ -153,7 +153,7 @@ export class ReconnectionUseCase {
 
         const reconnectResult = await this.roomService.handlePlayerReconnection(
           roomId,
-          existingWaitingPlayer.playerId,
+          existingWaitingPlayer.seatId,
           socketId,
           authenticatedUser.id,
           this.resolveDisplayName(authenticatedUser),
@@ -162,7 +162,7 @@ export class ReconnectionUseCase {
           this.logStateMismatch(
             roomId,
             authenticatedUser.id,
-            existingWaitingPlayer.playerId,
+            existingWaitingPlayer.seatId,
             updatedRoom.players.length,
             roomGameState.getState().players.length,
             reconnectResult.error,
@@ -178,12 +178,12 @@ export class ReconnectionUseCase {
         this.syncGlobalConnectionUser(
           socketId,
           authenticatedUser,
-          existingWaitingPlayer.playerId,
+          existingWaitingPlayer.seatId,
         );
 
         const reconnectedRoom = await this.roomService.getRoom(roomId);
         const reconnectedPlayer = reconnectedRoom?.players.find(
-          (player) => player.playerId === existingWaitingPlayer.playerId,
+          (player) => player.seatId === existingWaitingPlayer.seatId,
         );
         if (!reconnectedRoom || !reconnectedPlayer) {
           return {
@@ -200,10 +200,10 @@ export class ReconnectionUseCase {
           roomId,
           roomsList: await this.roomService.listRooms(),
           room: reconnectedRoom,
-          selfSeatId: asSeatId(reconnectedPlayer.playerId),
+          selfSeatId: asSeatId(reconnectedPlayer.seatId),
           selfName: reconnectedPlayer.name,
           selfTeam: reconnectedPlayer.team,
-          isHost: reconnectedRoom.hostSeatId === reconnectedPlayer.playerId,
+          isHost: reconnectedRoom.hostSeatId === reconnectedPlayer.seatId,
         };
       }
 
@@ -230,7 +230,7 @@ export class ReconnectionUseCase {
         !(await this.claimMembership(
           authenticatedUser.id,
           roomId,
-          existingPlayer.playerId,
+          existingPlayer.seatId,
         ))
       ) {
         return this.buildMembershipConflict(roomId);
@@ -238,7 +238,7 @@ export class ReconnectionUseCase {
 
       const reconnectResult = await this.roomService.handlePlayerReconnection(
         roomId,
-        existingPlayer.playerId,
+        existingPlayer.seatId,
         socketId,
         authenticatedUser.id,
         this.resolveDisplayName(authenticatedUser),
@@ -247,7 +247,7 @@ export class ReconnectionUseCase {
         this.logStateMismatch(
           roomId,
           authenticatedUser.id,
-          existingPlayer.playerId,
+          existingPlayer.seatId,
           room.players.length,
           state.players.length,
           reconnectResult.error,
@@ -263,13 +263,13 @@ export class ReconnectionUseCase {
       this.syncGlobalConnectionUser(
         socketId,
         authenticatedUser,
-        existingPlayer.playerId,
+        existingPlayer.seatId,
       );
 
       const reconnectedRoom = await this.roomService.getRoom(roomId);
       const reconnectedPlayer = roomGameState
         .getState()
-        .players.find((player) => player.playerId === existingPlayer.playerId);
+        .players.find((player) => player.seatId === existingPlayer.seatId);
       if (!reconnectedRoom || !reconnectedPlayer) {
         return {
           success: false,
@@ -365,7 +365,7 @@ export class ReconnectionUseCase {
       ? (roomGameState
           .getState()
           .players.find(
-            (player) => player.playerId === persistedRoomPlayer.playerId,
+            (player) => player.seatId === persistedRoomPlayer.seatId,
           ) ?? null)
       : resolvePlayerByActorId(roomGameState, authenticatedUserId);
   }
@@ -380,14 +380,14 @@ export class ReconnectionUseCase {
     const currentTurnSeatId = resolveCurrentSeatId(state);
 
     return {
-      selfSeatId: asSeatId(player.playerId),
-      reconnectToken: player.playerId,
+      selfSeatId: asSeatId(player.seatId),
+      reconnectToken: player.seatId,
       currentTurnSeatId: currentTurnSeatId ? asSeatId(currentTurnSeatId) : null,
       gameState: {
         players: resolveTransportPlayers(roomGameState, state.players, {
           roomPlayers: room.players,
           mapHand: (transportPlayer) =>
-            transportPlayer.seatId === asSeatId(player.playerId)
+            transportPlayer.seatId === asSeatId(player.seatId)
               ? transportPlayer.hand
               : [],
         }),
@@ -400,7 +400,7 @@ export class ReconnectionUseCase {
           : null,
         blowState: toBlowStateContract(state.blowState),
         teamScores: state.teamScores,
-        youSeatId: asSeatId(player.playerId),
+        youSeatId: asSeatId(player.seatId),
         negriCard: state.playState?.negriCard ?? null,
         negriSeatId: state.playState?.negriSeatId
           ? asSeatId(state.playState.negriSeatId)
@@ -408,7 +408,7 @@ export class ReconnectionUseCase {
         revealedAgari:
           state.gamePhase === 'play' &&
           !state.playState?.negriCard &&
-          state.blowState.currentHighestDeclaration?.seatId === player.playerId
+          state.blowState.currentHighestDeclaration?.seatId === player.seatId
             ? (state.agari ?? null)
             : null,
         fields: (state.playState?.fields ?? []).map(toCompletedFieldContract),

--- a/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
+++ b/mei-tra-backend/src/use-cases/reveal-broken-hand.use-case.ts
@@ -43,7 +43,7 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
         return { success: false, error: 'Player not found in game state' };
       }
 
-      if (player.playerId !== playerId) {
+      if (player.seatId !== playerId) {
         return { success: false, error: 'Player mismatch for broken hand' };
       }
 
@@ -99,7 +99,7 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
       const roomGameState = await this.roomService.getRoomGameState(roomId);
       const state = roomGameState.getState();
       const room = await this.roomService.getRoom(roomId);
-      const player = state.players.find((p) => p.playerId === playerId);
+      const player = state.players.find((p) => p.seatId === playerId);
 
       if (!player) {
         return { success: false, error: 'Player not found in game state' };
@@ -151,7 +151,7 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
       const firstBlowIndex = nextState.blowState.currentBlowIndex;
       const firstBlowPlayer = nextState.players[firstBlowIndex];
 
-      setCurrentSeat(nextState, firstBlowPlayer?.playerId ?? null);
+      setCurrentSeat(nextState, firstBlowPlayer?.seatId ?? null);
       nextState.players.forEach((statePlayer) => {
         statePlayer.isPasser = false;
       });
@@ -173,7 +173,7 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
         });
 
         const brokenPayload: BrokenPayload = {
-          nextSeatId: asSeatId(firstBlowPlayer.playerId),
+          nextSeatId: asSeatId(firstBlowPlayer.seatId),
           players: resolveTransportPlayers(roomGameState, nextState.players, {
             roomPlayers: room?.players,
           }),
@@ -190,7 +190,7 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
           scope: 'room',
           roomId,
           event: 'update-turn',
-          payload: firstBlowPlayer.playerId,
+          payload: firstBlowPlayer.seatId,
         });
       }
 
@@ -200,11 +200,11 @@ export class RevealBrokenHandUseCase implements IRevealBrokenHandUseCase {
         actorSeatId: asSeatId(playerId),
         state: nextState,
         actionData: {
-          nextSeatId: firstBlowPlayer?.playerId ?? null,
+          nextSeatId: firstBlowPlayer?.seatId ?? null,
           nextBlowIndex: firstBlowIndex,
           startingHandsBySeatId: Object.fromEntries(
             nextState.players.map((statePlayer) => [
-              statePlayer.playerId,
+              statePlayer.seatId,
               [...statePlayer.hand],
             ]),
           ),

--- a/mei-tra-backend/src/use-cases/select-base-suit.use-case.ts
+++ b/mei-tra-backend/src/use-cases/select-base-suit.use-case.ts
@@ -37,7 +37,7 @@ export class SelectBaseSuitUseCase implements ISelectBaseSuitUseCase {
         return { success: false, error: 'Player not found in game state' };
       }
 
-      if (state.playState.currentField.dealerSeatId !== player.playerId) {
+      if (state.playState.currentField.dealerSeatId !== player.seatId) {
         return {
           success: false,
           error: "It's not your turn to select base suit",
@@ -62,7 +62,7 @@ export class SelectBaseSuitUseCase implements ISelectBaseSuitUseCase {
           scope: 'room',
           roomId,
           event: 'update-turn',
-          payload: nextPlayer.playerId,
+          payload: nextPlayer.seatId,
         });
       }
 

--- a/mei-tra-backend/src/use-cases/select-negri.use-case.ts
+++ b/mei-tra-backend/src/use-cases/select-negri.use-case.ts
@@ -38,7 +38,7 @@ export class SelectNegriUseCase implements ISelectNegriUseCase {
         return { success: false, error: 'Cannot select Negri card now' };
       }
 
-      if (!roomGameState.isPlayerTurn(player.playerId)) {
+      if (!roomGameState.isPlayerTurn(player.seatId)) {
         return { success: false, error: "It's not your turn to select Negri" };
       }
 
@@ -52,11 +52,11 @@ export class SelectNegriUseCase implements ISelectNegriUseCase {
           playedBy: [],
           playedBySeatIds: [],
           baseCard: '',
-          dealerSeatId: asSeatId(player.playerId),
+          dealerSeatId: asSeatId(player.seatId),
           isComplete: false,
         },
         negriCard: card,
-        negriSeatId: asSeatId(player.playerId),
+        negriSeatId: asSeatId(player.seatId),
         neguri: {},
         fields: [],
         lastWinnerSeatId: null,
@@ -77,7 +77,7 @@ export class SelectNegriUseCase implements ISelectNegriUseCase {
       }
 
       const winnerIndex = state.players.findIndex(
-        (p) => p.playerId === winner.seatId,
+        (p) => p.seatId === winner.seatId,
       );
       if (winnerIndex === -1) {
         return {
@@ -99,14 +99,14 @@ export class SelectNegriUseCase implements ISelectNegriUseCase {
           event: 'play-setup-complete',
           payload: {
             negriCard: card,
-            startingSeatId: asSeatId(state.players[winnerIndex].playerId),
+            startingSeatId: asSeatId(state.players[winnerIndex].seatId),
           },
         },
         {
           scope: 'room',
           roomId,
           event: 'update-turn',
-          payload: state.players[winnerIndex].playerId,
+          payload: state.players[winnerIndex].seatId,
         },
       ];
 

--- a/mei-tra-backend/src/use-cases/start-game.use-case.ts
+++ b/mei-tra-backend/src/use-cases/start-game.use-case.ts
@@ -40,7 +40,7 @@ export class StartGameUseCase implements IStartGameUseCase {
       }
 
       const roomGameState = await this.roomService.getRoomGameState(roomId);
-      const player = room.players.find((p) => p.playerId === playerId);
+      const player = room.players.find((p) => p.seatId === playerId);
       if (!player) {
         this.logger.error('Player not found in game state for game start', {
           playerId,
@@ -120,9 +120,7 @@ export class StartGameUseCase implements IStartGameUseCase {
       if (updatedState.blowState.currentBlowIndex !== currentPlayerIndex) {
         const currentPlayer = resolveCurrentPlayer(updatedState);
         roomGameState.updateState({
-          currentSeatId: currentPlayer
-            ? asSeatId(currentPlayer.playerId)
-            : null,
+          currentSeatId: currentPlayer ? asSeatId(currentPlayer.seatId) : null,
           blowState: {
             ...updatedState.blowState,
             currentBlowIndex: currentPlayerIndex,
@@ -156,12 +154,12 @@ export class StartGameUseCase implements IStartGameUseCase {
         state: updatedState,
         actionData: {
           startedBySeatId: playerId,
-          firstBlowSeatId: firstBlowPlayer?.playerId ?? null,
+          firstBlowSeatId: firstBlowPlayer?.seatId ?? null,
           pointsToWin: updatedState.pointsToWin,
           playerCount: updatedState.players.length,
           startingHandsBySeatId: Object.fromEntries(
             updatedState.players.map((player) => [
-              player.playerId,
+              player.seatId,
               [...player.hand],
             ]),
           ),
@@ -178,7 +176,7 @@ export class StartGameUseCase implements IStartGameUseCase {
             scores: updatedState.teamScores,
             winner: null,
           },
-          currentTurnSeatId: asSeatId(currentTurnPlayer.playerId),
+          currentTurnSeatId: asSeatId(currentTurnPlayer.seatId),
         },
       };
     } catch (error) {
@@ -203,16 +201,16 @@ export class StartGameUseCase implements IStartGameUseCase {
     // players array from that source before starting. This keeps the play order
     // aligned with the shuffled seat arrangement instead of any stale game-state order.
     const existingPlayers = new Map(
-      state.players.map((statePlayer) => [statePlayer.playerId, statePlayer]),
+      state.players.map((statePlayer) => [statePlayer.seatId, statePlayer]),
     );
     state.players = room.players.map((roomPlayer) => {
-      const existingPlayer = existingPlayers.get(roomPlayer.playerId);
+      const existingPlayer = existingPlayers.get(roomPlayer.seatId);
 
       if (!existingPlayer) {
         if (typeof roomGameState.registerPlayerToken === 'function') {
           roomGameState.registerPlayerToken(
-            roomPlayer.playerId,
-            roomPlayer.playerId,
+            roomPlayer.seatId,
+            roomPlayer.seatId,
           );
         }
         return {
@@ -231,7 +229,7 @@ export class StartGameUseCase implements IStartGameUseCase {
     });
 
     state.teamAssignments = Object.fromEntries(
-      state.players.map((player) => [player.playerId, player.team]),
+      state.players.map((player) => [player.seatId, player.team]),
     );
 
     return state;

--- a/mei-tra-backend/src/use-cases/toggle-player-ready.use-case.ts
+++ b/mei-tra-backend/src/use-cases/toggle-player-ready.use-case.ts
@@ -26,7 +26,7 @@ export class TogglePlayerReadyUseCase implements ITogglePlayerReadyUseCase {
         return { success: false, error: 'Room not found' };
       }
 
-      const player = room.players.find((p) => p.playerId === playerId);
+      const player = room.players.find((p) => p.seatId === playerId);
       if (!player) {
         return { success: false, error: 'Player not found in room' };
       }

--- a/mei-tra-backend/src/use-cases/update-auth.use-case.ts
+++ b/mei-tra-backend/src/use-cases/update-auth.use-case.ts
@@ -146,7 +146,7 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
     const roomStatePlayer = roomPlayer
       ? (roomGameState
           .getState()
-          .players.find((player) => player.playerId === roomPlayer.playerId) ??
+          .players.find((player) => player.seatId === roomPlayer.seatId) ??
         null)
       : null;
     const currentPlayer =
@@ -164,7 +164,7 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
       authenticatedUser.email ||
       currentPlayer.name;
     currentPlayer.name = displayName;
-    await roomGameState.applyPlayerConnectionState(currentPlayer.playerId, {
+    await roomGameState.applyPlayerConnectionState(currentPlayer.seatId, {
       socketId,
       userId: authenticatedUser.id,
       isAuthenticated: true,
@@ -172,7 +172,7 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
 
     await this.roomService.updatePlayerInRoom(
       currentRoomId,
-      currentPlayer.playerId,
+      currentPlayer.seatId,
       {
         socketId,
         name: displayName,
@@ -195,6 +195,6 @@ export class UpdateAuthUseCase implements IUpdateAuthUseCase {
       );
     }
 
-    return { playerId: currentPlayer.playerId, events: roomEvents };
+    return { playerId: currentPlayer.seatId, events: roomEvents };
   }
 }


### PR DESCRIPTION
## Summary
- `DomainPlayer` と `RoomPlayer` の identity を必須の `seatId` に統一
- adapter、COM置換、再接続、手番・吹き・場の参照から旧 `playerId` fallbackを削除
- 型検査を迂回していたテストfixtureもcanonicalな `seatId` 形式へ移行

## Validation
- `npx tsc --noEmit`
- `npm test -- --runInBand --forceExit` (63 suites / 397 tests)
- `npm run lint` (既存warning 1件、error 0件)
- `npm run build`
- `git diff --check`

## User-facing change
ゲーム内の席参照をseatIdへ統一し、再接続やCOM置換時の参照ずれを防ぎます。

## User benefit
席identityの分岐が減り、対局進行と復帰処理の安定性が上がります。
