### PR TITLE
WebとMobileの席ID aliasを削除

### DIFF
--- a/mei-tra-frontend/__tests__/components/BlowControls.logic.test.ts
+++ b/mei-tra-frontend/__tests__/components/BlowControls.logic.test.ts
@@ -8,7 +8,7 @@ import {
 const declaration = (
   overrides: Partial<BlowDeclaration> = {},
 ): BlowDeclaration => ({
-  playerId: 'player-1',
+  seatId: 'player-1',
   trumpType: 'zuppe',
   numberOfPairs: 6,
   timestamp: 1,

--- a/mei-tra-frontend/__tests__/components/BlowControls.test.tsx
+++ b/mei-tra-frontend/__tests__/components/BlowControls.test.tsx
@@ -27,14 +27,14 @@ jest.mock('next-intl', () => ({
 
 const player: Player = {
   socketId: 'socket-1',
-  playerId: 'player-1',
+  seatId: 'player-1',
   name: 'Player 1',
   team: 0,
   hand: [],
 };
 
 const declaration: BlowDeclaration = {
-  playerId: 'player-1',
+  seatId: 'player-1',
   trumpType: 'daiya',
   numberOfPairs: 6,
   timestamp: 1,
@@ -42,7 +42,7 @@ const declaration: BlowDeclaration = {
 
 const action: BlowAction = {
   type: 'declare',
-  playerId: 'player-1',
+  seatId: 'player-1',
   trumpType: 'daiya',
   numberOfPairs: 6,
   timestamp: 1,

--- a/mei-tra-frontend/__tests__/components/BlowSpectatorPanel.test.tsx
+++ b/mei-tra-frontend/__tests__/components/BlowSpectatorPanel.test.tsx
@@ -25,14 +25,14 @@ jest.mock('next-intl', () => ({
 const players: Player[] = [
   {
     socketId: 'player-1',
-    playerId: 'player-1',
+    seatId: 'player-1',
     name: 'Player 1',
     team: 0,
     hand: [],
   },
   {
     socketId: 'player-2',
-    playerId: 'player-2',
+    seatId: 'player-2',
     name: 'Player 2',
     team: 1,
     hand: [],
@@ -41,7 +41,7 @@ const players: Player[] = [
 
 const declarations: BlowDeclaration[] = [
   {
-    playerId: 'player-1',
+    seatId: 'player-1',
     trumpType: 'daiya',
     numberOfPairs: 7,
     timestamp: 1,
@@ -51,14 +51,14 @@ const declarations: BlowDeclaration[] = [
 const actions: BlowAction[] = [
   {
     type: 'declare',
-    playerId: 'player-1',
+    seatId: 'player-1',
     trumpType: 'daiya',
     numberOfPairs: 7,
     timestamp: 1,
   },
   {
     type: 'pass',
-    playerId: 'player-2',
+    seatId: 'player-2',
     timestamp: 2,
   },
 ];

--- a/mei-tra-frontend/__tests__/components/CompletedFields.test.tsx
+++ b/mei-tra-frontend/__tests__/components/CompletedFields.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { asSeatId } from '@contracts/ids';
 import { CompletedFields } from '@/components/game/CompletedFields';
 
 describe('CompletedFields', () => {
@@ -12,8 +13,18 @@ describe('CompletedFields', () => {
     render(
       <CompletedFields
         fields={[
-          { cards: ['A♠', '10♥'], winnerId: 'player-1', winnerTeam: 0 },
-          { cards: ['C-K'], winnerId: 'player-2', winnerTeam: 0 },
+          {
+            cards: ['A♠', '10♥'],
+            winnerSeatId: asSeatId('player-1'),
+            dealerSeatId: asSeatId('player-2'),
+            winnerTeam: 0,
+          },
+          {
+            cards: ['C-K'],
+            winnerSeatId: asSeatId('player-2'),
+            dealerSeatId: asSeatId('player-1'),
+            winnerTeam: 0,
+          },
         ]}
       />,
     );

--- a/mei-tra-frontend/__tests__/components/GameTable.test.tsx
+++ b/mei-tra-frontend/__tests__/components/GameTable.test.tsx
@@ -48,14 +48,14 @@ jest.mock('@/components/game/BlowSpectatorPanel', () => ({
 const players: Player[] = [
   {
     socketId: 'player-1',
-    playerId: 'player-1',
+    seatId: 'player-1',
     name: 'Player 1',
     team: 0,
     hand: [],
   },
   {
     socketId: 'player-2',
-    playerId: 'player-2',
+    seatId: 'player-2',
     name: 'Player 2',
     team: 1,
     hand: [],

--- a/mei-tra-frontend/__tests__/components/PlayerHand.test.tsx
+++ b/mei-tra-frontend/__tests__/components/PlayerHand.test.tsx
@@ -95,7 +95,7 @@ const gameActions: GameActions = {
 
 const otherPlayer: Player = {
   socketId: '',
-  playerId: 'player-2',
+  seatId: 'player-2',
   name: 'Player 2',
   team: 0,
   hand: ['H-A'],
@@ -154,7 +154,7 @@ describe('PlayerHand', () => {
   it('shows the Agari card while selecting Negri', () => {
     renderPlayerHand({
       agariCard: 'H-A',
-      currentHighestDeclaration: { playerId: 'player-2' },
+      currentHighestDeclaration: { seatId: 'player-2' },
       currentPlayerId: 'player-2',
       whoseTurn: 'player-2',
       player: {
@@ -172,7 +172,7 @@ describe('PlayerHand', () => {
     renderPlayerHand({
       position: 'bottom',
       agariCard: 'H-A',
-      currentHighestDeclaration: { playerId: 'player-2' },
+      currentHighestDeclaration: { seatId: 'player-2' },
       currentPlayerId: 'player-2',
       whoseTurn: 'player-2',
       player: {
@@ -206,7 +206,7 @@ describe('PlayerHand', () => {
   it('uses the translated no-trump label in the declaration badge', () => {
     renderPlayerHand({
       currentHighestDeclaration: {
-        playerId: 'player-2',
+        seatId: 'player-2',
         trumpType: 'tra',
         numberOfPairs: 6,
       },
@@ -218,7 +218,7 @@ describe('PlayerHand', () => {
   it('omits the suit symbol from the declaration badge', () => {
     renderPlayerHand({
       currentHighestDeclaration: {
-        playerId: 'player-2',
+        seatId: 'player-2',
         trumpType: 'daiya',
         numberOfPairs: 7,
       },

--- a/mei-tra-frontend/__tests__/components/PlayerHand/useCardValidation.test.ts
+++ b/mei-tra-frontend/__tests__/components/PlayerHand/useCardValidation.test.ts
@@ -1,13 +1,14 @@
 import { renderHook } from '@testing-library/react';
+import { asSeatId } from '@contracts/ids';
 import type { Field } from '@/types/game.types';
 import { useCardValidation } from '@/components/game/PlayerHand/hooks/useCardValidation';
 
 const field = (baseCard: string, baseSuit?: string): Field => ({
   cards: [baseCard],
-  playedBy: ['player-1'],
+  playedBySeatIds: [asSeatId('player-1')],
   baseCard,
   ...(baseSuit ? { baseSuit } : {}),
-  dealerId: 'player-1',
+  dealerSeatId: asSeatId('player-1'),
   isComplete: false,
 });
 

--- a/mei-tra-frontend/__tests__/lib/playerIdentity.test.ts
+++ b/mei-tra-frontend/__tests__/lib/playerIdentity.test.ts
@@ -2,8 +2,8 @@ import { resolveSelfPlayerId } from '@/lib/utils/playerIdentity';
 
 describe('resolveSelfPlayerId', () => {
   const players = [
-    { playerId: 'seat-1', userId: 'user-1' },
-    { playerId: 'seat-2', userId: 'user-2' },
+    { seatId: 'seat-1', userId: 'user-1' },
+    { seatId: 'seat-2', userId: 'user-2' },
   ];
 
   it('prefers an authoritative server player id', () => {
@@ -30,7 +30,7 @@ describe('resolveSelfPlayerId', () => {
       resolveSelfPlayerId(
         [
           ...players,
-          { playerId: 'seat-3', userId: 'user-1' },
+          { seatId: 'seat-3', userId: 'user-1' },
         ],
         { userId: 'user-1' },
       ),

--- a/mei-tra-frontend/components/game/BlowControls/index.tsx
+++ b/mei-tra-frontend/components/game/BlowControls/index.tsx
@@ -53,15 +53,17 @@ export function BlowControls({
   players,
 }: BlowControlsProps) {
   const t = useTranslations('blowControls');
-  const currentPlayerName = players.find(p => p.playerId === whoseTurn)?.name;
-  const playerMap = new Map(players.map((player) => [player.playerId, player]));
+  const currentPlayerName = players.find(p => p.seatId === whoseTurn)?.name;
+  const playerMap = new Map<string, Player>(
+    players.map((player) => [player.seatId, player]),
+  );
   const currentPlayer =
     isCurrentPlayer && whoseTurn ? playerMap.get(whoseTurn) : undefined;
   const currentPlayerAlreadyActed =
     !!currentPlayer &&
     (currentPlayer.isPasser ||
-      blowDeclarations.some((declaration) => declaration.playerId === currentPlayer.playerId) ||
-      blowActionHistory.some((action) => action.playerId === currentPlayer.playerId));
+      blowDeclarations.some((declaration) => declaration.seatId === currentPlayer.seatId) ||
+      blowActionHistory.some((action) => action.seatId === currentPlayer.seatId));
 
   // 宣言処理
   const handleDeclare = () => {
@@ -182,7 +184,7 @@ export function BlowControls({
 
     const isLatestDeclaration = declaration === blowDeclarations[blowDeclarations.length - 1];
     const isHighestDeclaration = currentHighestDeclaration && 
-      declaration.playerId === currentHighestDeclaration.playerId &&
+      declaration.seatId === currentHighestDeclaration.seatId &&
       declaration.trumpType === currentHighestDeclaration.trumpType &&
       declaration.numberOfPairs === currentHighestDeclaration.numberOfPairs;
 
@@ -287,13 +289,13 @@ export function BlowControls({
         <div className={styles.declarations}>
           <div className={styles.declarationList}>
             {chronologicalDeclarations.map((entry, index) => {
-              const player = playerMap.get(entry.playerId);
-              const playerName = player?.name ?? entry.playerId;
+              const player = playerMap.get(entry.seatId);
+              const playerName = player?.name ?? entry.seatId;
 
               if (entry.type === 'pass') {
                 return (
                   <div
-                    key={`pass-${entry.playerId}-${index}`}
+                    key={`pass-${entry.seatId}-${index}`}
                     className={`${styles.declarationItem} ${styles.pass}`}
                     title={`${playerName}: ${t('passed')}`}
                   >
@@ -309,7 +311,7 @@ export function BlowControls({
               }
 
               const declaration = {
-                playerId: entry.playerId,
+                seatId: entry.seatId,
                 trumpType: entry.trumpType,
                 numberOfPairs: entry.numberOfPairs,
                 timestamp: entry.timestamp,
@@ -317,7 +319,7 @@ export function BlowControls({
 
               return (
                 <div
-                  key={`${entry.playerId}-${entry.timestamp}`}
+                  key={`${entry.seatId}-${entry.timestamp}`}
                   className={getDeclarationItemClassName(declaration)}
                   title={`${playerName}: ${entry.trumpType ? t(entry.trumpType) : ''} ${formatSetOption(declaration.numberOfPairs)}`}
                 >

--- a/mei-tra-frontend/components/game/BlowSpectatorPanel/index.tsx
+++ b/mei-tra-frontend/components/game/BlowSpectatorPanel/index.tsx
@@ -18,7 +18,9 @@ export function BlowSpectatorPanel({
   players,
 }: BlowSpectatorPanelProps) {
   const t = useTranslations('blowControls');
-  const playerMap = new Map(players.map((player) => [player.playerId, player]));
+  const playerMap = new Map<string, Player>(
+    players.map((player) => [player.seatId, player]),
+  );
   const currentPlayerName = whoseTurn
     ? playerMap.get(whoseTurn)?.name ?? whoseTurn
     : t('waiting');
@@ -27,7 +29,6 @@ export function BlowSpectatorPanel({
     : blowDeclarations.map((declaration) => ({
       type: 'declare' as const,
       seatId: declaration.seatId,
-      playerId: declaration.playerId,
       trumpType: declaration.trumpType,
       numberOfPairs: declaration.numberOfPairs,
       timestamp: declaration.timestamp,
@@ -41,7 +42,7 @@ export function BlowSpectatorPanel({
   const isHighestDeclaration = (action: BlowAction) =>
     action.type === 'declare' &&
     currentHighestDeclaration?.timestamp === action.timestamp &&
-    currentHighestDeclaration.playerId === action.playerId;
+    currentHighestDeclaration.seatId === action.seatId;
 
   return (
     <section
@@ -66,9 +67,9 @@ export function BlowSpectatorPanel({
               <span className={styles.declarationValue}>
                 <span
                   className={styles.playerName}
-                  title={getPlayerName(currentHighestDeclaration.playerId)}
+                  title={getPlayerName(currentHighestDeclaration.seatId)}
                 >
-                  {getPlayerName(currentHighestDeclaration.playerId)}
+                  {getPlayerName(currentHighestDeclaration.seatId)}
                 </span>
                 <span
                   className={styles.trump}
@@ -89,16 +90,16 @@ export function BlowSpectatorPanel({
           <ol className={styles.historyList}>
             {chronologicalActions.map((action) => (
               <li
-                key={`${action.type}-${action.playerId}-${action.timestamp}`}
+                key={`${action.type}-${action.seatId}-${action.timestamp}`}
                 className={`${styles.historyItem} ${
                   action.type === 'pass' ? styles.pass : ''
                 } ${isHighestDeclaration(action) ? styles.highest : ''}`}
               >
                 <span
                   className={styles.playerName}
-                  title={getPlayerName(action.playerId)}
+                  title={getPlayerName(action.seatId)}
                 >
-                  {getPlayerName(action.playerId)}
+                  {getPlayerName(action.seatId)}
                 </span>
                 {action.type === 'pass' ? (
                   <span>{t('pass')}</span>

--- a/mei-tra-frontend/components/game/GameField/index.tsx
+++ b/mei-tra-frontend/components/game/GameField/index.tsx
@@ -39,8 +39,8 @@ export const GameField: React.FC<GameFieldProps> = ({
       <div className={styles.fieldContainerOuter}>
         <div className={styles.fieldContainerInner}>
           {currentField.cards.map((card: string, index: number) => {
-            const playedByPlayerId = currentField.playedBy?.[index] ?? '';
-            const position = getCardSeatPosition(playedByPlayerId, orderedPlayers);
+            const playedBySeatId = currentField.playedBySeatIds[index] ?? '';
+            const position = getCardSeatPosition(playedBySeatId, orderedPlayers);
 
             return (
               <div

--- a/mei-tra-frontend/components/game/GameTable/index.tsx
+++ b/mei-tra-frontend/components/game/GameTable/index.tsx
@@ -83,12 +83,12 @@ export const GameTable: React.FC<GameTableProps> = ({
   const [spectatorPerspectivePlayerId, setSpectatorPerspectivePlayerId] =
     useState<string | null>(null);
 
-  const hostPlayerId = players.find((player) => player.isHost)?.playerId ?? players[0]?.playerId ?? null;
+  const hostPlayerId = players.find((player) => player.isHost)?.seatId ?? players[0]?.seatId ?? null;
   const tablePerspectivePlayerId = isSpectator
     ? spectatorPerspectivePlayerId ?? hostPlayerId
     : currentPlayerId;
   const perspectivePlayerTeam = players.find(
-    (player) => player.playerId === tablePerspectivePlayerId,
+    (player) => player.seatId === tablePerspectivePlayerId,
   )?.team ?? 0;
 
   useEffect(() => {
@@ -100,7 +100,7 @@ export const GameTable: React.FC<GameTableProps> = ({
     }
 
     const hasSelectedPerspective = players.some(
-      (player) => player.playerId === spectatorPerspectivePlayerId,
+      (player) => player.seatId === spectatorPerspectivePlayerId,
     );
     if (!hasSelectedPerspective) {
       setSpectatorPerspectivePlayerId(hostPlayerId);
@@ -122,7 +122,6 @@ export const GameTable: React.FC<GameTableProps> = ({
   const createCOMSlot = (idx: number): Player => ({
     socketId: `com-${idx}`,
     seatId: asSeatId(`com-${idx}`),
-    playerId: `com-${idx}`,
     name: 'COM',
     team: (idx % 2) as Player['team'],
     hand: [],
@@ -198,7 +197,7 @@ export const GameTable: React.FC<GameTableProps> = ({
           const position = positions[idx];
           const currentPlayerTeam = isSpectator
             ? perspectivePlayerTeam
-            : players.find(p => p.playerId === currentPlayerId)?.team ?? 0;
+            : players.find(p => p.seatId === currentPlayerId)?.team ?? 0;
 
           // Show all team's completed fields only for bottom player
           const teamCompletedFields = position === 'bottom'
@@ -210,9 +209,9 @@ export const GameTable: React.FC<GameTableProps> = ({
 
           return (
             <PlayerHand
-              key={player_.playerId}
+              key={player_.seatId}
               player={player_}
-              isCurrentTurn={whoseTurn === player_.playerId}
+              isCurrentTurn={whoseTurn === player_.seatId}
               negriCard={negriCard}
               gamePhase={gamePhase}
               whoseTurn={whoseTurn}
@@ -227,11 +226,11 @@ export const GameTable: React.FC<GameTableProps> = ({
               takenCount={takenCount}
               teamNames={teamNames}
               isHost={isHost}
-              isIdle={idlePlayerIds.includes(player_.playerId)}
-              isDisconnected={disconnectedPlayerIds.includes(player_.playerId)}
+              isIdle={idlePlayerIds.includes(player_.seatId)}
+              isDisconnected={disconnectedPlayerIds.includes(player_.seatId)}
               isSpectator={isSpectator}
               isSpectatorPerspective={
-                isSpectator && tablePerspectivePlayerId === player_.playerId
+                isSpectator && tablePerspectivePlayerId === player_.seatId
               }
               onSpectatorPerspectiveChange={
                 isSpectator ? setSpectatorPerspectivePlayerId : undefined

--- a/mei-tra-frontend/components/game/PlayerAvatar/index.tsx
+++ b/mei-tra-frontend/components/game/PlayerAvatar/index.tsx
@@ -21,7 +21,7 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
   const [profile, setProfile] = useState<PlayerProfile | null>(null);
   const [imageError, setImageError] = useState(false);
   const {
-    playerId,
+    seatId,
     userId,
     isAuthenticated,
     isCOM,
@@ -55,7 +55,7 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
       cancelled = true;
     };
   }, [
-    playerId,
+    seatId,
     userId,
     isAuthenticated,
     isCOM,
@@ -65,7 +65,7 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
 
   useEffect(() => {
     setImageError(false);
-  }, [playerId, profile?.avatarUrl]);
+  }, [seatId, profile?.avatarUrl]);
 
   const handleImageError = () => {
     setImageError(true);

--- a/mei-tra-frontend/components/game/PlayerHand/index.tsx
+++ b/mei-tra-frontend/components/game/PlayerHand/index.tsx
@@ -32,7 +32,7 @@ interface PlayerHandProps {
   gameActions: GameActions;
   position: string;
   agariCard?: string;
-  currentHighestDeclaration?: Pick<BlowDeclaration, 'playerId'> & Partial<Pick<BlowDeclaration, 'trumpType' | 'numberOfPairs'>>;
+  currentHighestDeclaration?: Pick<BlowDeclaration, 'seatId'> & Partial<Pick<BlowDeclaration, 'trumpType' | 'numberOfPairs'>>;
   completedFields: CompletedField[];
   currentPlayerId: string;
   currentField: Field | null;
@@ -90,9 +90,9 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
     currentField,
     currentTrump,
   );
-  const isCurrentPlayer = currentPlayerId === player.playerId;
+  const isCurrentPlayer = currentPlayerId === player.seatId;
   const canActAsCurrentPlayer = isCurrentPlayer && !isSpectator;
-  const isWinningPlayer = currentHighestDeclaration?.playerId === player.playerId;
+  const isWinningPlayer = currentHighestDeclaration?.seatId === player.seatId;
   const playerDeclaration = isWinningPlayer && currentHighestDeclaration?.trumpType
     ? {
       trumpType: currentHighestDeclaration.trumpType,
@@ -131,13 +131,13 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
     }
 
     autoRevealAttemptedRef.current = true;
-    gameActions.revealBrokenHand(player.playerId);
+    gameActions.revealBrokenHand(player.seatId);
   }, [
     gamePhase,
     gameActions,
     canActAsCurrentPlayer,
     player.hasRequiredBroken,
-    player.playerId,
+    player.seatId,
   ]);
 
   useEffect(() => {
@@ -222,7 +222,7 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
     }
 
     if (gamePhase === 'play' && whoseTurn === currentPlayerId) {
-      if (!negriCard && currentHighestDeclaration?.playerId === player.playerId) {
+      if (!negriCard && currentHighestDeclaration?.seatId === player.seatId) {
         setSelectedNegriCard(card);
       } else {
         setSelectedCard(card);
@@ -427,7 +427,7 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
       {gamePhase === 'blow' && canActAsCurrentPlayer && player.hasBroken && (
         <button
           className={styles.brokenButton}
-          onClick={() => gameActions.revealBrokenHand(player.playerId)}
+          onClick={() => gameActions.revealBrokenHand(player.seatId)}
         >
           {t('revealBroken')}
         </button>
@@ -484,7 +484,7 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
             <button
               type="button"
               className={`${styles.playerInfoContainer} ${styles.spectatorPerspectiveButton} ${isCurrentTurn ? styles.currentTurn : ''} ${isSpectatorPerspective ? styles.spectatorPerspective : ''}`}
-              onClick={() => onSpectatorPerspectiveChange?.(player.playerId)}
+              onClick={() => onSpectatorPerspectiveChange?.(player.seatId)}
               aria-pressed={isSpectatorPerspective}
               aria-label={`Switch spectator perspective to ${player.name}`}
             >
@@ -511,7 +511,7 @@ export const PlayerHand: React.FC<PlayerHandProps> = ({
                 <button
                   type="button"
                   className={styles.replaceWithComButton}
-                  onClick={() => onReplaceWithCOM(player.playerId)}
+                  onClick={() => onReplaceWithCOM(player.seatId)}
                 >
                   {tStatus('replaceWithCom')}
                 </button>

--- a/mei-tra-frontend/components/game/PreGameTable/index.tsx
+++ b/mei-tra-frontend/components/game/PreGameTable/index.tsx
@@ -27,7 +27,6 @@ function createEmptySlot(index: number): Player {
   return {
     socketId: `empty-${index}`,
     seatId: asSeatId(`empty-${index}`),
-    playerId: `empty-${index}`,
     name: 'COM',
     team: (index % 2) as Player['team'],
     hand: [],
@@ -91,7 +90,7 @@ export const PreGameTable: React.FC<PreGameTableProps> = ({
     <div className={styles.playerPositions}>
       {slots.map((player, idx) => (
         <div
-          key={player.playerId}
+          key={player.seatId}
           className={`${styles.playerSeat} ${styles[positions[idx]]} ${
             player.team === 0 ? styles.teamRed : styles.teamBlack
           }`}
@@ -104,11 +103,11 @@ export const PreGameTable: React.FC<PreGameTableProps> = ({
             {isHost &&
               onRemovePlayer &&
               !player.isCOM &&
-              player.playerId !== currentPlayerId && (
+              player.seatId !== currentPlayerId && (
                 <button
                   type="button"
                   className={styles.seatActionButton}
-                  onClick={() => onRemovePlayer(player.playerId)}
+                  onClick={() => onRemovePlayer(player.seatId)}
                 >
                   {tRoot('room.removePlayer')}
                 </button>

--- a/mei-tra-frontend/components/room/RoomList/index.tsx
+++ b/mei-tra-frontend/components/room/RoomList/index.tsx
@@ -171,7 +171,7 @@ export const RoomList: React.FC<RoomListProps> = ({
               .filter(
                 (player, index, players) =>
                   players.findIndex(
-                    (candidate) => candidate.playerId === player.playerId,
+                    (candidate) => candidate.seatId === player.seatId,
                   ) === index,
               )
               .slice(0, room.settings.maxPlayers);
@@ -187,7 +187,7 @@ export const RoomList: React.FC<RoomListProps> = ({
                   <ul className={styles.playerList}>
                     {displayPlayers.map((player, index) => (
                       <li
-                        key={`${player.playerId}-${index}`}
+                        key={`${player.seatId}-${index}`}
                         className={styles.playerItem}
                       >
                         <span className={styles.playerName} title={player.name}>{player.name}</span>

--- a/mei-tra-frontend/hooks/useGame.ts
+++ b/mei-tra-frontend/hooks/useGame.ts
@@ -84,7 +84,7 @@ const dedupeCompletedFields = (fields: CompletedField[]): CompletedField[] => {
   const seen = new Set<string>();
 
   return fields.filter((field) => {
-    const signature = `${field.winnerId}|${field.winnerTeam}|${field.cards.join(',')}`;
+    const signature = `${field.winnerSeatId}|${field.winnerTeam}|${field.cards.join(',')}`;
     if (seen.has(signature)) {
       return false;
     }
@@ -105,12 +105,12 @@ const toUiBlowDeclaration = (
   declaration: BlowDeclarationContract,
 ): BlowDeclaration => {
   const seatId = declaration.seatId;
-  return { ...declaration, seatId, playerId: seatId };
+  return { ...declaration, seatId };
 };
 
 const toUiBlowAction = (action: BlowActionContract): BlowAction => {
   const seatId = action.seatId;
-  return { ...action, seatId, playerId: seatId };
+  return { ...action, seatId };
 };
 
 const toUiField = (field: FieldContract | null): Field | null => {
@@ -123,11 +123,9 @@ const toUiField = (field: FieldContract | null): Field | null => {
   return {
     cards: field.cards,
     playedBySeatIds,
-    playedBy: playedBySeatIds,
     baseCard: field.baseCard,
     baseSuit: field.baseSuit,
     dealerSeatId,
-    dealerId: dealerSeatId,
     isComplete: field.isComplete,
   };
 };
@@ -140,10 +138,8 @@ const toUiCompletedField = (
   return {
     cards: field.cards,
     winnerSeatId,
-    winnerId: winnerSeatId,
     winnerTeam: field.winnerTeam,
     dealerSeatId,
-    dealerId: dealerSeatId,
   };
 };
 
@@ -172,11 +168,11 @@ const mergePlayersPreservingIdentity = (
   nextPlayers: Player[],
 ): Player[] => {
   const previousByPlayerId = new Map(
-    previousPlayers.map((player) => [player.playerId, player]),
+    previousPlayers.map((player) => [player.seatId, player]),
   );
 
   return nextPlayers.map((nextPlayer) => {
-    const previousPlayer = previousByPlayerId.get(nextPlayer.playerId);
+    const previousPlayer = previousByPlayerId.get(nextPlayer.seatId);
     if (!previousPlayer || nextPlayer.isCOM) {
       return nextPlayer;
     }
@@ -311,17 +307,17 @@ export const useGame = () => {
   );
 
   const syncDisconnectedPlayerIdsFromPlayers = useCallback(
-    (nextPlayers: Array<Pick<Player, 'playerId' | 'isCOM' | 'socketId'>>) => {
+    (nextPlayers: Array<Pick<Player, 'seatId' | 'isCOM' | 'socketId'>>) => {
       setDisconnectedPlayerIds(
         nextPlayers
           .filter((player) => !player.isCOM && !player.socketId)
-          .map((player) => player.playerId),
+          .map((player) => player.seatId),
       );
     },
     [],
   );
 
-  const resolveCurrentUserPlayerId = useCallback(<T extends { playerId: string; userId?: string }>(
+  const resolveCurrentUserPlayerId = useCallback(<T extends { seatId: string; userId?: string }>(
     nextPlayers: T[],
     fallbackPlayerId?: string | null,
     serverPlayerId?: string | null,
@@ -356,15 +352,15 @@ export const useGame = () => {
   const hasPlayerActedInCurrentBlow = useCallback(
     (playerId: string): boolean => {
       const player = playersRef.current.find(
-        (candidate) => candidate.playerId === playerId,
+        (candidate) => candidate.seatId === playerId,
       );
 
       return (
         Boolean(player?.isPasser) ||
         blowDeclarations.some(
-          (declaration) => declaration.playerId === playerId,
+          (declaration) => declaration.seatId === playerId,
         ) ||
-        blowActionHistory.some((action) => action.playerId === playerId)
+        blowActionHistory.some((action) => action.seatId === playerId)
       );
     },
     [blowActionHistory, blowDeclarations],
@@ -477,7 +473,7 @@ export const useGame = () => {
       !currentRoomId ||
       gamePhase !== 'play' ||
       !currentPlayerId ||
-      currentHighestDeclaration?.playerId !== currentPlayerId ||
+      currentHighestDeclaration?.seatId !== currentPlayerId ||
       revealedAgari ||
       negriCard
     ) {
@@ -553,7 +549,7 @@ export const useGame = () => {
         syncDisconnectedPlayerIdsFromPlayers(nextPlayers);
         setIdlePlayerIds((idleIds) =>
           idleIds.filter((playerId) =>
-            nextPlayers.some((player) => player.playerId === playerId),
+            nextPlayers.some((player) => player.seatId === playerId),
           ),
         );
         if (!isSpectator) {
@@ -602,7 +598,7 @@ export const useGame = () => {
       'name-updated': ({ success, playerId, name, error }: { success: boolean; playerId?: string; name?: string; error?: string }) => {
         if (success && playerId && name) {
           setUsers((prev) => {
-            const existingIndex = prev.findIndex((u) => u.playerId === playerId);
+            const existingIndex = prev.findIndex((u) => u.seatId === playerId);
             const baseUser = {
               socketId: '',
               seatId: asSeatId(playerId),
@@ -639,7 +635,7 @@ export const useGame = () => {
         syncDisconnectedPlayerIdsFromPlayers(nextPlayers);
         setIdlePlayerIds((prev) =>
           prev.filter((playerId) =>
-            nextPlayers.some((player) => player.playerId === playerId),
+            nextPlayers.some((player) => player.seatId === playerId),
           ),
         );
         syncCurrentPlayerIdentity(nextPlayers, currentPlayerId);
@@ -661,7 +657,7 @@ export const useGame = () => {
           Boolean(
             selfPlayerId &&
               nextRoom.players.some(
-                (player) => player.playerId === selfPlayerId,
+                (player) => player.seatId === selfPlayerId,
               ),
           );
 
@@ -673,7 +669,7 @@ export const useGame = () => {
           setCurrentRoomId(nextRoom.id);
         }
 
-        setCurrentHostId(nextRoom.hostId);
+        setCurrentHostId(nextRoom.hostSeatId);
         setTeamNames(nextRoom.settings.teamNames);
         if (selfPlayerId) {
           setCurrentPlayerId(selfPlayerId);
@@ -692,7 +688,7 @@ export const useGame = () => {
           Boolean(
             selfPlayerId &&
               nextRoom.players.some(
-                (player) => player.playerId === selfPlayerId,
+                (player) => player.seatId === selfPlayerId,
               ),
           );
 
@@ -712,7 +708,7 @@ export const useGame = () => {
           setCurrentRoomId(nextRoom.id);
         }
 
-        setCurrentHostId(nextRoom.hostId);
+        setCurrentHostId(nextRoom.hostSeatId);
         setTeamNames(nextRoom.settings.teamNames);
         if (selfPlayerId) {
           setCurrentPlayerId(selfPlayerId);
@@ -792,7 +788,7 @@ export const useGame = () => {
         setTeamNames(teamNames);
         setIdlePlayerIds((prev) =>
           prev.filter((playerId) =>
-            nextPlayers.some((player) => player.playerId === playerId),
+            nextPlayers.some((player) => player.seatId === playerId),
           ),
         );
       },
@@ -816,14 +812,14 @@ export const useGame = () => {
           return;
         }
         updatePlayersLocally((prev) => {
-          const existingPlayer = prev.find(p => p.playerId === joinedSeatId);
+          const existingPlayer = prev.find(p => p.seatId === joinedSeatId);
           if (existingPlayer) {
             return prev;
           }
 
           // Look up display name from users list by playerId (not socket.id).
           // Use usersRef.current to avoid stale closure — users state may be empty at handler registration time.
-          const knownUser = usersRef.current.find(u => u.playerId === joinedSeatId);
+          const knownUser = usersRef.current.find(u => u.seatId === joinedSeatId);
 
           return [...prev, {
             socketId: knownUser?.socketId ?? '',
@@ -846,7 +842,7 @@ export const useGame = () => {
 
         updatePlayersLocally((prev) =>
           prev.map((player) =>
-            player.userId === userId || player.playerId === userId
+            player.userId === userId || player.seatId === userId
               ? { ...player, profileRevision }
               : player,
           ),
@@ -970,7 +966,7 @@ export const useGame = () => {
       // 'reveal-hands': ({ players }: { players: { playerId: string; hand: string[] }[] }) => {
       //   setPlayers(currentPlayers => 
       //     currentPlayers.map(p => {
-      //       const revealedPlayer = players.find(rp => rp.playerId === p.playerId);
+      //       const revealedPlayer = players.find(rp => rp.seatId === p.seatId);
       //       return revealedPlayer ? { ...p, hand: revealedPlayer.hand } : p;
       //     })
       //   );
@@ -1056,7 +1052,7 @@ export const useGame = () => {
         gameEventStateRef.current = {
           ...gameEventStateRef.current,
           players: gameEventStateRef.current.players.map((player) =>
-            player.playerId === playerId
+            player.seatId === playerId
               ? {
                   ...player,
                   socketId: '',
@@ -1067,7 +1063,7 @@ export const useGame = () => {
         };
         updatePlayersLocally((prev) =>
           prev.map((player) =>
-            player.playerId === playerId
+            player.seatId === playerId
               ? {
                   ...player,
                   socketId: '',
@@ -1120,7 +1116,7 @@ export const useGame = () => {
         gameEventStateRef.current = {
           ...gameEventStateRef.current,
           players: gameEventStateRef.current.players.map((player) =>
-            player.playerId === playerId
+            player.seatId === playerId
               ? { ...player, isCOM: true, socketId: '' }
               : player,
           ),

--- a/mei-tra-frontend/hooks/useRoom.ts
+++ b/mei-tra-frontend/hooks/useRoom.ts
@@ -55,7 +55,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
         serverPlayerId: currentPlayerId,
       });
       return (
-        room.players.find((player) => player.playerId === playerId) ?? null
+        room.players.find((player) => player.seatId === playerId) ?? null
       );
     },
     [currentPlayerId, user?.id],
@@ -237,7 +237,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
                 hand: [],
                 team: (index % 2) as Team,
                 isReady: false,
-                isHost: room.hostId === p,
+                isHost: room.hostSeatId === p,
                 joinedAt: new Date()
               } as RoomPlayer;
             }
@@ -246,14 +246,13 @@ export const useRoom = (options: UseRoomOptions = {}) => {
 
           // 既存プレイヤーチェック（重複防止）
           const alreadyInRoom = existingPlayers.some(
-            (player) => player.playerId === joinedSeatId,
+            (player) => player.seatId === joinedSeatId,
           );
           if (alreadyInRoom) return room;
 
           const newPlayer: RoomPlayer = {
             socketId: '',
             seatId: joinedSeatId,
-            playerId: joinedSeatId,
             name: joinedSeatId,
             hand: [],
             team: (existingPlayers.length % 2) as Team,
@@ -298,7 +297,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
           if (!prev) return null;
 
           const updatedPlayers = prev.players.map(p =>
-            p.playerId === playerId
+            p.seatId === playerId
               ? {
                   ...p,
                   socketId: '',
@@ -315,15 +314,15 @@ export const useRoom = (options: UseRoomOptions = {}) => {
               : p
           );
 
-          if (prev.hostId === playerId) {
+          if (prev.hostSeatId === playerId) {
             const newHost = updatedPlayers.find(p => !p.isCOM);
             if (newHost) {
               return {
                 ...prev,
                 players: updatedPlayers.map(p =>
-                  p.playerId === newHost.playerId ? { ...p, isHost: true } : p
+                  p.seatId === newHost.seatId ? { ...p, isHost: true } : p
                 ),
-                hostId: newHost.playerId,
+                hostSeatId: newHost.seatId,
               };
             }
           }
@@ -412,7 +411,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
     ): Room => ({
       ...room,
       players: room.players.map((player) =>
-        player.userId === userId || player.playerId === userId
+        player.userId === userId || player.seatId === userId
           ? { ...player, profileRevision }
           : player,
       ),
@@ -434,7 +433,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
       setAvailableRooms((prevRooms) =>
         prevRooms.map((room) =>
           room.players.some(
-            (player) => player.userId === userId || player.playerId === userId,
+            (player) => player.userId === userId || player.seatId === userId,
           )
             ? applyProfileRevision(room, userId, profileRevision)
             : room,
@@ -588,7 +587,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
     const displayName = user.profile?.displayName || user.email || 'User';
     const userToJoin = {
       socketId: socket.id ?? '',
-      playerId: user.id,  // Supabase userId — must match room.hostId set during createRoom
+      playerId: user.id, // Transport field carries the Supabase user ID during room creation.
       name: displayName,
       userId: user.id,
       isAuthenticated: true
@@ -644,13 +643,13 @@ export const useRoom = (options: UseRoomOptions = {}) => {
     // userId でマッチング（socket.id は再接続で変わるため使わない）
     const player = resolveSelfRoomPlayer(room);
 
-    if (!player?.playerId) {
+    if (!player?.seatId) {
       console.error('[useRoom] Cannot leave room: player not found');
       setError('Player not found in room');
       return;
     }
 
-    socket.emit('leave-room', { roomId, playerId: player.playerId }, (response: { success: boolean; error?: string }) => {
+    socket.emit('leave-room', { roomId, playerId: player.seatId }, (response: { success: boolean; error?: string }) => {
       if (response.success) {
         if (typeof window !== 'undefined') {
           sessionStorage.removeItem('roomId');
@@ -680,7 +679,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
       setError('Player not found in room');
       return;
     }
-    if (!player.playerId) {
+    if (!player.seatId) {
       setError('Player ID is not set');
       return;
     }
@@ -688,12 +687,12 @@ export const useRoom = (options: UseRoomOptions = {}) => {
     // ローカルの準備状態を即時更新
     setPlayerReadyStatus(prev => ({
       ...prev,
-      [player.playerId]: !prev[player.playerId]
+      [player.seatId]: !prev[player.seatId]
     }));
 
     socket.emit('toggle-player-ready', {
       roomId: currentRoom.id,
-      playerId: player.playerId
+      playerId: player.seatId
     });
   }, [socket, currentRoom, resolveSelfRoomPlayer]);
 
@@ -713,7 +712,7 @@ export const useRoom = (options: UseRoomOptions = {}) => {
 
     socket.emit('start-game', {
       roomId: currentRoom.id,
-      playerId: player.playerId
+      playerId: player.seatId
     });
   }, [socket, currentRoom, resolveSelfRoomPlayer]);
 
@@ -722,11 +721,11 @@ export const useRoom = (options: UseRoomOptions = {}) => {
     if (!socket) return;
     const room = availableRooms.find(r => r.id === roomId) || currentRoom;
     const player = resolveSelfRoomPlayer(room);
-    if (!player?.playerId) {
+    if (!player?.seatId) {
       console.error('[useRoom] Cannot fill with COM: player not found');
       return;
     }
-    socket.emit('fill-with-com', { roomId, playerId: player.playerId });
+    socket.emit('fill-with-com', { roomId, playerId: player.seatId });
   }, [socket, currentRoom, availableRooms, resolveSelfRoomPlayer]);
 
   // プレイヤーのチーム変更
@@ -737,13 +736,13 @@ export const useRoom = (options: UseRoomOptions = {}) => {
     // userId でマッチング（socket.id は再接続で変わるため使わない）
     const player = resolveSelfRoomPlayer(room);
 
-    if (!player?.playerId) {
+    if (!player?.seatId) {
       console.error('[useRoom] Cannot change team: player not found');
       return Promise.resolve(false);
     }
 
     return new Promise((resolve) => {
-      socket.emit('change-player-team', { roomId, playerId: player.playerId, teamChanges }, (response: { success: boolean }) => {
+      socket.emit('change-player-team', { roomId, playerId: player.seatId, teamChanges }, (response: { success: boolean }) => {
         resolve(response.success);
       });
     });

--- a/mei-tra-frontend/lib/utils/playerIdentity.ts
+++ b/mei-tra-frontend/lib/utils/playerIdentity.ts
@@ -1,5 +1,5 @@
 export interface PlayerIdentity {
-  playerId: string;
+  seatId: string;
   userId?: string;
 }
 
@@ -13,7 +13,7 @@ export function resolveSelfPlayerId<T extends PlayerIdentity>(
 ): string | null {
   if (
     options.serverPlayerId &&
-    players.some((player) => player.playerId === options.serverPlayerId)
+    players.some((player) => player.seatId === options.serverPlayerId)
   ) {
     return options.serverPlayerId;
   }
@@ -23,13 +23,13 @@ export function resolveSelfPlayerId<T extends PlayerIdentity>(
       (player) => player.userId === options.userId,
     );
     if (authenticatedMatches.length === 1) {
-      return authenticatedMatches[0].playerId;
+      return authenticatedMatches[0].seatId;
     }
   }
 
   if (
     options.fallbackPlayerId &&
-    players.some((player) => player.playerId === options.fallbackPlayerId)
+    players.some((player) => player.seatId === options.fallbackPlayerId)
   ) {
     return options.fallbackPlayerId;
   }

--- a/mei-tra-frontend/types/game.types.ts
+++ b/mei-tra-frontend/types/game.types.ts
@@ -13,8 +13,6 @@ export type TrumpType = 'tra' | 'herz' | 'daiya' | 'club' | 'zuppe';
 export interface ConnectionUser {
   socketId: string; // Connection/session identifier only
   seatId: SeatId;
-  /** @deprecated Use seatId. */
-  playerId: string;
   name: string;
   userId?: string; // Canonical authenticated account ID
   isAuthenticated?: boolean;
@@ -24,30 +22,24 @@ export interface ConnectionUser {
 export interface CompletedField {
   cards: string[];
   winnerSeatId: SeatId;
-  winnerId: string;
   winnerTeam: Team;
   dealerSeatId: SeatId;
-  dealerId: string;
 }
 
 export interface Field {
   cards: string[];
-  playedBy: string[];
   playedBySeatIds: SeatId[];
   baseCard: string;
   baseSuit?: string;
   dealerSeatId: SeatId;
-  dealerId: string;
   isComplete: boolean;
 }
 
 // Update socket event types
 export interface FieldCompleteEvent {
   winnerSeatId: SeatId;
-  winnerId: string;
   field: CompletedField;
   nextSeatId: SeatId;
-  nextPlayerId: string;
 }
 
 export interface Player extends ConnectionUser {
@@ -62,7 +54,6 @@ export interface Player extends ConnectionUser {
 
 export interface BlowDeclaration {
   seatId: SeatId;
-  playerId: string;
   team?: Team;
   trumpType: TrumpType;
   numberOfPairs: number;
@@ -72,7 +63,6 @@ export interface BlowDeclaration {
 export interface BlowAction {
   type: 'declare' | 'pass';
   seatId: SeatId;
-  playerId: string;
   trumpType?: TrumpType;
   numberOfPairs?: number;
   timestamp: number;
@@ -83,7 +73,7 @@ export interface BlowState {
   currentHighestDeclaration: BlowDeclaration | null;
   declarations: BlowDeclaration[];
   actionHistory: BlowAction[];
-  lastPasser: string | null;
+  lastPasserSeatId: SeatId | null;
   isRoundCancelled: boolean;
   currentBlowIndex: number;
 }
@@ -128,7 +118,6 @@ export function fromPlayerContract(player: PlayerContract): Player {
   return {
     socketId: normalized.socketId,
     seatId: normalized.seatId,
-    playerId: normalized.playerId,
     name: normalized.name,
     userId: normalized.userId,
     isAuthenticated: normalized.isAuthenticated,

--- a/mei-tra-frontend/types/room.types.ts
+++ b/mei-tra-frontend/types/room.types.ts
@@ -15,7 +15,6 @@ export interface Room {
   id: string;
   name: string;
   hostSeatId: SeatId;
-  hostId: string;
   status: RoomStatus;
   players: RoomPlayer[];
   settings: RoomSettings;
@@ -59,7 +58,6 @@ export function fromRoomPlayerContract(
   return {
     socketId: normalized.socketId,
     seatId: normalized.seatId,
-    playerId: normalized.playerId,
     name: normalized.name,
     userId: normalized.userId,
     isAuthenticated: normalized.isAuthenticated,
@@ -81,7 +79,6 @@ export function fromRoomContract(room: RoomContract): Room {
     id: normalized.id,
     name: normalized.name,
     hostSeatId: normalized.hostSeatId!,
-    hostId: normalized.hostId,
     status: toRoomStatus(normalized.status),
     players: normalized.players.map(fromRoomPlayerContract),
     settings: {

--- a/mei-tra-mobile/src/app/rooms.tsx
+++ b/mei-tra-mobile/src/app/rooms.tsx
@@ -208,7 +208,7 @@ export default function RoomsScreen() {
             const players = room.players.filter(
               (player, index, all) =>
                 all.findIndex(
-                  (candidate) => candidate.playerId === player.playerId,
+                  (candidate) => candidate.seatId === player.seatId,
                 ) === index,
             );
             const humans = players.filter((player) => !player.isCOM);

--- a/mei-tra-mobile/src/components/game/BlowControls.tsx
+++ b/mei-tra-mobile/src/components/game/BlowControls.tsx
@@ -55,7 +55,7 @@ export function BlowControls({
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMyTurn = currentTurn === currentPlayerId;
   const turnName =
-    players.find((player) => player.playerId === currentTurn)?.name ?? '—';
+    players.find((player) => player.seatId === currentTurn)?.name ?? '—';
 
   const validPairs = useMemo(
     () => getValidBlowPairValues(highest, selectedTrump),

--- a/mei-tra-mobile/src/components/game/GameBoard.tsx
+++ b/mei-tra-mobile/src/components/game/GameBoard.tsx
@@ -98,8 +98,8 @@ export function GameBoard({
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const hostPlayerId =
-    game.players.find((p) => p.isHost)?.playerId ??
-    game.players[0]?.playerId ??
+    game.players.find((p) => p.isHost)?.seatId ??
+    game.players[0]?.seatId ??
     null;
   const perspectivePlayerId = game.isSpectator
     ? spectatorPerspectiveId ?? hostPlayerId
@@ -108,13 +108,13 @@ export function GameBoard({
   useEffect(() => {
     if (!game.isSpectator) return;
     const valid = game.players.some(
-      (p) => p.playerId === spectatorPerspectiveId,
+      (p) => p.seatId === spectatorPerspectiveId,
     );
     if (!valid) setSpectatorPerspectiveId(hostPlayerId);
   }, [game.isSpectator, game.players, hostPlayerId, spectatorPerspectiveId]);
 
   const self = game.players.find(
-    (player) => player.playerId === perspectivePlayerId,
+    (player) => player.seatId === perspectivePlayerId,
   );
   const { width: windowWidth } = useWindowDimensions();
   // Size the fan from the hand it actually renders. Spectators have no
@@ -160,7 +160,7 @@ export function GameBoard({
   const mustSelectNegri =
     !game.isSpectator &&
     game.gamePhase === 'play' &&
-    highest?.playerId === game.youSeatId &&
+    highest?.seatId === game.youSeatId &&
     !game.negriCard;
   const isMyTurn =
     !game.isSpectator && game.currentTurnSeatId === game.youSeatId;
@@ -293,31 +293,31 @@ export function GameBoard({
           {opponentSlots.map(({ player, position }) => {
             const hasNegri =
               game.gamePhase === 'play' &&
-              game.negriSeatId === player.playerId;
-            const blowWinnerId = highest?.playerId;
+              game.negriSeatId === player.seatId;
+            const blowWinnerId = highest?.seatId;
             const hasAgari =
               game.gamePhase === 'play' &&
               game.revealedAgari &&
-              blowWinnerId === player.playerId;
+              blowWinnerId === player.seatId;
             const seatEl = (
               <PlayerSeat
-                key={player.playerId}
+                key={player.seatId}
                 agariCard={hasAgari ? game.revealedAgari ?? undefined : undefined}
                 declaration={
-                  highest && highest.playerId === player.playerId
+                  highest && highest.seatId === player.seatId
                     ? `${TRUMP_LABELS[highest.trumpType]} ${highest.numberOfPairs}`
                     : undefined
                 }
-                isBlowWinner={blowWinnerId === player.playerId}
+                isBlowWinner={blowWinnerId === player.seatId}
                 isDisconnected={game.disconnectedPlayerIds.includes(
-                  player.playerId,
+                  player.seatId,
                 )}
-                isIdle={game.idlePlayerIds.includes(player.playerId)}
-                isTurn={game.currentTurnSeatId === player.playerId}
+                isIdle={game.idlePlayerIds.includes(player.seatId)}
+                isTurn={game.currentTurnSeatId === player.seatId}
                 negriCard={hasNegri ? 'hidden' : undefined}
                 onPress={
                   game.isSpectator
-                    ? () => setSpectatorPerspectiveId(player.playerId)
+                    ? () => setSpectatorPerspectiveId(player.seatId)
                     : undefined
                 }
                 player={player}
@@ -333,7 +333,7 @@ export function GameBoard({
                   : styles.seatRight;
             const wrapped = isHost && !player.isCOM ? (
               <Pressable
-                key={player.playerId}
+                key={player.seatId}
                 onLongPress={() => {
                   Alert.alert(
                     player.name,
@@ -341,12 +341,12 @@ export function GameBoard({
                     [
                       {
                         text: 'COMに置換',
-                        onPress: () => onReplaceWithCOM(player.playerId),
+                        onPress: () => onReplaceWithCOM(player.seatId),
                       },
                       {
                         text: '退出させる',
                         style: 'destructive',
-                        onPress: () => onRemovePlayer(player.playerId),
+                        onPress: () => onRemovePlayer(player.seatId),
                       },
                       { text: 'キャンセル', style: 'cancel' },
                     ],
@@ -357,18 +357,18 @@ export function GameBoard({
               </Pressable>
             ) : seatEl;
             const isDisconnected = game.disconnectedPlayerIds.includes(
-              player.playerId,
+              player.seatId,
             );
-            const isIdle = game.idlePlayerIds.includes(player.playerId);
+            const isIdle = game.idlePlayerIds.includes(player.seatId);
             // Matches the web condition (PlayerHand/index.tsx): the host never
             // sees the control on their own seat.
             const showReplacePanel =
               isHost &&
               !player.isCOM &&
-              player.playerId !== game.youSeatId &&
+              player.seatId !== game.youSeatId &&
               (isDisconnected || isIdle);
             return (
-              <View key={player.playerId} style={posStyle}>
+              <View key={player.seatId} style={posStyle}>
                 {wrapped}
                 {showReplacePanel ? (
                   <View style={styles.replacePanel}>
@@ -376,7 +376,7 @@ export function GameBoard({
                       {isDisconnected ? '切断中' : '無操作'}
                     </Text>
                     <Pressable
-                      onPress={() => onReplaceWithCOM(player.playerId)}
+                      onPress={() => onReplaceWithCOM(player.seatId)}
                       style={styles.replacePanelButton}
                     >
                       <Text style={styles.replacePanelButtonText}>
@@ -395,9 +395,9 @@ export function GameBoard({
             <View style={styles.fieldCenter}>
               {game.currentField?.cards.length ? (
                 game.currentField.cards.map((card, index) => {
-                  const playerId = game.currentField!.playedBy[index];
+                  const seatId = game.currentField!.playedBySeatIds[index];
                   const seat = getCardSeatPosition(
-                    playerId,
+                    seatId,
                     orderedPlayers,
                   );
                   const seatOffsets: Record<string, { x: number; y: number }> = {
@@ -479,7 +479,7 @@ export function GameBoard({
                 style={[
                   styles.selfCard,
                   (game.isSpectator
-                    ? game.currentTurnSeatId === self.playerId
+                    ? game.currentTurnSeatId === self.seatId
                     : isMyTurn) && styles.selfCardTurn,
                 ]}
               >
@@ -499,7 +499,7 @@ export function GameBoard({
                 <Text style={styles.selfFieldCountText}>
                   取得 {teamFieldCounts[self.team] ?? 0}場
                 </Text>
-                {game.gamePhase === 'play' && game.negriCard && highest?.playerId === self.playerId ? (
+                {game.gamePhase === 'play' && game.negriCard && highest?.seatId === self.seatId ? (
                   <View style={styles.selfSpecialRow}>
                     <PlayingCard card={game.negriCard} size="seat" />
                     <Text style={styles.selfSpecialLabel}>ネグリ</Text>
@@ -646,12 +646,12 @@ export function GameBoard({
                 .filter(
                   (p) =>
                     !p.isCOM &&
-                    game.disconnectedPlayerIds.includes(p.playerId),
+                    game.disconnectedPlayerIds.includes(p.seatId),
                 )
                 .map((p) => (
                   <Pressable
-                    key={p.playerId}
-                    onPress={() => onReplaceWithCOM(p.playerId)}
+                    key={p.seatId}
+                    onPress={() => onReplaceWithCOM(p.seatId)}
                     style={styles.pausedReplaceButton}
                   >
                     <Text style={styles.pausedReplaceButtonText}>

--- a/mei-tra-mobile/src/components/game/WaitingRoom.tsx
+++ b/mei-tra-mobile/src/components/game/WaitingRoom.tsx
@@ -115,7 +115,7 @@ export function WaitingRoom({
                 player &&
                 !player.isHost &&
                 !player.isCOM &&
-                player.playerId !== currentPlayerId;
+                player.seatId !== currentPlayerId;
               const seatView = (
                 <View
                   accessibilityLabel={`${player?.name ?? '空席'}、${
@@ -155,13 +155,13 @@ export function WaitingRoom({
                           {
                             text: 'COMに置換',
                             onPress: () =>
-                              onReplaceWithCOM(player.playerId),
+                              onReplaceWithCOM(player.seatId),
                           },
                           {
                             text: '退出させる',
                             style: 'destructive',
                             onPress: () =>
-                              onRemovePlayer(player.playerId),
+                              onRemovePlayer(player.seatId),
                           },
                           { text: 'キャンセル', style: 'cancel' },
                         ],

--- a/mei-tra-mobile/src/context/GameContext.tsx
+++ b/mei-tra-mobile/src/context/GameContext.tsx
@@ -81,10 +81,10 @@ type Action =
   | { type: 'game'; game: MobileGameSnapshot }
   | { type: 'patchGame'; patch: Partial<MobileGameSnapshot> }
   | { type: 'players'; players: PlayerContract[] }
-  | { type: 'playerDisconnected'; playerId: string }
-  | { type: 'playerIdle'; playerId: string }
-  | { type: 'playerIdleCleared'; playerId: string }
-  | { type: 'playerConvertedToCom'; playerId: string }
+  | { type: 'playerDisconnected'; seatId: string }
+  | { type: 'playerIdle'; seatId: string }
+  | { type: 'playerIdleCleared'; seatId: string }
+  | { type: 'playerConvertedToCom'; seatId: string }
   | { type: 'error'; message: string | null }
   | { type: 'notice'; message: string | null }
   | { type: 'gameOver'; gameOver: MobileGameOver | null }
@@ -179,7 +179,7 @@ function reducer(state: MobileState, action: Action): MobileState {
       const roomPlayers = state.currentRoom
         ? state.currentRoom.players.map((roomPlayer) => {
             const updated = players.find(
-              (player) => player.playerId === roomPlayer.playerId,
+              (player) => player.seatId === roomPlayer.seatId,
             );
             return updated ? { ...roomPlayer, ...updated } : roomPlayer;
           })
@@ -201,15 +201,15 @@ function reducer(state: MobileState, action: Action): MobileState {
         game: {
           ...state.game,
           players: state.game.players.map((p) =>
-            p.playerId === action.playerId ? { ...p, socketId: '' } : p,
+            p.seatId === action.seatId ? { ...p, socketId: '' } : p,
           ),
           disconnectedPlayerIds: state.game.disconnectedPlayerIds.includes(
-            action.playerId,
+            action.seatId,
           )
             ? state.game.disconnectedPlayerIds
-            : [...state.game.disconnectedPlayerIds, action.playerId],
+            : [...state.game.disconnectedPlayerIds, action.seatId],
           idlePlayerIds: state.game.idlePlayerIds.filter(
-            (id) => id !== action.playerId,
+            (id) => id !== action.seatId,
           ),
         },
       };
@@ -220,9 +220,9 @@ function reducer(state: MobileState, action: Action): MobileState {
         ...state,
         game: {
           ...state.game,
-          idlePlayerIds: state.game.idlePlayerIds.includes(action.playerId)
+          idlePlayerIds: state.game.idlePlayerIds.includes(action.seatId)
             ? state.game.idlePlayerIds
-            : [...state.game.idlePlayerIds, action.playerId],
+            : [...state.game.idlePlayerIds, action.seatId],
         },
       };
     }
@@ -233,7 +233,7 @@ function reducer(state: MobileState, action: Action): MobileState {
         game: {
           ...state.game,
           idlePlayerIds: state.game.idlePlayerIds.filter(
-            (id) => id !== action.playerId,
+            (id) => id !== action.seatId,
           ),
         },
       };
@@ -245,10 +245,10 @@ function reducer(state: MobileState, action: Action): MobileState {
         game: {
           ...state.game,
           disconnectedPlayerIds: state.game.disconnectedPlayerIds.filter(
-            (id) => id !== action.playerId,
+            (id) => id !== action.seatId,
           ),
           idlePlayerIds: state.game.idlePlayerIds.filter(
-            (id) => id !== action.playerId,
+            (id) => id !== action.seatId,
           ),
         },
       };
@@ -775,7 +775,7 @@ export function GameProvider({ children }: PropsWithChildren) {
       gameEventStateRef.current = {
         ...gameEventStateRef.current,
         players: gameEventStateRef.current.players.map((player) =>
-          player.playerId === playerId
+          player.seatId === playerId
             ? {
                 ...player,
                 socketId: '',
@@ -784,7 +784,7 @@ export function GameProvider({ children }: PropsWithChildren) {
             : player,
         ),
       };
-      dispatch({ type: 'playerDisconnected', playerId });
+      dispatch({ type: 'playerDisconnected', seatId: playerId });
       dispatch({
         type: 'notice',
         message: `${playerName ?? playerId} が切断しました`,
@@ -793,14 +793,14 @@ export function GameProvider({ children }: PropsWithChildren) {
     socket.on('player-idle', (payload) => {
       const playerId = payload.seatId;
       const playerName = (payload as { playerName?: string }).playerName;
-      dispatch({ type: 'playerIdle', playerId });
+      dispatch({ type: 'playerIdle', seatId: playerId });
       dispatch({
         type: 'notice',
         message: `${playerName ?? playerId} が無操作です`,
       });
     });
     socket.on('player-idle-cleared', ({ seatId }) => {
-      dispatch({ type: 'playerIdleCleared', playerId: seatId });
+      dispatch({ type: 'playerIdleCleared', seatId });
     });
     socket.on(
       'player-converted-to-com',
@@ -813,7 +813,7 @@ export function GameProvider({ children }: PropsWithChildren) {
               : player,
           ),
         };
-        dispatch({ type: 'playerConvertedToCom', playerId: seatId });
+        dispatch({ type: 'playerConvertedToCom', seatId });
         if (seatId === asSeatId(resolveCurrentPlayerId() ?? '')) {
           void roomStorage.clear();
           dispatch({ type: 'resetRoom' });

--- a/mei-tra-mobile/src/context/__tests__/GameContext.test.tsx
+++ b/mei-tra-mobile/src/context/__tests__/GameContext.test.tsx
@@ -433,12 +433,12 @@ describe('GameProvider realtime resync safety', () => {
     expect(screen.latestGame.game?.players).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          playerId: 'player-2',
+          seatId: 'player-2',
           isCOM: true,
         }),
       ]),
     );
-    expect(screen.latestGame.game?.currentField?.playedBy).toEqual([
+    expect(screen.latestGame.game?.currentField?.playedBySeatIds).toEqual([
       'player-2',
     ]);
 

--- a/mei-tra-mobile/src/lib/__tests__/game-state.test.ts
+++ b/mei-tra-mobile/src/lib/__tests__/game-state.test.ts
@@ -21,7 +21,6 @@ const player = (
 ): MobilePlayer => ({
   socketId: `socket-${playerId}`,
   seatId: asSeatId(playerId),
-  playerId: asSeatId(playerId),
   name: playerId,
   userId: `user-${playerId}`,
   team: 0,
@@ -49,7 +48,7 @@ describe('mergePlayersByIdentity', () => {
       ),
     ).toEqual([
       expect.objectContaining({
-        playerId: 'player-1',
+        seatId: 'player-1',
         userId: 'user-1',
         name: 'Hikaru',
       }),
@@ -64,7 +63,7 @@ describe('mergePlayersByIdentity', () => {
       ),
     ).toEqual([
       expect.objectContaining({
-        playerId: 'player-1',
+        seatId: 'player-1',
         userId: undefined,
         name: 'COM 1',
       }),
@@ -115,7 +114,7 @@ describe('recovery helpers', () => {
       pointsToWin: 5,
     });
 
-    expect(snapshot.players).toEqual([expect.objectContaining({ playerId: 'server-player' })]);
+    expect(snapshot.players).toEqual([expect.objectContaining({ seatId: 'server-player' })]);
     expect(snapshot.fields).toHaveLength(1);
     expect(snapshot.youSeatId).toBe('server-player');
     expect(snapshot.negriSeatId).toBe('server-player');
@@ -137,7 +136,6 @@ describe('recovery helpers', () => {
             declarations: [],
             actionHistory: [],
             lastPasserSeatId: null,
-            lastPasser: null,
             isRoundCancelled: false,
             currentBlowIndex: 0,
           },
@@ -158,7 +156,6 @@ describe('recovery helpers', () => {
           id: 'room-1',
           name: 'room',
           hostSeatId: asSeatId('host'),
-          hostId: asSeatId('host'),
           status: 'waiting',
           players: [
             {
@@ -207,7 +204,7 @@ describe('recovery helpers', () => {
       pointsToWin: 5,
     });
 
-    expect(snapshot.players[0].playerId).toBe('canonical-seat');
+    expect(snapshot.players[0].seatId).toBe('canonical-seat');
     expect(snapshot.currentTurnSeatId).toBe('canonical-seat');
     expect(snapshot.youSeatId).toBe('canonical-seat');
     expect(snapshot.hostSeatId).toBe('canonical-seat');

--- a/mei-tra-mobile/src/lib/__tests__/table-order.test.ts
+++ b/mei-tra-mobile/src/lib/__tests__/table-order.test.ts
@@ -4,7 +4,7 @@ import {
 } from '@/lib/table-order';
 
 const player = (id: string) => ({
-  playerId: id,
+  seatId: id,
   team: 0,
 });
 
@@ -14,26 +14,26 @@ describe('getSeatOrderWithSelfBottom', () => {
   it('puts self at index 0 (bottom) and swaps indices 1/3', () => {
     // [A,B,C,D] rotate to C -> [C,D,A,B] -> swap 1&3 -> [C,B,A,D]
     const result = getSeatOrderWithSelfBottom(players, 'C');
-    expect(result.map((p) => p?.playerId)).toEqual(['C', 'B', 'A', 'D']);
+    expect(result.map((p) => p?.seatId)).toEqual(['C', 'B', 'A', 'D']);
   });
 
   it('applies swap even when self is null or missing', () => {
     // [A,B,C,D] -> no rotation, swap to [0,3,2,1] -> [A,D,C,B]
     const resultNull = getSeatOrderWithSelfBottom(players, null);
-    expect(resultNull.map((p) => p?.playerId)).toEqual(['A', 'D', 'C', 'B']);
+    expect(resultNull.map((p) => p?.seatId)).toEqual(['A', 'D', 'C', 'B']);
     const resultMissing = getSeatOrderWithSelfBottom(players, 'X');
-    expect(resultMissing.map((p) => p?.playerId)).toEqual(['A', 'D', 'C', 'B']);
+    expect(resultMissing.map((p) => p?.seatId)).toEqual(['A', 'D', 'C', 'B']);
   });
 
   it('handles self already at index 0', () => {
     const result = getSeatOrderWithSelfBottom(players, 'A');
-    expect(result.map((p) => p?.playerId)).toEqual(['A', 'D', 'C', 'B']);
+    expect(result.map((p) => p?.seatId)).toEqual(['A', 'D', 'C', 'B']);
   });
 
   it('keeps unoccupied seats empty instead of duplicating a player', () => {
     const result = getSeatOrderWithSelfBottom(players.slice(0, 2), 'A');
 
-    expect(result.map((p) => p?.playerId)).toEqual([
+    expect(result.map((p) => p?.seatId)).toEqual([
       'A',
       undefined,
       undefined,

--- a/mei-tra-mobile/src/lib/game-state.ts
+++ b/mei-tra-mobile/src/lib/game-state.ts
@@ -38,11 +38,11 @@ export const mergePlayersByIdentity = (
   const normalizedPrevious = normalizePlayerIdentities(previous);
   const normalizedNext = normalizePlayerIdentities(next);
   const previousByPlayerId = new Map(
-    normalizedPrevious.map((player) => [player.playerId, player]),
+    normalizedPrevious.map((player) => [player.seatId, player]),
   );
 
   return normalizedNext.map((player) => {
-    const oldPlayer = previousByPlayerId.get(player.playerId);
+    const oldPlayer = previousByPlayerId.get(player.seatId);
     if (!oldPlayer || player.isCOM) {
       return player;
     }
@@ -93,16 +93,16 @@ export const extractDisconnectedPlayerIds = (
 ): string[] =>
   normalizePlayerIdentities(players)
     .filter((p) => !p.isCOM && !p.socketId)
-    .map((p) => p.playerId);
+    .map((p) => p.seatId);
 
 export const createStartedGameSnapshot = (
   payload: GameStartedPayload,
-  currentPlayerId: string | null,
-  hostId: string | null,
+  currentSeatId: string | null,
+  hostSeatIdValue: string | null,
 ): MobileGameSnapshot => {
   const players = normalizePlayerIdentities(payload.players);
-  const youSeatId = currentPlayerId ? asSeatId(currentPlayerId) : null;
-  const hostSeatId = hostId ? asSeatId(hostId) : null;
+  const youSeatId = currentSeatId ? asSeatId(currentSeatId) : null;
+  const hostSeatId = hostSeatIdValue ? asSeatId(hostSeatIdValue) : null;
   return {
     roomId: payload.roomId,
     players,

--- a/shared/game-client/game-event-reducer.ts
+++ b/shared/game-client/game-event-reducer.ts
@@ -72,7 +72,6 @@ export const createEmptyBlowState = (): CanonicalBlowState => ({
   declarations: [],
   actionHistory: [],
   lastPasserSeatId: null,
-  lastPasser: null,
   isRoundCancelled: false,
   currentBlowIndex: 0,
 });
@@ -125,8 +124,8 @@ export const dedupeCompletedFields = (
   const seen = new Set<string>();
   return fields.map(normalizeCompletedFieldIdentity).filter((field) => {
     const key = [
-      field.dealerId,
-      field.winnerId,
+      field.dealerSeatId,
+      field.winnerSeatId,
       field.winnerTeam,
       field.cards.join(','),
     ].join('|');
@@ -140,11 +139,9 @@ export const dedupeCompletedFields = (
 
 const createEmptyField = (dealerSeatId: SeatId): CanonicalFieldContract => ({
   cards: [],
-  playedBy: [],
   playedBySeatIds: [],
   baseCard: '',
   dealerSeatId,
-  dealerId: dealerSeatId,
   isComplete: false,
 });
 
@@ -200,7 +197,6 @@ export const reduceGameEvent = (
             ? normalizeBlowDeclarationIdentity(event.payload.currentHighest)
             : null,
           lastPasserSeatId,
-          lastPasser: lastPasserSeatId,
         },
       };
     }
@@ -257,7 +253,7 @@ export const reduceGameEvent = (
         ...state,
         players: selfSeatId
           ? state.players.map((player) =>
-              player.playerId === selfSeatId
+              player.seatId === selfSeatId
                 ? {
                     ...player,
                     hand: player.hand.filter(

--- a/shared/game-client/identity.ts
+++ b/shared/game-client/identity.ts
@@ -12,21 +12,15 @@ import type { RoomContract } from '@meitra/contracts/room';
 
 export type CanonicalPlayerContract<T extends ConnectionUserContract> = T & {
   seatId: SeatId;
-  playerId: SeatId;
 };
 
 export type CanonicalRoomContract = Omit<RoomContract, 'players'> & {
-  hostId: SeatId;
   players: Array<CanonicalPlayerContract<RoomContract['players'][number]>>;
 };
 
-export type CanonicalBlowDeclaration = BlowDeclarationContract & {
-  playerId: SeatId;
-};
+export type CanonicalBlowDeclaration = BlowDeclarationContract;
 
-export type CanonicalBlowAction = BlowActionContract & {
-  playerId: SeatId;
-};
+export type CanonicalBlowAction = BlowActionContract;
 
 export type CanonicalBlowState = Omit<
   BlowStateContract,
@@ -35,18 +29,11 @@ export type CanonicalBlowState = Omit<
   currentHighestDeclaration: CanonicalBlowDeclaration | null;
   declarations: CanonicalBlowDeclaration[];
   actionHistory: CanonicalBlowAction[];
-  lastPasser: SeatId | null;
 };
 
-export type CanonicalFieldContract = FieldContract & {
-  playedBy: SeatId[];
-  dealerId: SeatId;
-};
+export type CanonicalFieldContract = FieldContract;
 
-export type CanonicalCompletedFieldContract = CompletedFieldContract & {
-  winnerId: SeatId;
-  dealerId: SeatId;
-};
+export type CanonicalCompletedFieldContract = CompletedFieldContract;
 
 export type CanonicalGameStatePayload = Omit<
   GameStatePayload,
@@ -64,10 +51,7 @@ export type CanonicalGameStatePayload = Omit<
 export const normalizePlayerIdentity = <T extends ConnectionUserContract>(
   player: T,
 ): CanonicalPlayerContract<T> => {
-  return {
-    ...player,
-    playerId: player.seatId,
-  };
+  return { ...player };
 };
 
 export const normalizePlayerIdentities = <T extends ConnectionUserContract>(
@@ -78,13 +62,13 @@ export const normalizePlayerIdentities = <T extends ConnectionUserContract>(
 export const normalizeBlowDeclarationIdentity = (
   declaration: BlowDeclarationContract,
 ): CanonicalBlowDeclaration => {
-  return { ...declaration, playerId: declaration.seatId };
+  return { ...declaration };
 };
 
 export const normalizeBlowActionIdentity = (
   action: BlowActionContract,
 ): CanonicalBlowAction => {
-  return { ...action, playerId: action.seatId };
+  return { ...action };
 };
 
 export const normalizeBlowStateIdentity = (
@@ -104,28 +88,19 @@ export const normalizeBlowStateIdentity = (
     declarations,
     actionHistory,
     currentHighestDeclaration,
-    lastPasser: blowState.lastPasserSeatId,
   };
 };
 
 export const normalizeFieldIdentity = (
   field: FieldContract,
 ): CanonicalFieldContract => {
-  return {
-    ...field,
-    playedBy: [...field.playedBySeatIds],
-    dealerId: field.dealerSeatId,
-  };
+  return { ...field, playedBySeatIds: [...field.playedBySeatIds] };
 };
 
 export const normalizeCompletedFieldIdentity = (
   field: CompletedFieldContract,
 ): CanonicalCompletedFieldContract => {
-  return {
-    ...field,
-    winnerId: field.winnerSeatId,
-    dealerId: field.dealerSeatId,
-  };
+  return { ...field };
 };
 
 export const normalizeRoomIdentity = (
@@ -135,7 +110,6 @@ export const normalizeRoomIdentity = (
 
   return {
     ...room,
-    hostId: room.hostSeatId,
     players,
   };
 };

--- a/shared/game-client/table-order.ts
+++ b/shared/game-client/table-order.ts
@@ -1,7 +1,7 @@
 export type SeatPosition = 'bottom' | 'left' | 'top' | 'right';
 
 type TablePlayer = {
-  playerId: string;
+  seatId: string;
 };
 
 type TeamTablePlayer = TablePlayer & {
@@ -12,15 +12,15 @@ const SEAT_POSITIONS: SeatPosition[] = ['bottom', 'left', 'top', 'right'];
 
 function arrangeWithSelfBottom<TPlayer extends TablePlayer>(
   players: readonly (TPlayer | undefined)[],
-  selfPlayerId: string | null,
+  selfSeatId: string | null,
 ): (TPlayer | undefined)[] {
   const order = [...players.slice(0, 4)];
   while (order.length < 4) {
     order.push(undefined);
   }
 
-  const selfIndex = selfPlayerId
-    ? order.findIndex((player) => player?.playerId === selfPlayerId)
+  const selfIndex = selfSeatId
+    ? order.findIndex((player) => player?.seatId === selfSeatId)
     : -1;
   const rotated =
     selfIndex > 0
@@ -34,7 +34,7 @@ export function getConsistentTableOrderWithSelfBottom<
   TPlayer extends TeamTablePlayer,
 >(
   players: readonly TPlayer[],
-  selfPlayerId: string | null,
+  selfSeatId: string | null,
 ): (TPlayer | undefined)[] {
   const team0 = players.filter((player) => player.team === 0);
   const team1 = players.filter((player) => player.team === 1);
@@ -46,22 +46,22 @@ export function getConsistentTableOrderWithSelfBottom<
     if (team1[index]) alternatingOrder.push(team1[index]);
   }
 
-  return arrangeWithSelfBottom(alternatingOrder, selfPlayerId);
+  return arrangeWithSelfBottom(alternatingOrder, selfSeatId);
 }
 
 export function getSeatOrderWithSelfBottom<TPlayer extends TablePlayer>(
   players: readonly TPlayer[],
-  selfPlayerId: string | null,
+  selfSeatId: string | null,
 ): (TPlayer | undefined)[] {
-  return arrangeWithSelfBottom(players, selfPlayerId);
+  return arrangeWithSelfBottom(players, selfSeatId);
 }
 
 export function getCardSeatPosition<TPlayer extends TablePlayer>(
-  playedByPlayerId: string,
+  playedBySeatId: string,
   orderedPlayers: readonly (TPlayer | undefined)[],
 ): SeatPosition {
   const index = orderedPlayers.findIndex(
-    (player) => player?.playerId === playedByPlayerId,
+    (player) => player?.seatId === playedBySeatId,
   );
   return index >= 0 ? SEAT_POSITIONS[index] : 'bottom';
 }


### PR DESCRIPTION
## Summary

Web・Mobile・共有クライアント層から席identityの旧aliasを削除し、`seatId`系フィールドへ統一しました。`playerId`に加えて`hostId`、`winnerId`、`dealerId`、`playedBy`、`lastPasser`の再生成も廃止しています。

## User-facing change

Web版とMobile版のプレイヤー・手番・場札・獲得組の参照を席IDに統一しました。

## User benefit

再接続やCOM置換後も同じ席を一貫して参照し、表示や進行の不整合を防ぎます。

## Validation

- Frontend: `npx tsc --noEmit`
- Frontend: `npm run lint`
- Frontend: `npm test -- --runInBand` (29 suites / 98 tests)
- Frontend: `npm run build`
- Mobile: `npm run typecheck`
- Mobile: `npm run lint`
- Mobile: `npm test -- --runInBand` (21 suites / 108 tests)
- Repository-wide `@deprecated` search: 0件
- `git diff --check`
